### PR TITLE
Import types in implementation and fix a type bug

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1357,7 +1357,7 @@ export namespace Temporal {
     isoMillisecond: number;
     isoMicrosecond: number;
     isoNanosecond: number;
-    offsetNanoseconds: number;
+    offset: string;
     timeZone: TimeZoneProtocol;
     calendar: CalendarProtocol;
   };

--- a/lib/calendar.ts
+++ b/lib/calendar.ts
@@ -2,6 +2,7 @@ import { DEBUG } from './debug';
 import { ES } from './ecmascript';
 import { GetIntrinsic, MakeIntrinsicClass, DefineIntrinsic } from './intrinsicclass';
 import { CALENDAR_ID, ISO_YEAR, ISO_MONTH, ISO_DAY, CreateSlots, GetSlot, HasSlot, SetSlot } from './slots';
+import { Temporal } from '..';
 
 const ArrayIncludes = Array.prototype.includes;
 const ArrayPrototypePush = Array.prototype.push;
@@ -13,7 +14,7 @@ const ObjectEntries = Object.entries;
 
 const impl = {};
 
-export class Calendar {
+export class Calendar implements Temporal.Calendar {
   constructor(id) {
     // Note: if the argument is not passed, IsBuiltinCalendar("undefined") will fail. This check
     //       exists only to improve the error message.

--- a/lib/duration.ts
+++ b/lib/duration.ts
@@ -16,8 +16,9 @@ import {
   GetSlot,
   SetSlot
 } from './slots';
+import { Temporal } from '..';
 
-export class Duration {
+export class Duration implements Temporal.Duration {
   constructor(
     years = 0,
     months = 0,
@@ -459,7 +460,7 @@ export class Duration {
     console.warn('Temporal.Duration.prototype.toLocaleString() requires Intl.DurationFormat.');
     return ES.TemporalDurationToString(this);
   }
-  valueOf() {
+  valueOf(): never {
     throw new TypeError('use compare() to compare Temporal.Duration');
   }
   static from(item) {

--- a/lib/instant.ts
+++ b/lib/instant.ts
@@ -3,6 +3,7 @@ import { ES } from './ecmascript';
 import { DateTimeFormat } from './intl';
 import { GetIntrinsic, MakeIntrinsicClass } from './intrinsicclass';
 import { EPOCHNANOSECONDS, CreateSlots, GetSlot, SetSlot } from './slots';
+import { Temporal } from '..';
 
 import bigInt from 'big-integer';
 
@@ -16,7 +17,7 @@ const MAX_DIFFERENCE_INCREMENTS = {
   nanosecond: 1000
 };
 
-export class Instant {
+export class Instant implements Temporal.Instant {
   constructor(epochNanoseconds) {
     // Note: if the argument is not passed, ToBigInt(undefined) will throw. This check exists only
     //       to improve the error message.
@@ -207,7 +208,7 @@ export class Instant {
     if (!ES.IsTemporalInstant(this)) throw new TypeError('invalid receiver');
     return new DateTimeFormat(locales, options).format(this);
   }
-  valueOf() {
+  valueOf(): never {
     throw new TypeError('use compare() or equals() to compare Temporal.Instant');
   }
   toZonedDateTime(item) {

--- a/lib/now.ts
+++ b/lib/now.ts
@@ -1,5 +1,6 @@
 import { ES } from './ecmascript';
 import { GetIntrinsic } from './intrinsicclass';
+import { Temporal } from '..';
 
 const instant = () => {
   const Instant = GetIntrinsic('%Temporal.Instant%');
@@ -38,7 +39,7 @@ const timeZone = () => {
   return ES.SystemTimeZone();
 };
 
-export const Now = {
+export const Now: typeof Temporal.Now = {
   instant,
   plainDateTime,
   plainDateTimeISO,

--- a/lib/plaindate.ts
+++ b/lib/plaindate.ts
@@ -17,10 +17,11 @@ import {
   GetSlot,
   HasSlot
 } from './slots';
+import { Temporal } from '..';
 
 const DISALLOWED_UNITS = ['hour', 'minute', 'second', 'millisecond', 'microsecond', 'nanosecond'];
 
-export class PlainDate {
+export class PlainDate implements Temporal.PlainDate {
   constructor(isoYear, isoMonth, isoDay, calendar = ES.GetISO8601Calendar()) {
     isoYear = ES.ToFiniteInteger(isoYear);
     isoMonth = ES.ToFiniteInteger(isoMonth);
@@ -288,7 +289,7 @@ export class PlainDate {
     if (!ES.IsTemporalDate(this)) throw new TypeError('invalid receiver');
     return new DateTimeFormat(locales, options).format(this);
   }
-  valueOf() {
+  valueOf(): never {
     throw new TypeError('use compare() or equals() to compare Temporal.PlainDate');
   }
   toPlainDateTime(temporalTime = undefined) {

--- a/lib/plaindatetime.ts
+++ b/lib/plaindatetime.ts
@@ -18,8 +18,9 @@ import {
   GetSlot,
   HasSlot
 } from './slots';
+import { Temporal } from '..';
 
-export class PlainDateTime {
+export class PlainDateTime implements Temporal.PlainDateTime {
   constructor(
     isoYear,
     isoMonth,
@@ -610,7 +611,7 @@ export class PlainDateTime {
     if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
     return new DateTimeFormat(locales, options).format(this);
   }
-  valueOf() {
+  valueOf(): never {
     throw new TypeError('use compare() or equals() to compare Temporal.PlainDateTime');
   }
 

--- a/lib/plainmonthday.ts
+++ b/lib/plainmonthday.ts
@@ -2,10 +2,11 @@ import { ES } from './ecmascript';
 import { DateTimeFormat } from './intl';
 import { MakeIntrinsicClass } from './intrinsicclass';
 import { ISO_MONTH, ISO_DAY, ISO_YEAR, CALENDAR, TIME_ZONE, GetSlot, HasSlot } from './slots';
+import { Temporal } from '..';
 
 const ObjectCreate = Object.create;
 
-export class PlainMonthDay {
+export class PlainMonthDay implements Temporal.PlainMonthDay {
   constructor(isoMonth, isoDay, calendar = ES.GetISO8601Calendar(), referenceISOYear = 1972) {
     isoMonth = ES.ToFiniteInteger(isoMonth);
     isoDay = ES.ToFiniteInteger(isoDay);
@@ -87,7 +88,7 @@ export class PlainMonthDay {
     if (!ES.IsTemporalMonthDay(this)) throw new TypeError('invalid receiver');
     return new DateTimeFormat(locales, options).format(this);
   }
-  valueOf() {
+  valueOf(): never {
     throw new TypeError('use equals() to compare Temporal.PlainMonthDay');
   }
   toPlainDate(item) {

--- a/lib/plaintime.ts
+++ b/lib/plaintime.ts
@@ -21,6 +21,7 @@ import {
   HasSlot,
   SetSlot
 } from './slots';
+import { Temporal } from '..';
 
 const ObjectAssign = Object.assign;
 
@@ -63,7 +64,7 @@ function TemporalTimeToString(time, precision, options = undefined) {
   return `${hour}:${minute}${seconds}`;
 }
 
-export class PlainTime {
+export class PlainTime implements Temporal.PlainTime {
   constructor(isoHour = 0, isoMinute = 0, isoSecond = 0, isoMillisecond = 0, isoMicrosecond = 0, isoNanosecond = 0) {
     isoHour = ES.ToFiniteInteger(isoHour);
     isoMinute = ES.ToFiniteInteger(isoMinute);
@@ -396,7 +397,7 @@ export class PlainTime {
     if (!ES.IsTemporalTime(this)) throw new TypeError('invalid receiver');
     return new DateTimeFormat(locales, options).format(this);
   }
-  valueOf() {
+  valueOf(): never {
     throw new TypeError('use compare() or equals() to compare Temporal.PlainTime');
   }
 

--- a/lib/plainyearmonth.ts
+++ b/lib/plainyearmonth.ts
@@ -2,12 +2,13 @@ import { ES } from './ecmascript';
 import { DateTimeFormat } from './intl';
 import { GetIntrinsic, MakeIntrinsicClass } from './intrinsicclass';
 import { ISO_YEAR, ISO_MONTH, ISO_DAY, CALENDAR, TIME_ZONE, GetSlot, HasSlot } from './slots';
+import { Temporal } from '..';
 
 const ObjectCreate = Object.create;
 
 const DISALLOWED_UNITS = ['week', 'day', 'hour', 'minute', 'second', 'millisecond', 'microsecond', 'nanosecond'];
 
-export class PlainYearMonth {
+export class PlainYearMonth implements Temporal.PlainYearMonth {
   constructor(isoYear, isoMonth, calendar = ES.GetISO8601Calendar(), referenceISODay = 1) {
     isoYear = ES.ToFiniteInteger(isoYear);
     isoMonth = ES.ToFiniteInteger(isoMonth);
@@ -290,7 +291,7 @@ export class PlainYearMonth {
     if (!ES.IsTemporalYearMonth(this)) throw new TypeError('invalid receiver');
     return new DateTimeFormat(locales, options).format(this);
   }
-  valueOf() {
+  valueOf(): never {
     throw new TypeError('use compare() or equals() to compare Temporal.PlainYearMonth');
   }
   toPlainDate(item) {

--- a/lib/timezone.ts
+++ b/lib/timezone.ts
@@ -17,8 +17,9 @@ import {
   GetSlot,
   SetSlot
 } from './slots';
+import { Temporal } from '..';
 
-export class TimeZone {
+export class TimeZone implements Temporal.TimeZone {
   constructor(timeZoneIdentifier) {
     // Note: if the argument is not passed, GetCanonicalTimeZoneIdentifier(undefined) will throw.
     //       This check exists only to improve the error message.

--- a/lib/zoneddatetime.ts
+++ b/lib/zoneddatetime.ts
@@ -18,12 +18,13 @@ import {
   GetSlot,
   HasSlot
 } from './slots';
+import { Temporal } from '..';
 
 import bigInt from 'big-integer';
 
 const ArrayPrototypePush = Array.prototype.push;
 
-export class ZonedDateTime {
+export class ZonedDateTime implements Temporal.ZonedDateTime {
   constructor(epochNanoseconds, timeZone, calendar = ES.GetISO8601Calendar()) {
     // Note: if the argument is not passed, ToBigInt(undefined) will throw. This check exists only
     //       to improve the error message.
@@ -649,7 +650,7 @@ export class ZonedDateTime {
     if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
     return ES.TemporalZonedDateTimeToString(this, 'auto');
   }
-  valueOf() {
+  valueOf(): never {
     throw new TypeError('use compare() or equals() to compare Temporal.ZonedDateTime');
   }
   startOfDay() {


### PR DESCRIPTION
This PR modifies implementation files to import types from index.d.ts.  Now, type mistakes will be easier to catch.

Example: I found a type bug in the ZonedDateTimeISOFields declaration. This bug is fixed here too.