### PR TITLE
Add a warning to the test262 test runner script if the submodule hasn't

### DIFF
--- a/test/test262.sh
+++ b/test/test262.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# Note that this script is only expected to be run via `npm run test262`, not by
+# being manually executed.
 set -e
 
 TESTS=${@:-"**/*.js"}
@@ -10,6 +12,11 @@ else
   threads=$(nproc --ignore 1)
 fi
 if [ $threads -gt 8 ]; then threads=8; fi
+
+if [ ! -d "$(dirname "$0")"/../test262/test/ ]; then
+  echo "Missing Test262 directory. Try initializing the submodule with 'git submodule init && git submodule update'";
+  exit 1;
+fi
 
 cd "$(dirname "$0")"/../test262/test/
 test262-harness \


### PR DESCRIPTION
been initialized.

Fixes #76.