### PR TITLE
Remove unused ecmascript.ts functions and un-export unused exports

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -36,7 +36,8 @@ rules:
   curly:
     - error
     - multi-line
-  func-call-spacing: error
+  func-call-spacing: off
+  '@typescript-eslint/func-call-spacing': error
   function-call-argument-newline:
     - error
     - consistent

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,3 +11,13 @@ jobs:
           node-version: 15.x
       - run: npm ci --no-optional
       - run: npm run lint
+  lint-unused-code: # look for unused functions and unused exports
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: use node.js v16.x
+        uses: actions/setup-node@v1
+        with:
+          node-version: 16.x
+      - run: npm ci --no-optional
+      - run: npm run prune

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,12 +28,12 @@ jobs:
   test-test262:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: use node.js v16.x
-      uses: actions/setup-node@v1
-      with:
-        node-version: 16.x
-    - run: npm ci
-    - run: npm run test262
-      env:
-        HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+      - uses: actions/checkout@v2
+      - name: use node.js v16.x
+        uses: actions/setup-node@v1
+        with:
+          node-version: 16.x
+      - run: npm ci
+      - run: npm run test262
+        env:
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}

--- a/lib/ecmascript.ts
+++ b/lib/ecmascript.ts
@@ -62,7 +62,7 @@ const YEAR_MIN = -271821;
 const YEAR_MAX = 275760;
 const BEFORE_FIRST_DST = bigInt(-388152).multiply(1e13); // 1847-01-01T00:00:00Z
 
-export function IsInteger(value: unknown): value is number {
+function IsInteger(value: unknown): value is number {
   if (typeof value !== 'number' || !NumberIsFinite(value)) return false;
   const abs = MathAbs(value);
   return MathFloor(abs) === abs;
@@ -94,7 +94,7 @@ export function ToNumber(value: unknown): number {
   return NumberCtor(value);
 }
 
-export function ToInteger(value: unknown): number {
+function ToInteger(value: unknown): number {
   const num = ToNumber(value);
   if (NumberIsNaN(num)) return 0;
   const integer = MathTrunc(num);
@@ -131,7 +131,7 @@ export function ToPositiveInteger(value, property?: string) {
   return value;
 }
 
-export function ToIntegerNoFraction(value) {
+function ToIntegerNoFraction(value) {
   value = ToNumber(value);
   if (!IsInteger(value)) {
     throw new RangeError(`unsupported fractional value ${value}`);
@@ -258,7 +258,7 @@ export function IsTemporalMonthDay(item) {
 export function IsTemporalZonedDateTime(item) {
   return HasSlot(item, EPOCHNANOSECONDS, TIME_ZONE, CALENDAR);
 }
-export function TemporalTimeZoneFromString(stringIdent) {
+function TemporalTimeZoneFromString(stringIdent) {
   let { ianaName, offset, z } = ParseTemporalTimeZoneString(stringIdent);
   let identifier = ianaName;
   if (!identifier && z) identifier = 'UTC';
@@ -274,13 +274,13 @@ export function TemporalTimeZoneFromString(stringIdent) {
   return result;
 }
 
-export function FormatCalendarAnnotation(id, showCalendar) {
+function FormatCalendarAnnotation(id, showCalendar) {
   if (showCalendar === 'never') return '';
   if (showCalendar === 'auto' && id === 'iso8601') return '';
   return `[u-ca=${id}]`;
 }
 
-export function ParseISODateTime(isoString, { zoneRequired }) {
+function ParseISODateTime(isoString, { zoneRequired }) {
   const regex = zoneRequired ? PARSE.instant : PARSE.datetime;
   const match = regex.exec(isoString);
   if (!match) throw new RangeError(`invalid ISO 8601 string: ${isoString}`);
@@ -344,23 +344,23 @@ export function ParseISODateTime(isoString, { zoneRequired }) {
   };
 }
 
-export function ParseTemporalInstantString(isoString) {
+function ParseTemporalInstantString(isoString) {
   return ParseISODateTime(isoString, { zoneRequired: true });
 }
 
-export function ParseTemporalZonedDateTimeString(isoString) {
+function ParseTemporalZonedDateTimeString(isoString) {
   return ParseISODateTime(isoString, { zoneRequired: true });
 }
 
-export function ParseTemporalDateTimeString(isoString) {
+function ParseTemporalDateTimeString(isoString) {
   return ParseISODateTime(isoString, { zoneRequired: false });
 }
 
-export function ParseTemporalDateString(isoString) {
+function ParseTemporalDateString(isoString) {
   return ParseISODateTime(isoString, { zoneRequired: false });
 }
 
-export function ParseTemporalTimeString(isoString) {
+function ParseTemporalTimeString(isoString) {
   const match = PARSE.time.exec(isoString);
   let hour, minute, second, millisecond, microsecond, nanosecond, calendar;
   if (match) {
@@ -381,7 +381,7 @@ export function ParseTemporalTimeString(isoString) {
   return { hour, minute, second, millisecond, microsecond, nanosecond, calendar };
 }
 
-export function ParseTemporalYearMonthString(isoString) {
+function ParseTemporalYearMonthString(isoString) {
   const match = PARSE.yearmonth.exec(isoString);
   let year, month, calendar, referenceISODay;
   if (match) {
@@ -396,7 +396,7 @@ export function ParseTemporalYearMonthString(isoString) {
   return { year, month, calendar, referenceISODay };
 }
 
-export function ParseTemporalMonthDayString(isoString) {
+function ParseTemporalMonthDayString(isoString) {
   const match = PARSE.monthday.exec(isoString);
   let month, day, calendar, referenceISOYear;
   if (match) {
@@ -408,7 +408,7 @@ export function ParseTemporalMonthDayString(isoString) {
   return { month, day, calendar, referenceISOYear };
 }
 
-export function ParseTemporalTimeZoneString(stringIdent): {
+function ParseTemporalTimeZoneString(stringIdent): {
   ianaName?: string | undefined;
   offset?: string | undefined;
   z?: boolean | undefined;
@@ -431,7 +431,7 @@ export function ParseTemporalTimeZoneString(stringIdent): {
   }
 }
 
-export function ParseTemporalDurationString(isoString) {
+function ParseTemporalDurationString(isoString) {
   const match = PARSE.duration.exec(isoString);
   if (!match) throw new RangeError(`invalid duration: ${isoString}`);
   if (match.slice(2).every((element) => element === undefined)) {
@@ -467,7 +467,7 @@ export function ParseTemporalDurationString(isoString) {
   return { years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds };
 }
 
-export function ParseTemporalInstant(isoString) {
+function ParseTemporalInstant(isoString) {
   const { year, month, day, hour, minute, second, millisecond, microsecond, nanosecond, offset, z } =
     ParseTemporalInstantString(isoString);
 
@@ -522,7 +522,7 @@ export function RegulateISOYearMonth(year, month, overflow) {
   return { year, month };
 }
 
-export function DurationHandleFractions(fHours, minutes, fMinutes, seconds, milliseconds, microseconds, nanoseconds) {
+function DurationHandleFractions(fHours, minutes, fMinutes, seconds, milliseconds, microseconds, nanoseconds) {
   if (fHours !== 0) {
     [minutes, fMinutes, seconds, milliseconds, microseconds, nanoseconds].forEach((val) => {
       if (val !== 0) throw new RangeError('only the smallest unit can be fractional');
@@ -561,7 +561,7 @@ export function DurationHandleFractions(fHours, minutes, fMinutes, seconds, mill
   return { minutes, seconds, milliseconds, microseconds, nanoseconds };
 }
 
-export function ToTemporalDurationRecord(item) {
+function ToTemporalDurationRecord(item) {
   if (IsTemporalDuration(item)) {
     return {
       years: GetSlot(item, YEARS),
@@ -1722,7 +1722,7 @@ export function ToTemporalCalendar(calendarLike) {
   return new TemporalCalendar(calendar);
 }
 
-export function GetTemporalCalendarWithISODefault(item) {
+function GetTemporalCalendarWithISODefault(item) {
   if (HasSlot(item, CALENDAR)) return GetSlot(item, CALENDAR);
   const { calendar } = item;
   if (calendar === undefined) return GetISO8601Calendar();
@@ -1853,7 +1853,7 @@ export function BuiltinTimeZoneGetInstantFor(timeZone, dateTime, disambiguation)
   return DisambiguatePossibleInstants(possibleInstants, timeZone, dateTime, disambiguation);
 }
 
-export function DisambiguatePossibleInstants(possibleInstants, timeZone, dateTime, disambiguation) {
+function DisambiguatePossibleInstants(possibleInstants, timeZone, dateTime, disambiguation) {
   const Instant = GetIntrinsic('%Temporal.Instant%');
   const numInstants = possibleInstants.length;
 
@@ -1978,7 +1978,7 @@ export function DisambiguatePossibleInstants(possibleInstants, timeZone, dateTim
   }
 }
 
-export function GetPossibleInstantsFor(timeZone, dateTime) {
+function GetPossibleInstantsFor(timeZone, dateTime) {
   const possibleInstants = timeZone.getPossibleInstantsFor(dateTime);
   const result = [];
   for (const instant of possibleInstants) {
@@ -2262,7 +2262,7 @@ export function GetIANATimeZoneOffsetNanoseconds(epochNanoseconds, id) {
   return +utc.minus(epochNanoseconds);
 }
 
-export function FormatTimeZoneOffsetString(offsetNanoseconds) {
+function FormatTimeZoneOffsetString(offsetNanoseconds) {
   const sign = offsetNanoseconds < 0 ? '-' : '+';
   offsetNanoseconds = MathAbs(offsetNanoseconds);
   const nanoseconds = offsetNanoseconds % 1e9;
@@ -2299,7 +2299,7 @@ export function GetEpochFromISOParts(year, month, day, hour, minute, second, mil
   return ns;
 }
 
-export function GetISOPartsFromEpoch(epochNanoseconds) {
+function GetISOPartsFromEpoch(epochNanoseconds) {
   const { quotient, remainder } = bigInt(epochNanoseconds).divmod(1e6);
   let epochMilliseconds = +quotient;
   let nanos = +remainder;
@@ -2509,7 +2509,7 @@ export function DurationSign(y, mon, w, d, h, min, s, ms, µs, ns) {
   return 0;
 }
 
-export function BalanceISOYearMonth(year, month) {
+function BalanceISOYearMonth(year, month) {
   if (!NumberIsFinite(year) || !NumberIsFinite(month)) throw new RangeError('infinity is out of range');
   month -= 1;
   year += MathFloor(month / 12);
@@ -2519,7 +2519,7 @@ export function BalanceISOYearMonth(year, month) {
   return { year, month };
 }
 
-export function BalanceISODate(year, month, day) {
+function BalanceISODate(year, month, day) {
   if (!NumberIsFinite(day)) throw new RangeError('infinity is out of range');
   ({ year, month } = BalanceISOYearMonth(year, month));
   let daysInYear = 0;
@@ -2548,7 +2548,7 @@ export function BalanceISODate(year, month, day) {
   return { year, month, day };
 }
 
-export function BalanceISODateTime(year, month, day, hour, minute, second, millisecond, microsecond, nanosecond) {
+function BalanceISODateTime(year, month, day, hour, minute, second, millisecond, microsecond, nanosecond) {
   let deltaDays;
   ({ deltaDays, hour, minute, second, millisecond, microsecond, nanosecond } = BalanceTime(
     hour,
@@ -2562,7 +2562,7 @@ export function BalanceISODateTime(year, month, day, hour, minute, second, milli
   return { year, month, day, hour, minute, second, millisecond, microsecond, nanosecond };
 }
 
-export function BalanceTime(hour, minute, second, millisecond, microsecond, nanosecond) {
+function BalanceTime(hour, minute, second, millisecond, microsecond, nanosecond) {
   if (
     !NumberIsFinite(hour) ||
     !NumberIsFinite(minute) ||
@@ -2614,7 +2614,7 @@ export function TotalDurationNanoseconds(
   return bigInt(nanoseconds).add(microseconds.multiply(1000));
 }
 
-export function NanosecondsToDays(nanoseconds, relativeTo) {
+function NanosecondsToDays(nanoseconds, relativeTo) {
   const TemporalInstant = GetIntrinsic('%Temporal.Instant%');
   const sign = MathSign(nanoseconds);
   nanoseconds = bigInt(nanoseconds);
@@ -3000,13 +3000,13 @@ export function CreateNegatedTemporalDuration(duration) {
 export function ConstrainToRange(value, min, max) {
   return MathMin(max, MathMax(min, value));
 }
-export function ConstrainISODate(year, month, day?: any) {
+function ConstrainISODate(year, month, day?: any) {
   month = ConstrainToRange(month, 1, 12);
   day = ConstrainToRange(day, 1, ISODaysInMonth(year, month));
   return { year, month, day };
 }
 
-export function ConstrainTime(hour, minute, second, millisecond, microsecond, nanosecond) {
+function ConstrainTime(hour, minute, second, millisecond, microsecond, nanosecond) {
   hour = ConstrainToRange(hour, 0, 23);
   minute = ConstrainToRange(minute, 0, 59);
   second = ConstrainToRange(second, 0, 59);
@@ -3020,12 +3020,12 @@ export function RejectToRange(value, min, max) {
   if (value < min || value > max) throw new RangeError(`value out of range: ${min} <= ${value} <= ${max}`);
 }
 
-export function RejectISODate(year, month, day) {
+function RejectISODate(year, month, day) {
   RejectToRange(month, 1, 12);
   RejectToRange(day, 1, ISODaysInMonth(year, month));
 }
 
-export function RejectDateRange(year, month, day) {
+function RejectDateRange(year, month, day) {
   // Noon avoids trouble at edges of DateTime range (excludes midnight)
   RejectDateTimeRange(year, month, day, 12, 0, 0, 0, 0, 0);
 }
@@ -3039,12 +3039,12 @@ export function RejectTime(hour, minute, second, millisecond, microsecond, nanos
   RejectToRange(nanosecond, 0, 999);
 }
 
-export function RejectDateTime(year, month, day, hour, minute, second, millisecond, microsecond, nanosecond) {
+function RejectDateTime(year, month, day, hour, minute, second, millisecond, microsecond, nanosecond) {
   RejectISODate(year, month, day);
   RejectTime(hour, minute, second, millisecond, microsecond, nanosecond);
 }
 
-export function RejectDateTimeRange(year, month, day, hour, minute, second, millisecond, microsecond, nanosecond) {
+function RejectDateTimeRange(year, month, day, hour, minute, second, millisecond, microsecond, nanosecond) {
   RejectToRange(year, YEAR_MIN, YEAR_MAX);
   // Reject any DateTime 24 hours or more outside the Instant range
   if (
@@ -3065,7 +3065,7 @@ export function ValidateEpochNanoseconds(epochNanoseconds) {
   }
 }
 
-export function RejectYearMonthRange(year, month) {
+function RejectYearMonthRange(year, month) {
   RejectToRange(year, YEAR_MIN, YEAR_MAX);
   if (year === YEAR_MIN) {
     RejectToRange(month, 4, 12);
@@ -3074,7 +3074,7 @@ export function RejectYearMonthRange(year, month) {
   }
 }
 
-export function RejectDuration(y, mon, w, d, h, min, s, ms, µs, ns) {
+function RejectDuration(y, mon, w, d, h, min, s, ms, µs, ns) {
   const sign = DurationSign(y, mon, w, d, h, min, s, ms, µs, ns);
   for (const prop of [y, mon, w, d, h, min, s, ms, µs, ns]) {
     if (!NumberIsFinite(prop)) throw new RangeError('infinite values not allowed as duration fields');
@@ -3689,7 +3689,7 @@ export function AddZonedDateTime(
   return AddInstant(GetSlot(instantIntermediate, EPOCHNANOSECONDS), h, min, s, ms, µs, ns);
 }
 
-export function RoundNumberToIncrement(quantity, increment, mode) {
+function RoundNumberToIncrement(quantity, increment, mode) {
   if (increment === 1) return quantity;
   let { quotient, remainder } = quantity.divmod(increment);
   if (remainder.equals(bigInt.zero)) return quantity;
@@ -3809,7 +3809,7 @@ export function RoundTime(
   }
 }
 
-export function DaysUntil(earlier, later) {
+function DaysUntil(earlier, later) {
   return DifferenceISODate(
     GetSlot(earlier, ISO_YEAR),
     GetSlot(earlier, ISO_MONTH),
@@ -3821,7 +3821,7 @@ export function DaysUntil(earlier, later) {
   ).days;
 }
 
-export function MoveRelativeDate(calendar, relativeTo, duration) {
+function MoveRelativeDate(calendar, relativeTo, duration) {
   const options = ObjectCreate(null);
   const later = CalendarDateAdd(calendar, relativeTo, duration, options);
   const days = DaysUntil(relativeTo, later);
@@ -4223,7 +4223,7 @@ export function CompareISODate(y1, m1, d1, y2, m2, d2) {
   return 0;
 }
 
-export function NonNegativeModulo(x, y) {
+function NonNegativeModulo(x, y) {
   let result = x % y;
   if (ObjectIs(result, -0)) return 0;
   if (result < 0) result += y;
@@ -4298,7 +4298,7 @@ export function GetOptionsObject(options) {
   throw new TypeError(`Options parameter must be an object, not ${options === null ? 'null' : `a ${typeof options}`}`);
 }
 
-export function GetOption(options, property, allowedValues, fallback) {
+function GetOption(options, property, allowedValues, fallback) {
   let value = options[property];
   if (value !== undefined) {
     value = ToString(value);
@@ -4310,7 +4310,7 @@ export function GetOption(options, property, allowedValues, fallback) {
   return fallback;
 }
 
-export function GetNumberOption(options, property, minimum, maximum, fallback) {
+function GetNumberOption(options, property, minimum, maximum, fallback) {
   let value = options[property];
   if (value === undefined) return fallback;
   value = ToNumber(value);

--- a/lib/ecmascript.ts
+++ b/lib/ecmascript.ts
@@ -2322,6 +2322,7 @@ function GetISOPartsFromEpoch(epochNanoseconds) {
   return { epochMilliseconds, year, month, day, hour, minute, second, millisecond, microsecond, nanosecond };
 }
 
+// ts-prune-ignore-next TODO: remove this after tests are converted to TS
 export function GetIANATimeZoneDateTimeParts(epochNanoseconds, id) {
   const { epochMilliseconds, millisecond, microsecond, nanosecond } = GetISOPartsFromEpoch(epochNanoseconds);
   const { year, month, day, hour, minute, second } = GetFormatterParts(id, epochMilliseconds);
@@ -2376,6 +2377,7 @@ export function GetIANATimeZonePreviousTransition(epochNanoseconds, id) {
   return result;
 }
 
+// ts-prune-ignore-next TODO: remove this after tests are converted to TS
 export function GetFormatterParts(timeZone, epochMilliseconds) {
   const formatter = getIntlDateTimeFormatEnUsForTimeZone(timeZone);
   // FIXME: can this use formatToParts instead?

--- a/lib/ecmascript.ts
+++ b/lib/ecmascript.ts
@@ -478,39 +478,6 @@ export function ParseTemporalInstant(isoString) {
   return epochNs.subtract(offsetNs);
 }
 
-export function RegulateISODateTime(
-  year,
-  month,
-  day,
-  hour,
-  minute,
-  second,
-  millisecond,
-  microsecond,
-  nanosecond,
-  overflow
-) {
-  switch (overflow) {
-    case 'reject':
-      RejectDateTime(year, month, day, hour, minute, second, millisecond, microsecond, nanosecond);
-      break;
-    case 'constrain':
-      ({ year, month, day, hour, minute, second, millisecond, microsecond, nanosecond } = ConstrainISODateTime(
-        year,
-        month,
-        day,
-        hour,
-        minute,
-        second,
-        millisecond,
-        microsecond,
-        nanosecond
-      ));
-      break;
-  }
-  return { year, month, day, hour, minute, second, millisecond, microsecond, nanosecond };
-}
-
 export function RegulateISODate(year, month, day, overflow) {
   switch (overflow) {
     case 'reject':
@@ -655,10 +622,6 @@ export function ToLimitedTemporalDuration(item, disallowedProperties = []) {
     }
   }
   return record;
-}
-
-export function ToTemporalDurationOverflow(options) {
-  return GetOption(options, 'overflow', ['constrain', 'balance'], 'constrain');
 }
 
 export function ToTemporalOverflow(options) {
@@ -923,13 +886,6 @@ export function DefaultTemporalLargestUnit(
 export function LargerOfTwoTemporalUnits(unit1, unit2) {
   if (ALLOWED_UNITS.indexOf(unit1) > ALLOWED_UNITS.indexOf(unit2)) return unit2;
   return unit1;
-}
-
-export function CastIfDefined(value, cast) {
-  if (value !== undefined) {
-    return cast(value);
-  }
-  return value;
 }
 
 export function ToPartialRecord(bag, fields, callerCast?: (value: unknown) => unknown) {
@@ -1771,12 +1727,6 @@ export function GetTemporalCalendarWithISODefault(item) {
   const { calendar } = item;
   if (calendar === undefined) return GetISO8601Calendar();
   return ToTemporalCalendar(calendar);
-}
-
-export function CalendarCompare(one, two) {
-  const cal1 = ToString(one);
-  const cal2 = ToString(two);
-  return cal1 < cal2 ? -1 : cal1 > cal2 ? 1 : 0;
 }
 
 export function CalendarEquals(one, two) {
@@ -3066,19 +3016,6 @@ export function ConstrainTime(hour, minute, second, millisecond, microsecond, na
   return { hour, minute, second, millisecond, microsecond, nanosecond };
 }
 
-export function ConstrainISODateTime(year, month, day, hour, minute, second, millisecond, microsecond, nanosecond) {
-  ({ year, month, day } = ConstrainISODate(year, month, day));
-  ({ hour, minute, second, millisecond, microsecond, nanosecond } = ConstrainTime(
-    hour,
-    minute,
-    second,
-    millisecond,
-    microsecond,
-    nanosecond
-  ));
-  return { year, month, day, hour, minute, second, millisecond, microsecond, nanosecond };
-}
-
 export function RejectToRange(value, min, max) {
   if (value < min || value > max) throw new RangeError(`value out of range: ${min} <= ${value} <= ${max}`);
 }
@@ -3478,17 +3415,6 @@ export function AddTime(
     nanosecond
   ));
   return { deltaDays, hour, minute, second, millisecond, microsecond, nanosecond };
-}
-
-export function SubtractDate(year, month, day, years, months, weeks, days, overflow) {
-  days += 7 * weeks;
-  day -= days;
-  ({ year, month, day } = BalanceISODate(year, month, day));
-  month -= months;
-  year -= years;
-  ({ year, month } = BalanceISOYearMonth(year, month));
-  ({ year, month, day } = RegulateISODate(year, month, day, overflow));
-  return { year, month, day };
 }
 
 export function AddDuration(
@@ -4295,11 +4221,6 @@ export function CompareISODate(y1, m1, d1, y2, m2, d2) {
     if (x !== y) return ComparisonResult(x - y);
   }
   return 0;
-}
-
-export function AssertPositiveInteger(num) {
-  if (!NumberIsFinite(num) || MathAbs(num) !== num) throw new RangeError(`invalid positive integer: ${num}`);
-  return num;
 }
 
 export function NonNegativeModulo(x, y) {

--- a/lib/regex.ts
+++ b/lib/regex.ts
@@ -1,16 +1,16 @@
 const tzComponent = /\.[-A-Za-z_]|\.\.[-A-Za-z._]{1,12}|\.[-A-Za-z_][-A-Za-z._]{0,12}|[A-Za-z_][-A-Za-z._]{0,13}/;
 const offsetNoCapture = /(?:[+\u2212-][0-2][0-9](?::?[0-5][0-9](?::?[0-5][0-9](?:[.,]\d{1,9})?)?)?)/;
-export const timeZoneID = new RegExp(
+const timeZoneID = new RegExp(
   `(?:(?:${tzComponent.source})(?:\\/(?:${tzComponent.source}))*|Etc/GMT[-+]\\d{1,2}|${offsetNoCapture.source})`
 );
 
 const calComponent = /[A-Za-z0-9]{3,8}/;
-export const calendarID = new RegExp(`(?:${calComponent.source}(?:-${calComponent.source})*)`);
+const calendarID = new RegExp(`(?:${calComponent.source}(?:-${calComponent.source})*)`);
 
 const yearpart = /(?:[+\u2212-]\d{6}|\d{4})/;
 const monthpart = /(?:0[1-9]|1[0-2])/;
 const daypart = /(?:0[1-9]|[12]\d|3[01])/;
-export const datesplit = new RegExp(
+const datesplit = new RegExp(
   `(${yearpart.source})(?:-(${monthpart.source})-(${daypart.source})|(${monthpart.source})(${daypart.source}))`
 );
 const timesplit = /(\d{2})(?::(\d{2})(?::(\d{2})(?:[.,](\d{1,9}))?)?|(\d{2})(?:(\d{2})(?:[.,](\d{1,9}))?)?)?/;

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "rollup-plugin-dts": "^3.0.2",
         "rollup-plugin-terser": "^7.0.2",
         "timezones.json": "^1.5.2",
+        "ts-prune": "^0.10.1",
         "typescript": "^4.3.5"
       },
       "engines": {
@@ -1810,6 +1811,18 @@
       "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
       "dev": true
     },
+    "node_modules/@ts-morph/common": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.10.1.tgz",
+      "integrity": "sha512-rKN/VtZUUlW4M+6vjLFSaFc1Z9sK+1hh0832ucPtPkXqOw/mSWE80Lau4z2zTPNTqtxAjfZbvKpQcEwJy0KIEg==",
+      "dev": true,
+      "dependencies": {
+        "fast-glob": "^3.2.5",
+        "minimatch": "^3.0.4",
+        "mkdirp": "^1.0.4",
+        "path-browserify": "^1.0.1"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "0.0.39",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
@@ -1826,6 +1839,12 @@
       "version": "16.4.10",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.4.10.tgz",
       "integrity": "sha512-TmVHsm43br64js9BqHWqiDZA+xMtbUpI1MBIA0EyiBmoV9pcEYFOSdj5fr6enZNfh4fChh+AGOLIzGwJnkshyQ==",
+      "dev": true
+    },
+    "node_modules/@types/parse-json": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
       "dev": true
     },
     "node_modules/@types/resolve": {
@@ -2288,6 +2307,12 @@
         "node": ">=4"
       }
     },
+    "node_modules/code-block-writer": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/code-block-writer/-/code-block-writer-10.1.1.tgz",
+      "integrity": "sha512-67ueh2IRGst/51p0n6FvPrnRjAGHY5F8xdjkgrYE7DDzpJe6qA07RYQ9VcoUeo5ATOjSOiWpSL3SWBRRbempMw==",
+      "dev": true
+    },
     "node_modules/color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -2357,6 +2382,22 @@
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/cosmiconfig": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
+      "integrity": "sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/parse-json": "^4.0.0",
+        "import-fresh": "^3.2.1",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0",
+        "yaml": "^1.10.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/cross-spawn": {
@@ -2463,6 +2504,15 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "dev": true,
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
       }
     },
     "node_modules/escalade": {
@@ -3170,6 +3220,12 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
     },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "dev": true
+    },
     "node_modules/is-core-module": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.5.0.tgz",
@@ -3308,6 +3364,12 @@
         "node": ">=4"
       }
     },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true
+    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -3347,6 +3409,18 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
+      "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
+      "dev": true
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
     },
     "node_modules/lodash.clonedeep": {
       "version": "4.5.0",
@@ -3439,6 +3513,18 @@
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
       "dev": true
     },
+    "node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true,
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -3521,6 +3607,30 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+      "dev": true
     },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
@@ -4159,6 +4269,51 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/true-myth": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/true-myth/-/true-myth-4.1.1.tgz",
+      "integrity": "sha512-rqy30BSpxPznbbTcAcci90oZ1YR4DqvKcNXNerG5gQBU2v4jk0cygheiul5J6ExIMrgDVuanv/MkGfqZbKrNNg==",
+      "dev": true,
+      "engines": {
+        "node": "10.* || >= 12.*"
+      }
+    },
+    "node_modules/ts-morph": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-11.0.3.tgz",
+      "integrity": "sha512-ymuPkndv9rzqTLiHWMkVrFXWcN4nBiBGhRP/kTC9F5amAAl7BNLfyrsTzMD1o9A0zishKoF1KQT/0yyFhJnPgA==",
+      "dev": true,
+      "dependencies": {
+        "@ts-morph/common": "~0.10.1",
+        "code-block-writer": "^10.1.1"
+      }
+    },
+    "node_modules/ts-prune": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/ts-prune/-/ts-prune-0.10.1.tgz",
+      "integrity": "sha512-s40MIEt7kGzZHuC8CwoSUY8UuaEVVSxGydIffYvbdG8ZV5I5vWcC5lIGxqr9JlIJJrENeNuJ0rfVgzWTGlgugQ==",
+      "dev": true,
+      "dependencies": {
+        "commander": "^6.2.1",
+        "cosmiconfig": "^7.0.1",
+        "json5": "^2.1.3",
+        "lodash": "^4.17.21",
+        "true-myth": "^4.1.0",
+        "ts-morph": "^11.0.2"
+      },
+      "bin": {
+        "ts-prune": "lib/index.js"
+      }
+    },
+    "node_modules/ts-prune/node_modules/commander": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+      "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
@@ -4312,6 +4467,15 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
+    },
+    "node_modules/yaml": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
+      }
     }
   },
   "dependencies": {
@@ -5553,6 +5717,18 @@
         }
       }
     },
+    "@ts-morph/common": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.10.1.tgz",
+      "integrity": "sha512-rKN/VtZUUlW4M+6vjLFSaFc1Z9sK+1hh0832ucPtPkXqOw/mSWE80Lau4z2zTPNTqtxAjfZbvKpQcEwJy0KIEg==",
+      "dev": true,
+      "requires": {
+        "fast-glob": "^3.2.5",
+        "minimatch": "^3.0.4",
+        "mkdirp": "^1.0.4",
+        "path-browserify": "^1.0.1"
+      }
+    },
     "@types/estree": {
       "version": "0.0.39",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
@@ -5569,6 +5745,12 @@
       "version": "16.4.10",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.4.10.tgz",
       "integrity": "sha512-TmVHsm43br64js9BqHWqiDZA+xMtbUpI1MBIA0EyiBmoV9pcEYFOSdj5fr6enZNfh4fChh+AGOLIzGwJnkshyQ==",
+      "dev": true
+    },
+    "@types/parse-json": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
       "dev": true
     },
     "@types/resolve": {
@@ -5878,6 +6060,12 @@
         "supports-color": "^5.3.0"
       }
     },
+    "code-block-writer": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/code-block-writer/-/code-block-writer-10.1.1.tgz",
+      "integrity": "sha512-67ueh2IRGst/51p0n6FvPrnRjAGHY5F8xdjkgrYE7DDzpJe6qA07RYQ9VcoUeo5ATOjSOiWpSL3SWBRRbempMw==",
+      "dev": true
+    },
     "color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -5942,6 +6130,19 @@
           "integrity": "sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==",
           "dev": true
         }
+      }
+    },
+    "cosmiconfig": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
+      "integrity": "sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==",
+      "dev": true,
+      "requires": {
+        "@types/parse-json": "^4.0.0",
+        "import-fresh": "^3.2.1",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0",
+        "yaml": "^1.10.0"
       }
     },
     "cross-spawn": {
@@ -6022,6 +6223,15 @@
       "dev": true,
       "requires": {
         "ansi-colors": "^4.1.1"
+      }
+    },
+    "error-ex": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "dev": true,
+      "requires": {
+        "is-arrayish": "^0.2.1"
       }
     },
     "escalade": {
@@ -6541,6 +6751,12 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
     },
+    "is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "dev": true
+    },
     "is-core-module": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.5.0.tgz",
@@ -6648,6 +6864,12 @@
       "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
       "dev": true
     },
+    "json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true
+    },
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -6678,6 +6900,18 @@
         "prelude-ls": "^1.2.1",
         "type-check": "~0.4.0"
       }
+    },
+    "lines-and-columns": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
+      "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
+      "dev": true
+    },
+    "lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
     },
     "lodash.clonedeep": {
       "version": "4.5.0",
@@ -6758,6 +6992,12 @@
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
       "dev": true
     },
+    "mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true
+    },
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -6825,6 +7065,24 @@
       "requires": {
         "callsites": "^3.0.0"
       }
+    },
+    "parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      }
+    },
+    "path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+      "dev": true
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -7284,6 +7542,44 @@
         "is-number": "^7.0.0"
       }
     },
+    "true-myth": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/true-myth/-/true-myth-4.1.1.tgz",
+      "integrity": "sha512-rqy30BSpxPznbbTcAcci90oZ1YR4DqvKcNXNerG5gQBU2v4jk0cygheiul5J6ExIMrgDVuanv/MkGfqZbKrNNg==",
+      "dev": true
+    },
+    "ts-morph": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-11.0.3.tgz",
+      "integrity": "sha512-ymuPkndv9rzqTLiHWMkVrFXWcN4nBiBGhRP/kTC9F5amAAl7BNLfyrsTzMD1o9A0zishKoF1KQT/0yyFhJnPgA==",
+      "dev": true,
+      "requires": {
+        "@ts-morph/common": "~0.10.1",
+        "code-block-writer": "^10.1.1"
+      }
+    },
+    "ts-prune": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/ts-prune/-/ts-prune-0.10.1.tgz",
+      "integrity": "sha512-s40MIEt7kGzZHuC8CwoSUY8UuaEVVSxGydIffYvbdG8ZV5I5vWcC5lIGxqr9JlIJJrENeNuJ0rfVgzWTGlgugQ==",
+      "dev": true,
+      "requires": {
+        "commander": "^6.2.1",
+        "cosmiconfig": "^7.0.1",
+        "json5": "^2.1.3",
+        "lodash": "^4.17.21",
+        "true-myth": "^4.1.0",
+        "ts-morph": "^11.0.2"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+          "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+          "dev": true
+        }
+      }
+    },
     "tslib": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
@@ -7395,6 +7691,12 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
+    },
+    "yaml": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "playground": "TEMPORAL_PLAYGROUND=1 npm run build && node --experimental-modules --no-warnings --icu-data-dir node_modules/full-icu -r ./dist/playground.cjs",
     "lint": "eslint . --ext ts,js,mjs,.d.ts --max-warnings 0 --cache \"$@\"",
     "postlint": "npm run tscheck",
+    "prune": "ts-prune -e -i test/tc39 -i \"(lib/index|lib/init|index.d).ts\"",
     "pretty": "eslint . --ext ts,js,mjs,.d.ts --fix",
     "tscheck": "tsc index.d.ts --noEmit --strict --lib ESNext"
   },
@@ -88,6 +89,7 @@
     "rollup-plugin-dts": "^3.0.2",
     "rollup-plugin-terser": "^7.0.2",
     "timezones.json": "^1.5.2",
+    "ts-prune": "^0.10.1",
     "typescript": "^4.3.5"
   },
   "engines": {


### PR DESCRIPTION
Now that #57 is merged, it's easy to find which functions aren't used via [ts-prune](https://github.com/nadeesha/ts-prune).  This PR:
1. Deletes functions that aren't used at all
2. Removes `export` from functions that are never used (including tests) outside the file where they are declared. Fixes #63.
3. Adds a CI test for ts-prune so we can catch future cases of orphaned code or unused exports.  
4. While I was editing the GH actions config, I noticed that we weren't calling ESLint in CI tests, so I added that too.

**Deleted Functions Info**

According to `ts-prune`, the following 6 functions in ecmascript.ts weren't used:
* `RegulateISODateTime`
* `CastIfDefined`
* `CalendarCompare`
* `SubtractDate`
* `AssertPositiveInteger`
* `ToTemporalDurationOverflow`

After those were deleted, `ConstrainISODateTime` was now unused because `RegulateISODateTime` (now deleted) was its only caller. So `ConstrainISODateTime` is also deleted in this PR.

I verified via grep that these are indeed unused anywhere (including tests).  Also, none of these show up in the spec.