### PR TITLE
Add '.js' suffix to ecmascript imports

### DIFF
--- a/lib/ecmascript.ts
+++ b/lib/ecmascript.ts
@@ -16,16 +16,16 @@ const ObjectIs = Object.is;
 
 import { DEBUG } from './debug';
 import bigInt from 'big-integer';
-import Call from 'es-abstract/2020/Call';
-import GetMethod from 'es-abstract/2020/GetMethod';
-import IsInteger from 'es-abstract/2020/IsInteger';
-import ToInteger from 'es-abstract/2020/ToInteger';
-import ToLength from 'es-abstract/2020/ToLength';
-import ToNumber from 'es-abstract/2020/ToNumber';
-import ToPrimitive from 'es-abstract/2020/ToPrimitive';
-import ToString from 'es-abstract/2020/ToString';
-import Type from 'es-abstract/2020/Type';
-import HasOwnProperty from 'es-abstract/2020/HasOwnProperty';
+import Call from 'es-abstract/2020/Call.js';
+import GetMethod from 'es-abstract/2020/GetMethod.js';
+import IsInteger from 'es-abstract/2020/IsInteger.js';
+import ToInteger from 'es-abstract/2020/ToInteger.js';
+import ToLength from 'es-abstract/2020/ToLength.js';
+import ToNumber from 'es-abstract/2020/ToNumber.js';
+import ToPrimitive from 'es-abstract/2020/ToPrimitive.js';
+import ToString from 'es-abstract/2020/ToString.js';
+import Type from 'es-abstract/2020/Type.js';
+import HasOwnProperty from 'es-abstract/2020/HasOwnProperty.js';
 
 import { GetIntrinsic } from './intrinsicclass';
 import {


### PR DESCRIPTION
File extensions are mandatory in ESM imports – q.v.
https://nodejs.org/api/esm.html#esm_mandatory_file_extensions.