### PR TITLE
Sync package-lock.json to package.json version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@js-temporal/polyfill",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@js-temporal/polyfill",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "ISC",
       "dependencies": {
         "big-integer": "^1.6.48",


### PR DESCRIPTION
#27 didn't update the version in package-lock.json. I don't know what (if anything) this will break, but I assume they should be synced.