### PR TITLE
Add VS Code configs for IDE debugging of tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@ node_modules/
 dist/
 tsc-out/
 .eslintcache
-.vscode/
+.vscode/*
+!.vscode/launch.json
 *.tgz

--- a/.npmignore
+++ b/.npmignore
@@ -3,3 +3,4 @@ test
 types
 tsconfig.json
 *.sh
+.vscode

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,50 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Test262 (edit subset in launch.json)",
+      "request": "launch",
+      "type": "node",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "test262"],
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen",
+      "autoAttachChildProcesses": true,
+      "env": {
+        // Replace the glob pattern below with tests you want to debug.
+        // Comment out to run all tests, but will be very slow!
+        "TESTS": "PlainYearMonth/prototype/subtract/*.js",
+        // Extends timeouts to 1 hour (from 10 seconds default) so you can
+        // debug a test stopped at a breakpoint before the runner kills it.
+        "TIMEOUT": "3600000"
+      }
+    },
+    {
+      "name": "Test262 (current file)",
+      "request": "launch",
+      "type": "node",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "test262"],
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen",
+      "autoAttachChildProcesses": true,
+      "env": {
+        // Only test the currently-opened file in the IDE
+        "TESTS": "${file}",
+        // Extends timeouts to 1 hour (from 10 seconds default) so you can
+        // debug a test stopped at a breakpoint before the runner kills it.
+        "TIMEOUT": "3600000"
+      }
+    },
+    {
+      "name": "Demitasse tests",
+      "request": "launch",
+      "type": "node",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["test"],
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen",
+      "autoAttachChildProcesses": true,
+    },
+ ]
+}


### PR DESCRIPTION
This PR adds a launch.json debug configuration file that VS Code users can use for one-click IDE debugging of either Demitasse or (coming soon once #41 is merged) Test262 tests.  

Demitasse test debugging "just works".  You should be able to set breakpoints inside Demitasse tests and the debugger will break there.

Test262 debugging has more quirks.  Notably, breakpoints don't work inside the Test262 test runner because there's no sourcemap pointing from the executing code back to the original test sources. This may not be worth solving anyways, because I suspect that generating sourcemaps for every test file would take a loooooooong time!

What *does* work is to place a `debugger;` statement inside a Test262 test that you want to debug. Execution will pause at the `debugger` statement and then you can inspect variables, step in/over, and set breakpoints on later code. Just remember to remove the `debugger` statement before committing tests! 😄  

There are two Test262 debug configs:
1.  `Test262 (current file)` is the easiest. It just debugs the test file currently open in the editor.
2. `Test262 (subset in launch.json)` debugs a subset of tests hardcoded to a glob pattern in launch.json. This is useful for repeatedly debugging the same set of multiple tests. 

In addition to #41, tolerable Test262 debugging also depends on https://github.com/tc39/proposal-temporal/pull/1812 which contains several fixes to the debug experience.  It's not really usable without those changes.