### PR TITLE
Rename the CJS emit to use the cjs file extension.

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.2.0",
   "description": "Polyfill for Temporal",
   "type": "module",
-  "main": "dist/index.js",
+  "main": "dist/index.cjs",
   "module": "dist/index.esm.js",
   "browser": "dist/index.umd.js",
   "types": "index.d.ts",


### PR DESCRIPTION
Node will treat all files (including those in dist/) as ESM within the
Temporal source due to setting "type":"module". Renaming this file to
use the cjs file extension tells Node to ignore this setting and treat
the content of this file as CommonJS.

Fixes #29

@justingrant Can you try patching your environment and confirming this will fix it?