### PR TITLE
Save String constructor in ecmascript.ts at module load time

### DIFF
--- a/lib/ecmascript.ts
+++ b/lib/ecmascript.ts
@@ -9,6 +9,7 @@ const MathTrunc = Math.trunc;
 const NumberIsNaN = Number.isNaN;
 const NumberIsFinite = Number.isFinite;
 const NumberCtor = Number;
+const StringCtor = String;
 const NumberMaxSafeInteger = Number.MAX_SAFE_INTEGER;
 const ObjectCreate = Object.create;
 const ObjectDefineProperty = Object.defineProperty;
@@ -96,7 +97,7 @@ export function ToString(value: unknown): string {
   if (typeof value === 'symbol') {
     throw new TypeError('Cannot convert a Symbol value to a String');
   }
-  return String(value);
+  return StringCtor(value);
 }
 
 export function ToIntegerThrowOnInfinity(value): number {
@@ -188,7 +189,7 @@ function getIntlDateTimeFormatEnUsForTimeZone(timeZoneIdentifier) {
   let instance = IntlDateTimeFormatEnUsCache.get(timeZoneIdentifier);
   if (instance === undefined) {
     instance = new IntlDateTimeFormat('en-us', {
-      timeZone: String(timeZoneIdentifier),
+      timeZone: StringCtor(timeZoneIdentifier),
       hour12: false,
       era: 'short',
       year: 'numeric',
@@ -2225,7 +2226,7 @@ export function TemporalZonedDateTimeToString(
 }
 
 export function ParseOffsetString(string) {
-  const match = OFFSET.exec(String(string));
+  const match = OFFSET.exec(StringCtor(string));
   if (!match) return null;
   const sign = match[1] === '-' || match[1] === '\u2212' ? -1 : +1;
   const hours = +match[2];
@@ -2238,7 +2239,7 @@ export function ParseOffsetString(string) {
 export function GetCanonicalTimeZoneIdentifier(timeZoneIdentifier) {
   const offsetNs = ParseOffsetString(timeZoneIdentifier);
   if (offsetNs !== null) return FormatTimeZoneOffsetString(offsetNs);
-  const formatter = getIntlDateTimeFormatEnUsForTimeZone(String(timeZoneIdentifier));
+  const formatter = getIntlDateTimeFormatEnUsForTimeZone(StringCtor(timeZoneIdentifier));
   return formatter.resolvedOptions().timeZone;
 }
 

--- a/lib/timezone.ts
+++ b/lib/timezone.ts
@@ -139,7 +139,7 @@ export class TimeZone implements Temporal.TimeZone {
   }
   toString() {
     if (!ES.IsTemporalTimeZone(this)) throw new TypeError('invalid receiver');
-    return String(GetSlot(this, TIMEZONE_ID));
+    return ES.ToString(GetSlot(this, TIMEZONE_ID));
   }
   toJSON() {
     return ES.ToString(this);


### PR DESCRIPTION
This PR aligns with the pattern we use for the Number constructor and other ES built-in objects, where the object is saved when the ecmascript.ts module is imported and that saved reference is used in place of `String()` elsewhere.

My only concern with this PR is whether it will impact perf in the case where the literal text `"String"` is special-cased into a fast path by JS engines. I'll check the test runtime before and after this change to see if perf looks like a problem.

UPDATE: I didn't see any huge perf impact.