### PR TITLE
Fix division issues caught by tsc in RoundDuration.

### DIFF
--- a/lib/ecmascript.mjs
+++ b/lib/ecmascript.mjs
@@ -3898,8 +3898,8 @@ export const ES = ObjectAssign({}, ES2020, {
         oneYearDays = MathAbs(oneYearDays);
         const divisor = bigInt(oneYearDays).multiply(dayLengthNs);
         nanoseconds = divisor.multiply(years).plus(bigInt(days).multiply(dayLengthNs)).plus(nanoseconds);
-        const rounded = ES.RoundNumberToIncrement(nanoseconds, divisor * increment, roundingMode);
-        total = nanoseconds.toJSNumber() / divisor;
+        const rounded = ES.RoundNumberToIncrement(nanoseconds, divisor.toJSNumber() * increment, roundingMode);
+        total = nanoseconds.toJSNumber() / divisor.toJSNumber();
         years = rounded.divide(divisor).toJSNumber();
         nanoseconds = months = weeks = days = 0;
         break;
@@ -3940,8 +3940,8 @@ export const ES = ObjectAssign({}, ES2020, {
         oneMonthDays = MathAbs(oneMonthDays);
         const divisor = bigInt(oneMonthDays).multiply(dayLengthNs);
         nanoseconds = divisor.multiply(months).plus(bigInt(days).multiply(dayLengthNs)).plus(nanoseconds);
-        const rounded = ES.RoundNumberToIncrement(nanoseconds, divisor * increment, roundingMode);
-        total = nanoseconds.toJSNumber() / divisor;
+        const rounded = ES.RoundNumberToIncrement(nanoseconds, divisor.toJSNumber() * increment, roundingMode);
+        total = nanoseconds.toJSNumber() / divisor.toJSNumber();
         months = rounded.divide(divisor).toJSNumber();
         nanoseconds = weeks = days = 0;
         break;
@@ -3962,8 +3962,8 @@ export const ES = ObjectAssign({}, ES2020, {
         oneWeekDays = MathAbs(oneWeekDays);
         const divisor = bigInt(oneWeekDays).multiply(dayLengthNs);
         nanoseconds = divisor.multiply(weeks).plus(bigInt(days).multiply(dayLengthNs)).plus(nanoseconds);
-        const rounded = ES.RoundNumberToIncrement(nanoseconds, divisor * increment, roundingMode);
-        total = nanoseconds.toJSNumber() / divisor;
+        const rounded = ES.RoundNumberToIncrement(nanoseconds, divisor.toJSNumber() * increment, roundingMode);
+        total = nanoseconds.toJSNumber() / divisor.toJSNumber();
         weeks = rounded.divide(divisor).toJSNumber();
         nanoseconds = days = 0;
         break;
@@ -3971,8 +3971,8 @@ export const ES = ObjectAssign({}, ES2020, {
       case 'day': {
         const divisor = bigInt(dayLengthNs);
         nanoseconds = divisor.multiply(days).plus(nanoseconds);
-        const rounded = ES.RoundNumberToIncrement(nanoseconds, divisor * increment, roundingMode);
-        total = nanoseconds.toJSNumber() / divisor;
+        const rounded = ES.RoundNumberToIncrement(nanoseconds, divisor.toJSNumber() * increment, roundingMode);
+        total = nanoseconds.toJSNumber() / divisor.toJSNumber();
         days = rounded.divide(divisor).toJSNumber();
         nanoseconds = 0;
         break;

--- a/lib/ecmascript.mjs
+++ b/lib/ecmascript.mjs
@@ -3898,7 +3898,7 @@ export const ES = ObjectAssign({}, ES2020, {
         oneYearDays = MathAbs(oneYearDays);
         const divisor = bigInt(oneYearDays).multiply(dayLengthNs);
         nanoseconds = divisor.multiply(years).plus(bigInt(days).multiply(dayLengthNs)).plus(nanoseconds);
-        const rounded = ES.RoundNumberToIncrement(nanoseconds, divisor.toJSNumber() * increment, roundingMode);
+        const rounded = ES.RoundNumberToIncrement(nanoseconds, divisor.multiply(increment).toJSNumber(), roundingMode);
         total = nanoseconds.toJSNumber() / divisor.toJSNumber();
         years = rounded.divide(divisor).toJSNumber();
         nanoseconds = months = weeks = days = 0;
@@ -3940,7 +3940,7 @@ export const ES = ObjectAssign({}, ES2020, {
         oneMonthDays = MathAbs(oneMonthDays);
         const divisor = bigInt(oneMonthDays).multiply(dayLengthNs);
         nanoseconds = divisor.multiply(months).plus(bigInt(days).multiply(dayLengthNs)).plus(nanoseconds);
-        const rounded = ES.RoundNumberToIncrement(nanoseconds, divisor.toJSNumber() * increment, roundingMode);
+        const rounded = ES.RoundNumberToIncrement(nanoseconds, divisor.multiply(increment).toJSNumber(), roundingMode);
         total = nanoseconds.toJSNumber() / divisor.toJSNumber();
         months = rounded.divide(divisor).toJSNumber();
         nanoseconds = weeks = days = 0;
@@ -3962,7 +3962,7 @@ export const ES = ObjectAssign({}, ES2020, {
         oneWeekDays = MathAbs(oneWeekDays);
         const divisor = bigInt(oneWeekDays).multiply(dayLengthNs);
         nanoseconds = divisor.multiply(weeks).plus(bigInt(days).multiply(dayLengthNs)).plus(nanoseconds);
-        const rounded = ES.RoundNumberToIncrement(nanoseconds, divisor.toJSNumber() * increment, roundingMode);
+        const rounded = ES.RoundNumberToIncrement(nanoseconds, divisor.multiply(increment).toJSNumber(), roundingMode);
         total = nanoseconds.toJSNumber() / divisor.toJSNumber();
         weeks = rounded.divide(divisor).toJSNumber();
         nanoseconds = days = 0;
@@ -3971,7 +3971,7 @@ export const ES = ObjectAssign({}, ES2020, {
       case 'day': {
         const divisor = bigInt(dayLengthNs);
         nanoseconds = divisor.multiply(days).plus(nanoseconds);
-        const rounded = ES.RoundNumberToIncrement(nanoseconds, divisor.toJSNumber() * increment, roundingMode);
+        const rounded = ES.RoundNumberToIncrement(nanoseconds, divisor.multiply(increment).toJSNumber(), roundingMode);
         total = nanoseconds.toJSNumber() / divisor.toJSNumber();
         days = rounded.divide(divisor).toJSNumber();
         nanoseconds = 0;


### PR DESCRIPTION
While migrating the source of the polyfill to TypeScript, tsc caught cases where native math operations were being used on big-integer polyfill objects as if they were native BigInts or numbers (`The left-hand side of an arithmetic operation must be of type 'any', 'number', 'bigint' or an enum type.ts(2362)`). 

This PR fixes this error by converting them back to JS numbers, but should these be turned back into JS numbers, or should these operations be done using the big-integer library?