### PR TITLE
Revert "Copy options object for PlainYearMonth.{add,subtract} and Int…

### DIFF
--- a/lib/ecmascript.ts
+++ b/lib/ecmascript.ts
@@ -1025,11 +1025,11 @@ export const ES = ObjectAssign({}, ES2020, {
   },
   InterpretTemporalDateTimeFields: (calendar, fields, options) => {
     let { hour, minute, second, millisecond, microsecond, nanosecond } = ES.ToTemporalTimeRecord(fields);
-    const overflow = ES.ToTemporalOverflow(options);
     const date = ES.DateFromFields(calendar, fields, options);
     const year = GetSlot(date, ISO_YEAR);
     const month = GetSlot(date, ISO_MONTH);
     const day = GetSlot(date, ISO_DAY);
+    const overflow = ES.ToTemporalOverflow(options);
     ({ hour, minute, second, millisecond, microsecond, nanosecond } = ES.RegulateTime(
       hour,
       minute,

--- a/lib/plainyearmonth.ts
+++ b/lib/plainyearmonth.ts
@@ -108,11 +108,10 @@ export class PlainYearMonth implements Temporal.PlainYearMonth {
     const sign = ES.DurationSign(years, months, weeks, days, 0, 0, 0, 0, 0, 0);
     const day = sign < 0 ? ES.ToPositiveInteger(ES.CalendarDaysInMonth(calendar, this)) : 1;
     const startDate = ES.DateFromFields(calendar, { ...fields, day });
-    const optionsCopy = { ...options };
     const addedDate = ES.CalendarDateAdd(calendar, startDate, { ...duration, days }, options);
     const addedDateFields = ES.ToTemporalYearMonthFields(addedDate, fieldNames);
 
-    return ES.YearMonthFromFields(calendar, addedDateFields, optionsCopy);
+    return ES.YearMonthFromFields(calendar, addedDateFields, options);
   }
   subtract(temporalDurationLike, options = undefined) {
     if (!ES.IsTemporalYearMonth(this)) throw new TypeError('invalid receiver');
@@ -140,11 +139,10 @@ export class PlainYearMonth implements Temporal.PlainYearMonth {
     const sign = ES.DurationSign(years, months, weeks, days, 0, 0, 0, 0, 0, 0);
     const day = sign < 0 ? ES.ToPositiveInteger(ES.CalendarDaysInMonth(calendar, this)) : 1;
     const startDate = ES.DateFromFields(calendar, { ...fields, day });
-    const optionsCopy = { ...options };
     const addedDate = ES.CalendarDateAdd(calendar, startDate, { ...duration, days }, options);
     const addedDateFields = ES.ToTemporalYearMonthFields(addedDate, fieldNames);
 
-    return ES.YearMonthFromFields(calendar, addedDateFields, optionsCopy);
+    return ES.YearMonthFromFields(calendar, addedDateFields, options);
   }
   until(other, options = undefined) {
     if (!ES.IsTemporalYearMonth(this)) throw new TypeError('invalid receiver');


### PR DESCRIPTION
…erpretTemporalDateTimeFields to prevent user-modified objects from interfering with later operations."

This reverts commit bafa1bdf2dbfc28513d7e39b0c0d1c3d075d9db5 in order to get test262 to pass against this repo.

Once the corresponding change lands in the proposal repo(https://github.com/tc39/proposal-temporal/pull/1748), we can port that back over.