### PR TITLE
Rename all non-ESM build artifacts to use the cjs file extension.

### DIFF
--- a/lib/init.cjs
+++ b/lib/init.cjs
@@ -3,7 +3,7 @@ if (module.parent && module.parent.id === 'internal/preload') {
   globalThis.__debug__ = true;
 }
 
-import('../dist/index.js')
+import('../dist/index.cjs')
   .then(({ Temporal, Intl, toTemporalInstant }) => {
     globalThis.Temporal = { ...Temporal };
     Object.defineProperty(globalThis.Temporal, Symbol.toStringTag, {

--- a/package.json
+++ b/package.json
@@ -3,15 +3,24 @@
   "version": "0.2.0",
   "description": "Polyfill for Temporal",
   "type": "module",
-  "main": "dist/index.js",
-  "module": "dist/index.esm.js",
-  "browser": "dist/index.umd.js",
-  "types": "index.d.ts",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.esm.js",
+  "browser": "./dist/index.umd.js",
+  "exports": {
+    ".": [
+      {
+       "import": "./dist/index.esm.js",
+       "default": "./dist/index.cjs"
+      },
+      "./dist/index.cjs"
+    ]
+ },
+  "types": "./index.d.ts",
   "scripts": {
     "test": "tsc && node --no-warnings --experimental-modules --experimental-specifier-resolution=node --icu-data-dir node_modules/full-icu --loader ./test/resolve.source.mjs ./test/all.mjs",
     "build": "rollup -c rollup.config.js",
     "prepublishOnly": "npm run build",
-    "playground": "npm run build && node --experimental-modules --no-warnings --icu-data-dir node_modules/full-icu -r ./lib/init.js",
+    "playground": "npm run build && node --experimental-modules --no-warnings --icu-data-dir node_modules/full-icu -r ./lib/init.cjs",
     "lint": "eslint . --ext ts,js,mjs,.d.ts --max-warnings 0 --cache \"$@\"",
     "postlint": "npm run tscheck",
     "pretty": "eslint . --ext ts,js,mjs,.d.ts --fix",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -55,12 +55,22 @@ export default [
   {
     input,
     external,
-    output: [outputEntry(pkg.module, 'es'), outputEntry(pkg.main, 'cjs')],
+    output: [
+      // ESM bundle
+      outputEntry(pkg.module, 'es'),
+      // CJS bundle.
+      // Note that because package.json specifies "type":"module", the name of
+      // this file MUST end in ".cjs" in order to be treated as a CommonJS file.
+      outputEntry(pkg.main, 'cjs')
+    ],
     plugins
   },
   {
     input,
-    output: [outputEntry(pkg.browser, 'umd'), outputEntry(pkg.module.replace('.esm', '.browser.esm'), 'es')],
+    // UMD bundle for using in script tags, etc
+    // Note that some build systems don't like reading UMD files if they end in
+    // '.cjs', so this entry in package.json should end in a .js file extension.
+    output: [outputEntry(pkg.browser, 'umd')],
     plugins
   }
 ];


### PR DESCRIPTION
Node will treat all files (including those in dist/) as ESM within the
Temporal source due to setting "type":"module". Renaming these files to
use the cjs file extension tells Node to ignore this setting and treat
the content of those files as CommonJS.