### PR TITLE
Make runtime type checks TS-friendly

### DIFF
--- a/lib/calendar.ts
+++ b/lib/calendar.ts
@@ -62,19 +62,19 @@ export class Calendar implements Temporal.Calendar {
   }
   dateFromFields(fields, options = undefined) {
     if (!ES.IsTemporalCalendar(this)) throw new TypeError('invalid receiver');
-    if (ES.Type(fields) !== 'Object') throw new TypeError('invalid fields');
+    if (!ES.IsObject(fields)) throw new TypeError('invalid fields');
     options = ES.GetOptionsObject(options);
     return impl[GetSlot(this, CALENDAR_ID)].dateFromFields(fields, options, this);
   }
   yearMonthFromFields(fields, options = undefined) {
     if (!ES.IsTemporalCalendar(this)) throw new TypeError('invalid receiver');
-    if (ES.Type(fields) !== 'Object') throw new TypeError('invalid fields');
+    if (!ES.IsObject(fields)) throw new TypeError('invalid fields');
     options = ES.GetOptionsObject(options);
     return impl[GetSlot(this, CALENDAR_ID)].yearMonthFromFields(fields, options, this);
   }
   monthDayFromFields(fields, options = undefined) {
     if (!ES.IsTemporalCalendar(this)) throw new TypeError('invalid receiver');
-    if (ES.Type(fields) !== 'Object') throw new TypeError('invalid fields');
+    if (!ES.IsObject(fields)) throw new TypeError('invalid fields');
     options = ES.GetOptionsObject(options);
     return impl[GetSlot(this, CALENDAR_ID)].monthDayFromFields(fields, options, this);
   }
@@ -94,7 +94,7 @@ export class Calendar implements Temporal.Calendar {
       'nanosecond'
     ]);
     for (const name of fields) {
-      if (ES.Type(name) !== 'String') throw new TypeError('invalid fields');
+      if (typeof name !== 'string') throw new TypeError('invalid fields');
       if (!allowed.has(name)) throw new RangeError(`invalid field name ${name}`);
       allowed.delete(name);
       ArrayPrototypePush.call(fieldsArray, name);
@@ -658,7 +658,7 @@ const nonIsoHelperBase: NonIsoHelperBase = {
     if (day === undefined) throw new RangeError('Missing day');
     if (monthCode !== undefined) {
       if (typeof monthCode !== 'string') {
-        throw new RangeError(`monthCode must be a string, not ${ES.Type(monthCode).toLowerCase()}`);
+        throw new RangeError(`monthCode must be a string, not ${typeof monthCode}`);
       }
       if (!/^M([01]?\d)(L?)$/.test(monthCode)) throw new RangeError(`Invalid monthCode: ${monthCode}`);
     }

--- a/lib/instant.ts
+++ b/lib/instant.ts
@@ -213,7 +213,7 @@ export class Instant implements Temporal.Instant {
   }
   toZonedDateTime(item) {
     if (!ES.IsTemporalInstant(this)) throw new TypeError('invalid receiver');
-    if (ES.Type(item) !== 'Object') {
+    if (!ES.IsObject(item)) {
       throw new TypeError('invalid argument in toZonedDateTime');
     }
     const calendarLike = item.calendar;
@@ -230,7 +230,7 @@ export class Instant implements Temporal.Instant {
   }
   toZonedDateTimeISO(item) {
     if (!ES.IsTemporalInstant(this)) throw new TypeError('invalid receiver');
-    if (ES.Type(item) === 'Object') {
+    if (ES.IsObject(item)) {
       const timeZoneProperty = item.timeZone;
       if (timeZoneProperty !== undefined) {
         item = timeZoneProperty;

--- a/lib/plaindate.ts
+++ b/lib/plaindate.ts
@@ -100,7 +100,7 @@ export class PlainDate implements Temporal.PlainDate {
   }
   with(temporalDateLike, options = undefined) {
     if (!ES.IsTemporalDate(this)) throw new TypeError('invalid receiver');
-    if (ES.Type(temporalDateLike) !== 'Object') {
+    if (!ES.IsObject(temporalDateLike)) {
       throw new TypeError('invalid argument');
     }
     if (HasSlot(temporalDateLike, CALENDAR) || HasSlot(temporalDateLike, TIME_ZONE)) {
@@ -321,7 +321,7 @@ export class PlainDate implements Temporal.PlainDate {
     if (!ES.IsTemporalDate(this)) throw new TypeError('invalid receiver');
 
     let timeZone, temporalTime;
-    if (ES.Type(item) === 'Object') {
+    if (ES.IsObject(item)) {
       const timeZoneLike = item.timeZone;
       if (timeZoneLike === undefined) {
         timeZone = ES.ToTemporalTimeZone(item);

--- a/lib/plaindatetime.ts
+++ b/lib/plaindatetime.ts
@@ -152,7 +152,7 @@ export class PlainDateTime implements Temporal.PlainDateTime {
   }
   with(temporalDateTimeLike, options = undefined) {
     if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
-    if (ES.Type(temporalDateTimeLike) !== 'Object') {
+    if (!ES.IsObject(temporalDateTimeLike)) {
       throw new TypeError('invalid argument');
     }
     if (HasSlot(temporalDateTimeLike, CALENDAR) || HasSlot(temporalDateTimeLike, TIME_ZONE)) {

--- a/lib/plainmonthday.ts
+++ b/lib/plainmonthday.ts
@@ -39,7 +39,7 @@ export class PlainMonthDay implements Temporal.PlainMonthDay {
 
   with(temporalMonthDayLike, options = undefined) {
     if (!ES.IsTemporalMonthDay(this)) throw new TypeError('invalid receiver');
-    if (ES.Type(temporalMonthDayLike) !== 'Object') {
+    if (!ES.IsObject(temporalMonthDayLike)) {
       throw new TypeError('invalid argument');
     }
     if (HasSlot(temporalMonthDayLike, CALENDAR) || HasSlot(temporalMonthDayLike, TIME_ZONE)) {
@@ -94,7 +94,7 @@ export class PlainMonthDay implements Temporal.PlainMonthDay {
   }
   toPlainDate(item) {
     if (!ES.IsTemporalMonthDay(this)) throw new TypeError('invalid receiver');
-    if (ES.Type(item) !== 'Object') throw new TypeError('argument should be an object');
+    if (!ES.IsObject(item)) throw new TypeError('argument should be an object');
     const calendar = GetSlot(this, CALENDAR);
 
     const receiverFieldNames = ES.CalendarFields(calendar, ['day', 'monthCode']);

--- a/lib/plaintime.ts
+++ b/lib/plaintime.ts
@@ -124,7 +124,7 @@ export class PlainTime implements Temporal.PlainTime {
 
   with(temporalTimeLike, options = undefined) {
     if (!ES.IsTemporalTime(this)) throw new TypeError('invalid receiver');
-    if (ES.Type(temporalTimeLike) !== 'Object') {
+    if (!ES.IsObject(temporalTimeLike)) {
       throw new TypeError('invalid argument');
     }
     if (HasSlot(temporalTimeLike, CALENDAR) || HasSlot(temporalTimeLike, TIME_ZONE)) {
@@ -433,7 +433,7 @@ export class PlainTime implements Temporal.PlainTime {
   toZonedDateTime(item) {
     if (!ES.IsTemporalTime(this)) throw new TypeError('invalid receiver');
 
-    if (ES.Type(item) !== 'Object') {
+    if (!ES.IsObject(item)) {
       throw new TypeError('invalid argument');
     }
 

--- a/lib/plainyearmonth.ts
+++ b/lib/plainyearmonth.ts
@@ -67,7 +67,7 @@ export class PlainYearMonth implements Temporal.PlainYearMonth {
   }
   with(temporalYearMonthLike, options = undefined) {
     if (!ES.IsTemporalYearMonth(this)) throw new TypeError('invalid receiver');
-    if (ES.Type(temporalYearMonthLike) !== 'Object') {
+    if (!ES.IsObject(temporalYearMonthLike)) {
       throw new TypeError('invalid argument');
     }
     if (HasSlot(temporalYearMonthLike, CALENDAR) || HasSlot(temporalYearMonthLike, TIME_ZONE)) {
@@ -299,7 +299,7 @@ export class PlainYearMonth implements Temporal.PlainYearMonth {
   }
   toPlainDate(item) {
     if (!ES.IsTemporalYearMonth(this)) throw new TypeError('invalid receiver');
-    if (ES.Type(item) !== 'Object') throw new TypeError('argument should be an object');
+    if (!ES.IsObject(item)) throw new TypeError('argument should be an object');
     const calendar = GetSlot(this, CALENDAR);
 
     const receiverFieldNames = ES.CalendarFields(calendar, ['monthCode', 'year']);

--- a/lib/zoneddatetime.ts
+++ b/lib/zoneddatetime.ts
@@ -171,7 +171,7 @@ export class ZonedDateTime implements Temporal.ZonedDateTime {
   }
   with(temporalZonedDateTimeLike, options = undefined) {
     if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
-    if (ES.Type(temporalZonedDateTimeLike) !== 'Object') {
+    if (!ES.IsObject(temporalZonedDateTimeLike)) {
       throw new TypeError('invalid zoned-date-time-like');
     }
     if (HasSlot(temporalZonedDateTimeLike, CALENDAR) || HasSlot(temporalZonedDateTimeLike, TIME_ZONE)) {


### PR DESCRIPTION
This PR makes minor refactors to runtime type checks to make that validation more TS-friendly:
* Replace use of `ES.Type` for validating `Object` with a new type guard `IsObject` function. The function is overloaded so unknown values are typed as `Record`, while known types like `DurationLike | string` are simply stripped of primitive types while leaving the object types. As a nice side effect, this should reduce bundle size a little bit.
* For the other uses of ES.Type (there were only <5 of them), converts to simple `typeof` checks which provide the same type-narrowing benefit as type guard functions.
* Removes the ES.Type function.
* Adds type annotations to make all IsTemporalXxx into TS type guards.

@ptomato what do you think about whether I should port the ES.Type=>{IsObject, typeof} changes over to proposal-temporal to reduce divergence in the code?