### PR TITLE
Make `options` optional in TS types of Calendar and CalendarProtocol methods

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -663,25 +663,25 @@ export namespace Temporal {
     ): boolean;
     dateFromFields(
       fields: { year: number | undefined; month: number | undefined; monthCode: string | undefined; day: number },
-      options: AssignmentOptions
+      options?: AssignmentOptions
     ): Temporal.PlainDate;
     yearMonthFromFields(
       fields: { year: number | undefined; month: number | undefined; monthCode: string | undefined },
-      options: AssignmentOptions
+      options?: AssignmentOptions
     ): Temporal.PlainYearMonth;
     monthDayFromFields(
       fields: { year: number | undefined; month: number | undefined; monthCode: string | undefined; day: number },
-      options: AssignmentOptions
+      options?: AssignmentOptions
     ): Temporal.PlainMonthDay;
     dateAdd?(
       date: Temporal.PlainDate | PlainDateLike | string,
       duration: Temporal.Duration | DurationLike | string,
-      options: ArithmeticOptions
+      options?: ArithmeticOptions
     ): Temporal.PlainDate;
     dateUntil?(
       one: Temporal.PlainDate | PlainDateLike | string,
       two: Temporal.PlainDate | PlainDateLike | string,
-      options: DifferenceOptions<
+      options?: DifferenceOptions<
         | 'year'
         | 'month'
         | 'week'
@@ -749,20 +749,20 @@ export namespace Temporal {
     ): boolean;
     dateFromFields(
       fields: { year: number | undefined; month: number | undefined; monthCode: string | undefined; day: number },
-      options: AssignmentOptions
+      options?: AssignmentOptions
     ): Temporal.PlainDate;
     yearMonthFromFields(
       fields: { year: number | undefined; month: number | undefined; monthCode: string | undefined },
-      options: AssignmentOptions
+      options?: AssignmentOptions
     ): Temporal.PlainYearMonth;
     monthDayFromFields(
       fields: { year: number | undefined; month: number | undefined; monthCode: string | undefined; day: number },
-      options: AssignmentOptions
+      options?: AssignmentOptions
     ): Temporal.PlainMonthDay;
     dateAdd(
       date: Temporal.PlainDate | PlainDateLike | string,
       duration: Temporal.Duration | DurationLike | string,
-      options: ArithmeticOptions
+      options?: ArithmeticOptions
     ): Temporal.PlainDate;
     dateUntil(
       one: Temporal.PlainDate | PlainDateLike | string,


### PR DESCRIPTION
This PR ensures that the TS types for methods of the Calendar and CalendarProtocol types now correctly type `options` as optional.

This PR should be ported over to proposal-temporal too.