### PR TITLE
Change let->const to satisfy lint checks for TS sources.

### DIFF
--- a/lib/calendar.mjs
+++ b/lib/calendar.mjs
@@ -450,7 +450,7 @@ const nonIsoHelperBase = {
     return this.formatter;
   },
   isoToCalendarDate(isoDate, cache) {
-    let { year: isoYear, month: isoMonth, day: isoDay } = isoDate;
+    const { year: isoYear, month: isoMonth, day: isoDay } = isoDate;
     const key = JSON.stringify({ func: 'isoToCalendarDate', isoYear, isoMonth, isoDay, id: this.id });
     const cached = cache.get(key);
     if (cached) return cached;
@@ -538,7 +538,7 @@ const nonIsoHelperBase = {
     return calendarDate;
   },
   validateCalendarDate(calendarDate) {
-    let { era, month, year, day, eraYear, monthCode, monthExtra } = calendarDate;
+    const { era, month, year, day, eraYear, monthCode, monthExtra } = calendarDate;
     // When there's a suffix (e.g. "5bis" for a leap month in Chinese calendar)
     // the derived class must deal with it.
     if (monthExtra !== undefined) throw new RangeError('Unexpected `monthExtra` value');
@@ -939,7 +939,7 @@ const nonIsoHelperBase = {
     const startDateIso = { year: 1972, month: 1, day: 1 };
     const { year: calendarYear } = this.isoToCalendarDate(startDateIso, cache);
     for (let i = 0; i < 100; i++) {
-      let testCalendarDate = this.adjustCalendarDate({ day, monthCode, year: calendarYear - i }, cache);
+      const testCalendarDate = this.adjustCalendarDate({ day, monthCode, year: calendarYear - i }, cache);
       const isoDate = this.calendarToIsoDate(testCalendarDate, 'constrain', cache);
       const roundTripCalendarDate = this.isoToCalendarDate(isoDate, cache);
       ({ year: isoYear, month: isoMonth, day: isoDay } = isoDate);
@@ -1754,7 +1754,7 @@ const helperChinese = ObjectAssign({}, nonIsoHelperBase, {
         const months = this.getMonthList(year, cache);
         let numberPart = monthCode.replace('L', 'bis').slice(1);
         if (numberPart[0] === '0') numberPart = numberPart.slice(1);
-        let monthInfo = months[numberPart];
+        const monthInfo = months[numberPart];
         if (!monthInfo) throw new RangeError(`Unmatched monthCode ${monthCode} in Chinese year ${year}`);
         if (month !== monthInfo.monthIndex) {
           throw new RangeError(`monthCode ${monthCode} doesn't correspond to month ${month} in Chinese year ${year}`);

--- a/lib/duration.mjs
+++ b/lib/duration.mjs
@@ -170,7 +170,7 @@ export class Duration {
     if (!props) {
       throw new TypeError('invalid duration-like');
     }
-    let {
+    const {
       years = GetSlot(this, YEARS),
       months = GetSlot(this, MONTHS),
       weeks = GetSlot(this, WEEKS),

--- a/lib/ecmascript.mjs
+++ b/lib/ecmascript.mjs
@@ -376,7 +376,7 @@ export const ES = ObjectAssign({}, ES2020, {
     let minutes = ES.ToInteger(match[8]) * sign;
     let fMinutes = match[9];
     let seconds = ES.ToInteger(match[10]) * sign;
-    let fSeconds = match[11] + '000000000';
+    const fSeconds = match[11] + '000000000';
     let milliseconds = ES.ToInteger(fSeconds.slice(0, 3)) * sign;
     let microseconds = ES.ToInteger(fSeconds.slice(3, 6)) * sign;
     let nanoseconds = ES.ToInteger(fSeconds.slice(6, 9)) * sign;
@@ -509,7 +509,7 @@ export const ES = ObjectAssign({}, ES2020, {
       ].forEach((val) => {
         if (val !== 0) throw new RangeError('only the smallest unit can be fractional');
       });
-      let mins = fHours * 60;
+      const mins = fHours * 60;
       minutes = MathTrunc(mins);
       fMinutes = mins % 1;
     }
@@ -520,7 +520,7 @@ export const ES = ObjectAssign({}, ES2020, {
           if (val !== 0) throw new RangeError('only the smallest unit can be fractional');
         }
       );
-      let secs = fMinutes * 60;
+      const secs = fMinutes * 60;
       seconds = MathTrunc(secs);
       fSeconds = secs % 1;
     }
@@ -529,7 +529,7 @@ export const ES = ObjectAssign({}, ES2020, {
       [milliseconds, fMilliseconds, microseconds, fMicroseconds, nanoseconds, fNanoseconds].forEach((val) => {
         if (val !== 0) throw new RangeError('only the smallest unit can be fractional');
       });
-      let mils = fSeconds * 1000;
+      const mils = fSeconds * 1000;
       milliseconds = MathTrunc(mils);
       fMilliseconds = mils % 1;
     }
@@ -538,7 +538,7 @@ export const ES = ObjectAssign({}, ES2020, {
       [microseconds, fMicroseconds, nanoseconds, fNanoseconds].forEach((val) => {
         if (val !== 0) throw new RangeError('only the smallest unit can be fractional');
       });
-      let mics = fMilliseconds * 1000;
+      const mics = fMilliseconds * 1000;
       microseconds = MathTrunc(mics);
       fMicroseconds = mics % 1;
     }
@@ -547,7 +547,7 @@ export const ES = ObjectAssign({}, ES2020, {
       [nanoseconds, fNanoseconds].forEach((val) => {
         if (val !== 0) throw new RangeError('only the smallest unit can be fractional');
       });
-      let nans = fMicroseconds * 1000;
+      const nans = fMicroseconds * 1000;
       nanoseconds = MathTrunc(nans);
     }
 
@@ -591,7 +591,7 @@ export const ES = ObjectAssign({}, ES2020, {
       }
     );
     if (!props) throw new TypeError('invalid duration-like');
-    let {
+    const {
       years = 0,
       months = 0,
       weeks = 0,
@@ -684,7 +684,7 @@ export const ES = ObjectAssign({}, ES2020, {
     return ES.ToTemporalRoundingIncrement(options, maximumIncrements[smallestUnit], false);
   },
   ToSecondsStringPrecision: (options) => {
-    let smallestUnit = ES.ToSmallestTemporalUnit(options, undefined, ['year', 'month', 'week', 'day', 'hour']);
+    const smallestUnit = ES.ToSmallestTemporalUnit(options, undefined, ['year', 'month', 'week', 'day', 'hour']);
     switch (smallestUnit) {
       case 'minute':
         return { precision: 'minute', unit: 'minute', increment: 1 };
@@ -1043,7 +1043,7 @@ export const ES = ObjectAssign({}, ES2020, {
       return ES.DateFromFields(calendar, fields, options);
     }
     ES.ToTemporalOverflow(options); // validate and ignore
-    let { year, month, day, calendar } = ES.ParseTemporalDateString(ES.ToString(item));
+    const { year, month, day, calendar } = ES.ParseTemporalDateString(ES.ToString(item));
     const TemporalPlainDate = GetIntrinsic('%Temporal.PlainDate%');
     return new TemporalPlainDate(year, month, day, calendar); // include validation
   },
@@ -1850,7 +1850,7 @@ export const ES = ObjectAssign({}, ES2020, {
     }
   },
   GetPossibleInstantsFor: (timeZone, dateTime) => {
-    let getPossibleInstantsFor = ES.GetMethod(timeZone, 'getPossibleInstantsFor');
+    const getPossibleInstantsFor = ES.GetMethod(timeZone, 'getPossibleInstantsFor');
     const possibleInstants = ES.Call(getPossibleInstantsFor, timeZone, [dateTime]);
     const result = [];
     for (const instant of possibleInstants) {
@@ -1864,8 +1864,8 @@ export const ES = ObjectAssign({}, ES2020, {
   ISOYearString: (year) => {
     let yearString;
     if (year < 1000 || year > 9999) {
-      let sign = year < 0 ? '-' : '+';
-      let yearNumber = MathAbs(year);
+      const sign = year < 0 ? '-' : '+';
+      const yearNumber = MathAbs(year);
       yearString = sign + `000000${yearNumber}`.slice(-6);
     } else {
       yearString = `${year}`;
@@ -1956,7 +1956,7 @@ export const ES = ObjectAssign({}, ES2020, {
     ({ quotient: total, remainder: ns } = total.divmod(1000));
     ({ quotient: total, remainder: µs } = total.divmod(1000));
     ({ quotient: seconds, remainder: ms } = total.divmod(1000));
-    let fraction = MathAbs(ms.toJSNumber()) * 1e6 + MathAbs(µs.toJSNumber()) * 1e3 + MathAbs(ns.toJSNumber());
+    const fraction = MathAbs(ms.toJSNumber()) * 1e6 + MathAbs(µs.toJSNumber()) * 1e3 + MathAbs(ns.toJSNumber());
     let decimalPart;
     if (precision === 'auto') {
       if (fraction !== 0) {
@@ -2179,7 +2179,7 @@ export const ES = ObjectAssign({}, ES2020, {
   GetIANATimeZoneNextTransition: (epochNanoseconds, id) => {
     const uppercap = ES.SystemUTCEpochNanoSeconds() + 366 * DAYMILLIS * 1e6;
     let leftNanos = epochNanoseconds;
-    let leftOffsetNs = ES.GetIANATimeZoneOffsetNanoseconds(leftNanos, id);
+    const leftOffsetNs = ES.GetIANATimeZoneOffsetNanoseconds(leftNanos, id);
     let rightNanos = leftNanos;
     let rightOffsetNs = leftOffsetNs;
     while (leftOffsetNs === rightOffsetNs && bigInt(leftNanos).compare(uppercap) === -1) {
@@ -2202,7 +2202,7 @@ export const ES = ObjectAssign({}, ES2020, {
   GetIANATimeZonePreviousTransition: (epochNanoseconds, id) => {
     const lowercap = BEFORE_FIRST_DST; // 1847-01-01T00:00:00Z
     let rightNanos = bigInt(epochNanoseconds).minus(1);
-    let rightOffsetNs = ES.GetIANATimeZoneOffsetNanoseconds(rightNanos, id);
+    const rightOffsetNs = ES.GetIANATimeZoneOffsetNanoseconds(rightNanos, id);
     let leftNanos = rightNanos;
     let leftOffsetNs = rightOffsetNs;
     while (rightOffsetNs === leftOffsetNs && bigInt(rightNanos).compare(lowercap) === 1) {
@@ -2240,7 +2240,7 @@ export const ES = ObjectAssign({}, ES2020, {
     };
   },
   GetIANATimeZoneEpochValue: (id, year, month, day, hour, minute, second, millisecond, microsecond, nanosecond) => {
-    let ns = ES.GetEpochFromISOParts(year, month, day, hour, minute, second, millisecond, microsecond, nanosecond);
+    const ns = ES.GetEpochFromISOParts(year, month, day, hour, minute, second, millisecond, microsecond, nanosecond);
     if (ns === null) throw new RangeError('DateTime outside of supported range');
     const dayNanos = bigInt(DAYMILLIS).multiply(1e6);
     let nsEarlier = ns.minus(dayNanos);
@@ -2310,9 +2310,9 @@ export const ES = ObjectAssign({}, ES2020, {
     return days;
   },
   WeekOfYear: (year, month, day) => {
-    let doy = ES.DayOfYear(year, month, day);
-    let dow = ES.DayOfWeek(year, month, day) || 7;
-    let doj = ES.DayOfWeek(year, 1, 1);
+    const doy = ES.DayOfYear(year, month, day);
+    const dow = ES.DayOfWeek(year, month, day) || 7;
+    const doj = ES.DayOfWeek(year, 1, 1);
 
     const week = MathFloor((doy - dow + 10) / 7);
 
@@ -2415,7 +2415,7 @@ export const ES = ObjectAssign({}, ES2020, {
     hour += MathFloor(minute / 60);
     minute = ES.NonNegativeModulo(minute, 60);
 
-    let deltaDays = MathFloor(hour / 24);
+    const deltaDays = MathFloor(hour / 24);
     hour = ES.NonNegativeModulo(hour, 24);
 
     return { deltaDays, hour, minute, second, millisecond, microsecond, nanosecond };
@@ -3180,14 +3180,14 @@ export const ES = ObjectAssign({}, ES2020, {
       largestUnit,
       options
     );
-    let intermediateNs = ES.AddZonedDateTime(start, timeZone, calendar, years, months, weeks, 0, 0, 0, 0, 0, 0, 0);
+    const intermediateNs = ES.AddZonedDateTime(start, timeZone, calendar, years, months, weeks, 0, 0, 0, 0, 0, 0, 0);
     // may disambiguate
     let timeRemainderNs = ns2.subtract(intermediateNs);
     const intermediate = ES.CreateTemporalZonedDateTime(intermediateNs, timeZone, calendar);
     ({ nanoseconds: timeRemainderNs, days } = ES.NanosecondsToDays(timeRemainderNs, intermediate));
 
     // Finally, merge the date and time durations and return the merged result.
-    let { hours, minutes, seconds, milliseconds, microseconds, nanoseconds } = ES.BalanceDuration(
+    const { hours, minutes, seconds, milliseconds, microseconds, nanoseconds } = ES.BalanceDuration(
       0,
       0,
       0,
@@ -3496,7 +3496,7 @@ export const ES = ObjectAssign({}, ES2020, {
 
     // RFC 5545 requires the date portion to be added in calendar days and the
     // time portion to be added in exact time.
-    let dt = ES.BuiltinTimeZoneGetPlainDateTimeFor(timeZone, instant, calendar);
+    const dt = ES.BuiltinTimeZoneGetPlainDateTimeFor(timeZone, instant, calendar);
     const datePart = ES.CreateTemporalDate(
       GetSlot(dt, ISO_YEAR),
       GetSlot(dt, ISO_MONTH),
@@ -4155,7 +4155,7 @@ function bisect(getState, left, right, lstate = getState(left), rstate = getStat
   left = bigInt(left);
   right = bigInt(right);
   while (right.minus(left).greater(1)) {
-    let middle = left.plus(right).divide(2);
+    const middle = left.plus(right).divide(2);
     const mstate = getState(middle);
     if (mstate === lstate) {
       left = middle;

--- a/lib/intl.mjs
+++ b/lib/intl.mjs
@@ -107,8 +107,8 @@ export function DateTimeFormat(locale = undefined, options = undefined) {
   this[INST] = instantAmend;
 }
 
-DateTimeFormat.supportedLocalesOf = function (...args) {
-  return IntlDateTimeFormat.supportedLocalesOf(...args);
+DateTimeFormat.supportedLocalesOf = function (locales, options) {
+  return IntlDateTimeFormat.supportedLocalesOf(locales, options);
 };
 
 const properties = {
@@ -194,7 +194,7 @@ function formatRangeToParts(a, b) {
 
 function amend(options = {}, amended = {}) {
   options = ObjectAssign({}, options);
-  for (let opt of [
+  for (const opt of [
     'year',
     'month',
     'day',
@@ -476,7 +476,7 @@ function extractOverrides(temporalObj, main) {
       );
     }
 
-    let timeZone = GetSlot(temporalObj, TIME_ZONE);
+    const timeZone = GetSlot(temporalObj, TIME_ZONE);
     const objTimeZone = ES.ToString(timeZone);
     if (main[TZ_GIVEN] && main[TZ_GIVEN] !== objTimeZone) {
       throw new RangeError(`timeZone option ${main[TZ_GIVEN]} doesn't match actual time zone ${objTimeZone}`);

--- a/lib/intrinsicclass.mjs
+++ b/lib/intrinsicclass.mjs
@@ -46,13 +46,13 @@ export function MakeIntrinsicClass(Class, name) {
       configurable: true
     });
   }
-  for (let prop of Object.getOwnPropertyNames(Class)) {
+  for (const prop of Object.getOwnPropertyNames(Class)) {
     const desc = Object.getOwnPropertyDescriptor(Class, prop);
     if (!desc.configurable || !desc.enumerable) continue;
     desc.enumerable = false;
     Object.defineProperty(Class, prop, desc);
   }
-  for (let prop of Object.getOwnPropertyNames(Class.prototype)) {
+  for (const prop of Object.getOwnPropertyNames(Class.prototype)) {
     const desc = Object.getOwnPropertyDescriptor(Class.prototype, prop);
     if (!desc.configurable || !desc.enumerable) continue;
     desc.enumerable = false;

--- a/lib/plaindate.mjs
+++ b/lib/plaindate.mjs
@@ -326,7 +326,7 @@ export class PlainDate {
 
     let timeZone, temporalTime;
     if (ES.Type(item) === 'Object') {
-      let timeZoneLike = item.timeZone;
+      const timeZoneLike = item.timeZone;
       if (timeZoneLike === undefined) {
         timeZone = ES.ToTemporalTimeZone(item);
       } else {

--- a/lib/plaindatetime.mjs
+++ b/lib/plaindatetime.mjs
@@ -278,8 +278,8 @@ export class PlainDateTime {
   }
   add(temporalDurationLike, options = undefined) {
     if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
-    let duration = ES.ToLimitedTemporalDuration(temporalDurationLike);
-    let { years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds } = duration;
+    const duration = ES.ToLimitedTemporalDuration(temporalDurationLike);
+    const { years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds } = duration;
     options = ES.GetOptionsObject(options);
     const calendar = GetSlot(this, CALENDAR);
     const { year, month, day, hour, minute, second, millisecond, microsecond, nanosecond } = ES.AddDateTime(
@@ -320,8 +320,8 @@ export class PlainDateTime {
   }
   subtract(temporalDurationLike, options = undefined) {
     if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
-    let duration = ES.ToLimitedTemporalDuration(temporalDurationLike);
-    let { years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds } = duration;
+    const duration = ES.ToLimitedTemporalDuration(temporalDurationLike);
+    const { years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds } = duration;
     options = ES.GetOptionsObject(options);
     const calendar = GetSlot(this, CALENDAR);
     const { year, month, day, hour, minute, second, millisecond, microsecond, nanosecond } = ES.AddDateTime(

--- a/lib/plainmonthday.mjs
+++ b/lib/plainmonthday.mjs
@@ -95,7 +95,7 @@ export class PlainMonthDay {
     const calendar = GetSlot(this, CALENDAR);
 
     const receiverFieldNames = ES.CalendarFields(calendar, ['day', 'monthCode']);
-    let fields = ES.ToTemporalMonthDayFields(this, receiverFieldNames);
+    const fields = ES.ToTemporalMonthDayFields(this, receiverFieldNames);
 
     const inputFieldNames = ES.CalendarFields(calendar, ['year']);
     const inputEntries = [['year', undefined]];

--- a/lib/plaintime.mjs
+++ b/lib/plaintime.mjs
@@ -201,7 +201,7 @@ export class PlainTime {
   }
   subtract(temporalDurationLike) {
     if (!ES.IsTemporalTime(this)) throw new TypeError('invalid receiver');
-    let duration = ES.ToLimitedTemporalDuration(temporalDurationLike);
+    const duration = ES.ToLimitedTemporalDuration(temporalDurationLike);
     const { hours, minutes, seconds, milliseconds, microseconds, nanoseconds } = duration;
     let hour = GetSlot(this, ISO_HOUR);
     let minute = GetSlot(this, ISO_MINUTE);

--- a/lib/plainyearmonth.mjs
+++ b/lib/plainyearmonth.mjs
@@ -298,7 +298,7 @@ export class PlainYearMonth {
     const calendar = GetSlot(this, CALENDAR);
 
     const receiverFieldNames = ES.CalendarFields(calendar, ['monthCode', 'year']);
-    let fields = ES.ToTemporalYearMonthFields(this, receiverFieldNames);
+    const fields = ES.ToTemporalYearMonthFields(this, receiverFieldNames);
 
     const inputFieldNames = ES.CalendarFields(calendar, ['day']);
     const inputEntries = [['day']];

--- a/lib/zoneddatetime.mjs
+++ b/lib/zoneddatetime.mjs
@@ -209,7 +209,7 @@ export class ZonedDateTime {
     let fields = ES.ToTemporalZonedDateTimeFields(this, fieldNames);
     fields = ES.CalendarMergeFields(calendar, fields, props);
     fields = ES.ToTemporalZonedDateTimeFields(fields, fieldNames);
-    let { year, month, day, hour, minute, second, millisecond, microsecond, nanosecond } =
+    const { year, month, day, hour, minute, second, millisecond, microsecond, nanosecond } =
       ES.InterpretTemporalDateTimeFields(calendar, fields, options);
     const offsetNs = ES.ParseOffsetString(fields.offset);
     const epochNanoseconds = ES.InterpretISODateTimeOffset(


### PR DESCRIPTION
The existing eslint config doesn't seem to mind the lets currently, but does once the files are migrated. Splitting this into a separate PR makes the TypeScript source migration PR easier to review.