### PR TITLE
Fix running tests via VSCode launch script.

### DIFF
--- a/test/test262.sh
+++ b/test/test262.sh
@@ -3,11 +3,17 @@
 # being manually executed.
 set -e
 TESTS_FROM_ENV="$TESTS"
-TESTS="**/*.js"
+TESTS="*/Temporal/**/*.js"
 if [ $# -ne 0 ]; then
-  TESTS="$@";
+  TESTS="*/Temporal/$@";
 elif [ ! -z "$TESTS_FROM_ENV" ]; then
-  TESTS="$TESTS_FROM_ENV";
+  # VSCode launch.json passes the full path to the current file in some cases,
+  # so pass that on.
+  if [[ "$TESTS_FROM_ENV" =~ ^/.* ]]; then
+    TESTS="$TESTS_FROM_ENV";
+  else
+    TESTS="*/Temporal/$TESTS_FROM_ENV";
+  fi
 fi
 
 TIMEOUT=${TIMEOUT:-10000}
@@ -33,5 +39,5 @@ test262-harness \
   --prelude "../../dist/script.js" \
   --timeout "$TIMEOUT" \
   --preprocessor ../../test/preprocessor.test262.cjs \
-  "*/Temporal/$TESTS" \
+  "$TESTS" \
   | ../../test/parseResults.js


### PR DESCRIPTION
The vscode launch.json sets the value for tests to run as the full path (when using the "current file"), and this doesn't work when `*/Temporal/` is prepended to it. Instead, check and see if the pattern begins with `/` and use it as-is if so, otherwise we prepend.

Other ways to run tests should be unaffected, and all have the Temporal prefix automatically attached.