### PR TITLE
Speed up `toLocaleString` ~2.5x by reducing creation of `Intl.DateTimeFormat` instances

### DIFF
--- a/lib/ecmascript.mjs
+++ b/lib/ecmascript.mjs
@@ -27,6 +27,7 @@ import ToNumber from 'es-abstract/2020/ToNumber';
 import ToPrimitive from 'es-abstract/2020/ToPrimitive';
 import ToString from 'es-abstract/2020/ToString';
 import Type from 'es-abstract/2020/Type';
+import HasOwnProperty from 'es-abstract/2020/HasOwnProperty';
 
 import { GetIntrinsic } from './intrinsicclass.mjs';
 import {
@@ -139,6 +140,7 @@ import * as PARSE from './regex.mjs';
 const ES2020 = {
   Call,
   GetMethod,
+  HasOwnProperty,
   IsInteger,
   ToInteger,
   ToLength,

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "browser": "dist/index.umd.js",
   "types": "index.d.ts",
   "scripts": {
-    "test": "node --no-warnings --experimental-modules --icu-data-dir node_modules/full-icu --loader ./test/resolve.source.mjs ./test/all.mjs",
+    "test": "time node --no-warnings --experimental-modules --icu-data-dir node_modules/full-icu --loader ./test/resolve.source.mjs ./test/all.mjs",
     "build": "rollup -c rollup.config.js",
     "prepublishOnly": "npm run build",
     "playground": "node --experimental-modules --no-warnings --icu-data-dir node_modules/full-icu -r ./lib/init.js",


### PR DESCRIPTION
This PR speeds up `toLocaleString` and other operations that depend on the polyfilled `Intl.DateTimeFormat`. The fix was to prevent unnecessary creation of built-in `Intl.DateTimeFormat` objects, because the constructor of that built-in class is slooooooow. For more details about the underlying issue see: https://bugs.chromium.org/p/v8/issues/detail?id=6528

In local testing, speedup is about 2.5x for ZDT toLocaleString calls.  The sample code below runs in about 1800ms in the playground of the current main branch, and about 700ms in the playground of the PR branch. 

```js
(() => {
  start = Date.now();
  for (i = 0; i < 1000; i++) {
    Temporal.ZonedDateTime.from('2020-01-01[America/Los_Angeles]').toLocaleString();
  }
  total = Date.now()-start;
  console.log(`${total}ms`);
}) ()
```