### PR TITLE
Stop linting the test262 directory.

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -22,6 +22,7 @@ ignorePatterns:
   - node_modules/
   - /dist/
   - /tsc-out/
+  - /test262/
 rules:
   array-element-newline:
     - error


### PR DESCRIPTION
If we have setup the test262 submodule, running linting would "hang"
while it tried to lint all of that too.