### PR TITLE
Allow string param for `round` and `total`

### DIFF
--- a/lib/duration.ts
+++ b/lib/duration.ts
@@ -292,7 +292,10 @@ export class Duration implements Temporal.Duration {
       microseconds,
       nanoseconds
     );
-    const options = ES.GetOptionsObject(optionsParam);
+    const options =
+      typeof optionsParam === 'string'
+        ? (ES.CreateOnePropObject('smallestUnit', optionsParam) as Exclude<typeof optionsParam, string>)
+        : ES.GetOptionsObject(optionsParam);
     let smallestUnit = ES.ToSmallestTemporalUnit(options, undefined);
     let smallestUnitPresent = true;
     if (!smallestUnit) {
@@ -389,7 +392,10 @@ export class Duration implements Temporal.Duration {
     let nanoseconds = GetSlot(this, NANOSECONDS);
 
     if (optionsParam === undefined) throw new TypeError('options argument is required');
-    const options = ES.GetOptionsObject(optionsParam);
+    const options =
+      typeof optionsParam === 'string'
+        ? (ES.CreateOnePropObject('unit', optionsParam) as Exclude<typeof optionsParam, string>)
+        : ES.GetOptionsObject(optionsParam);
     const unit = ES.ToTemporalDurationTotalUnit(options);
     if (unit === undefined) throw new RangeError('unit option is required');
     const relativeTo = ES.ToRelativeTemporalObject(options);

--- a/lib/ecmascript.ts
+++ b/lib/ecmascript.ts
@@ -837,7 +837,7 @@ export function ToSecondsStringPrecision(options: Temporal.ToStringPrecisionOpti
 }
 
 export function ToLargestTemporalUnit<Allowed extends Temporal.DateTimeUnit, Disallowed extends Temporal.DateTimeUnit>(
-  options: { largestUnit?: Temporal.LargestUnitOption<Allowed> },
+  options: { largestUnit?: Temporal.LargestUnit<Allowed> },
   fallback: Allowed | 'auto',
   disallowedStrings?: ReadonlyArray<Disallowed>
 ): Allowed | 'auto';
@@ -846,7 +846,7 @@ export function ToLargestTemporalUnit<
   Disallowed extends Temporal.DateTimeUnit,
   IfAuto extends Allowed | undefined = Allowed
 >(
-  options: { largestUnit?: Temporal.LargestUnitOption<Allowed> },
+  options: { largestUnit?: Temporal.LargestUnit<Allowed> },
   fallback: Allowed | 'auto',
   disallowedStrings: ReadonlyArray<Disallowed>,
   autoValue?: IfAuto
@@ -856,7 +856,7 @@ export function ToLargestTemporalUnit<
   Disallowed extends Temporal.DateTimeUnit,
   IfAuto extends Allowed | undefined = Allowed
 >(
-  options: { largestUnit?: Temporal.LargestUnitOption<Allowed> },
+  options: { largestUnit?: Temporal.LargestUnit<Allowed> },
   fallback: Allowed | 'auto',
   disallowedStrings: ReadonlyArray<Disallowed> = [],
   autoValue?: IfAuto
@@ -882,7 +882,7 @@ export function ToSmallestTemporalUnit<
   Fallback extends Allowed,
   Disallowed extends Temporal.DateTimeUnit
 >(
-  options: { smallestUnit?: Temporal.SmallestUnitOption<Allowed> },
+  options: { smallestUnit?: Temporal.SmallestUnit<Allowed> },
   fallback: Fallback,
   disallowedStrings: ReadonlyArray<Disallowed> = []
 ): Allowed {
@@ -5063,6 +5063,12 @@ export function GetOptionsObject<T>(options: T) {
   if (options === undefined) return ObjectCreate(null) as T;
   if (IsObject(options) && options !== null) return options;
   throw new TypeError(`Options parameter must be an object, not ${options === null ? 'null' : `${typeof options}`}`);
+}
+
+export function CreateOnePropObject<K extends string, V extends unknown>(propName: K, propValue: V): { [k in K]: V } {
+  const o = ObjectCreate(null);
+  o[propName] = propValue;
+  return o;
 }
 
 function GetOption<P extends string, O extends Partial<Record<P, unknown>>>(

--- a/lib/instant.ts
+++ b/lib/instant.ts
@@ -165,7 +165,10 @@ export class Instant implements Temporal.Instant {
   round(optionsParam: Params['round'][0]): Return['round'] {
     if (!ES.IsTemporalInstant(this)) throw new TypeError('invalid receiver');
     if (optionsParam === undefined) throw new TypeError('options parameter is required');
-    const options = ES.GetOptionsObject(optionsParam);
+    const options =
+      typeof optionsParam === 'string'
+        ? (ES.CreateOnePropObject('smallestUnit', optionsParam) as Exclude<typeof optionsParam, string>)
+        : ES.GetOptionsObject(optionsParam);
     const smallestUnit = ES.ToSmallestTemporalUnit(options, undefined, DISALLOWED_UNITS);
     if (smallestUnit === undefined) throw new RangeError('smallestUnit is required');
     const roundingMode = ES.ToTemporalRoundingMode(options, 'halfExpand');

--- a/lib/plaindatetime.ts
+++ b/lib/plaindatetime.ts
@@ -518,7 +518,10 @@ export class PlainDateTime implements Temporal.PlainDateTime {
   round(optionsParam: Params['round'][0]): Return['round'] {
     if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
     if (optionsParam === undefined) throw new TypeError('options parameter is required');
-    const options = ES.GetOptionsObject(optionsParam);
+    const options =
+      typeof optionsParam === 'string'
+        ? (ES.CreateOnePropObject('smallestUnit', optionsParam) as Exclude<typeof optionsParam, string>)
+        : ES.GetOptionsObject(optionsParam);
     const smallestUnit = ES.ToSmallestTemporalUnit(options, undefined, ['year', 'month', 'week']);
     if (smallestUnit === undefined) throw new RangeError('smallestUnit is required');
     const roundingMode = ES.ToTemporalRoundingMode(options, 'halfExpand');

--- a/lib/plaintime.ts
+++ b/lib/plaintime.ts
@@ -354,7 +354,10 @@ export class PlainTime implements Temporal.PlainTime {
   round(optionsParam: Params['round'][0]): Return['round'] {
     if (!ES.IsTemporalTime(this)) throw new TypeError('invalid receiver');
     if (optionsParam === undefined) throw new TypeError('options parameter is required');
-    const options = ES.GetOptionsObject(optionsParam);
+    const options =
+      typeof optionsParam === 'string'
+        ? (ES.CreateOnePropObject('smallestUnit', optionsParam) as Exclude<typeof optionsParam, string>)
+        : ES.GetOptionsObject(optionsParam);
     const smallestUnit = ES.ToSmallestTemporalUnit(options, undefined, DISALLOWED_UNITS);
     if (smallestUnit === undefined) throw new RangeError('smallestUnit is required');
     const roundingMode = ES.ToTemporalRoundingMode(options, 'halfExpand');

--- a/lib/zoneddatetime.ts
+++ b/lib/zoneddatetime.ts
@@ -586,7 +586,10 @@ export class ZonedDateTime implements Temporal.ZonedDateTime {
   round(optionsParam: Params['round'][0]): Return['round'] {
     if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
     if (optionsParam === undefined) throw new TypeError('options parameter is required');
-    const options = ES.GetOptionsObject(optionsParam);
+    const options =
+      typeof optionsParam === 'string'
+        ? (ES.CreateOnePropObject('smallestUnit', optionsParam) as Exclude<typeof optionsParam, string>)
+        : ES.GetOptionsObject(optionsParam);
     const smallestUnit = ES.ToSmallestTemporalUnit(options, undefined, ['year', 'month', 'week']);
     if (smallestUnit === undefined) throw new RangeError('smallestUnit is required');
     const roundingMode = ES.ToTemporalRoundingMode(options, 'halfExpand');

--- a/test/duration.mjs
+++ b/test/duration.mjs
@@ -965,8 +965,8 @@ describe('Duration', () => {
     const d = new Duration(5, 5, 5, 5, 5, 5, 5, 5, 5, 5);
     const d2 = new Duration(0, 0, 0, 5, 5, 5, 5, 5, 5, 5);
     const relativeTo = Temporal.PlainDateTime.from('2020-01-01T00:00');
-    it('options may only be an object', () => {
-      [null, 1, 'hello', true, Symbol('foo'), 1n].forEach((badOptions) => throws(() => d.round(badOptions), TypeError));
+    it('parameter may only be an object or string', () => {
+      [null, 1, true, Symbol('foo'), 1n].forEach((badOptions) => throws(() => d.round(badOptions), TypeError));
     });
     it('throws without parameter', () => {
       throws(() => d.round(), TypeError);
@@ -977,9 +977,14 @@ describe('Duration', () => {
     it("succeeds with largestUnit: 'auto'", () => {
       equal(`${Duration.from({ hours: 25 }).round({ largestUnit: 'auto' })}`, 'PT25H');
     });
-    it('throws on disallowed or invalid smallestUnit', () => {
+    it('throws on disallowed or invalid smallestUnit (object param)', () => {
       ['era', 'nonsense'].forEach((smallestUnit) => {
         throws(() => d.round({ smallestUnit }), RangeError);
+      });
+    });
+    it('throws on disallowed or invalid smallestUnit (string param)', () => {
+      ['era', 'nonsense'].forEach((smallestUnit) => {
+        throws(() => d.round(smallestUnit), RangeError);
       });
     });
     it('throws if smallestUnit is larger than largestUnit', () => {
@@ -1002,6 +1007,24 @@ describe('Duration', () => {
           throws(() => d.round({ largestUnit, smallestUnit, relativeTo }), RangeError);
         }
       }
+    });
+    it('accepts string parameter as a shortcut for {smallestUnit}', () => {
+      const d = Temporal.Duration.from({
+        days: 1,
+        hours: 2,
+        minutes: 3,
+        seconds: 4,
+        milliseconds: 5,
+        microseconds: 6,
+        nanoseconds: 7
+      });
+      equal(d.round('day').toString(), 'P1D');
+      equal(d.round('hour').toString(), 'P1DT2H');
+      equal(d.round('minute').toString(), 'P1DT2H3M');
+      equal(d.round('second').toString(), 'P1DT2H3M4S');
+      equal(d.round('millisecond').toString(), 'P1DT2H3M4.005S');
+      equal(d.round('microsecond').toString(), 'P1DT2H3M4.005006S');
+      equal(d.round('nanosecond').toString(), 'P1DT2H3M4.005006007S');
     });
     it('assumes a different default for largestUnit if smallestUnit is larger than the default', () => {
       const almostYear = Duration.from({ days: 364 });
@@ -1171,12 +1194,26 @@ describe('Duration', () => {
     });
     it('throws if neither one of largestUnit or smallestUnit is given', () => {
       const hoursOnly = new Duration(0, 0, 0, 0, 1);
-      [{}, () => {}, { roundingMode: 'ceil' }].forEach((options) => {
-        throws(() => d.round(options), RangeError);
-        throws(() => hoursOnly.round(options), RangeError);
+      [{}, () => {}, { roundingMode: 'ceil' }].forEach((roundTo) => {
+        throws(() => d.round(roundTo), RangeError);
+        throws(() => hoursOnly.round(roundTo), RangeError);
       });
     });
-    it('relativeTo is not required for rounding non-calendar units in durations without calendar units', () => {
+    it('relativeTo not required to round non-calendar units in durations w/o calendar units (string param)', () => {
+      equal(`${d2.round('days')}`, 'P5D');
+      equal(`${d2.round('hours')}`, 'P5DT5H');
+      equal(`${d2.round('minutes')}`, 'P5DT5H5M');
+      equal(`${d2.round('seconds')}`, 'P5DT5H5M5S');
+      equal(`${d2.round('milliseconds')}`, 'P5DT5H5M5.005S');
+      equal(`${d2.round('microseconds')}`, 'P5DT5H5M5.005005S');
+      equal(`${d2.round('nanoseconds')}`, 'P5DT5H5M5.005005005S');
+    });
+    it('relativeTo is required to round calendar units even in durations w/o calendar units (string param)', () => {
+      throws(() => d2.round('years'), RangeError);
+      throws(() => d2.round('months'), RangeError);
+      throws(() => d2.round('weeks'), RangeError);
+    });
+    it('relativeTo not required to round non-calendar units in durations w/o calendar units (object param)', () => {
       equal(`${d2.round({ smallestUnit: 'days' })}`, 'P5D');
       equal(`${d2.round({ smallestUnit: 'hours' })}`, 'P5DT5H');
       equal(`${d2.round({ smallestUnit: 'minutes' })}`, 'P5DT5H5M');
@@ -1185,7 +1222,7 @@ describe('Duration', () => {
       equal(`${d2.round({ smallestUnit: 'microseconds' })}`, 'P5DT5H5M5.005005S');
       equal(`${d2.round({ smallestUnit: 'nanoseconds' })}`, 'P5DT5H5M5.005005005S');
     });
-    it('relativeTo is required for rounding calendar units even in durations without calendar units', () => {
+    it('relativeTo is required to round calendar units even in durations w/o calendar units (object param)', () => {
       throws(() => d2.round({ smallestUnit: 'years' }), RangeError);
       throws(() => d2.round({ smallestUnit: 'months' }), RangeError);
       throws(() => d2.round({ smallestUnit: 'weeks' }), RangeError);
@@ -1378,16 +1415,16 @@ describe('Duration', () => {
     ['minutes', 'seconds'].forEach((smallestUnit) => {
       it(`valid ${smallestUnit} increments divide into 60`, () => {
         [1, 2, 3, 4, 5, 6, 10, 12, 15, 20, 30].forEach((roundingIncrement) => {
-          const options = { smallestUnit, roundingIncrement, relativeTo };
-          assert(d.round(options) instanceof Temporal.Duration);
+          const roundTo = { smallestUnit, roundingIncrement, relativeTo };
+          assert(d.round(roundTo) instanceof Temporal.Duration);
         });
       });
     });
     ['milliseconds', 'microseconds', 'nanoseconds'].forEach((smallestUnit) => {
       it(`valid ${smallestUnit} increments divide into 1000`, () => {
         [1, 2, 4, 5, 8, 10, 20, 25, 40, 50, 100, 125, 200, 250, 500].forEach((roundingIncrement) => {
-          const options = { smallestUnit, roundingIncrement, relativeTo };
-          assert(d.round(options) instanceof Temporal.Duration);
+          const roundTo = { smallestUnit, roundingIncrement, relativeTo };
+          assert(d.round(roundTo) instanceof Temporal.Duration);
         });
       });
     });
@@ -1468,12 +1505,26 @@ describe('Duration', () => {
     const d = new Duration(5, 5, 5, 5, 5, 5, 5, 5, 5, 5);
     const d2 = new Duration(0, 0, 0, 5, 5, 5, 5, 5, 5, 5);
     const relativeTo = Temporal.PlainDateTime.from('2020-01-01T00:00');
-    it('options may only be an object', () => {
-      [null, 1, 'hello', true, Symbol('foo'), 1n].forEach((badOptions) => throws(() => d.total(badOptions), TypeError));
+    it('parameter may only be an object or string', () => {
+      [null, 1, true, Symbol('foo'), 1n].forEach((badOptions) => throws(() => d.total(badOptions), TypeError));
     });
-    it('throws on disallowed or invalid smallestUnit', () => {
+    it('accepts string parameter as shortcut for {unit}', () => {
+      equal(d2.total({ unit: 'days' }).toString(), d2.total('days').toString());
+      equal(d2.total({ unit: 'hours' }).toString(), d2.total('hours').toString());
+      equal(d2.total({ unit: 'minutes' }).toString(), d2.total('minutes').toString());
+      equal(d2.total({ unit: 'seconds' }).toString(), d2.total('seconds').toString());
+      equal(d2.total({ unit: 'milliseconds' }).toString(), d2.total('milliseconds').toString());
+      equal(d2.total({ unit: 'microseconds' }).toString(), d2.total('microseconds').toString());
+      equal(d2.total({ unit: 'nanoseconds' }).toString(), d2.total('nanoseconds').toString());
+    });
+    it('throws on disallowed or invalid unit (object param)', () => {
       ['era', 'nonsense'].forEach((unit) => {
         throws(() => d.total({ unit }), RangeError);
+      });
+    });
+    it('throws on disallowed or invalid unit (string param)', () => {
+      ['era', 'nonsense'].forEach((unit) => {
+        throws(() => d.total(unit), RangeError);
       });
     });
     it('does not lose precision for seconds and smaller units', () => {
@@ -1533,14 +1584,19 @@ describe('Duration', () => {
       equal(oneMonth.total({ unit: 'months', relativeTo: { year: 2020, month: 1, day: 1, months: 2 } }), 1);
     });
     it('throws RangeError if unit property is missing', () => {
-      [{}, () => {}, { roundingMode: 'ceil' }].forEach((options) => throws(() => d.total(options), RangeError));
+      [{}, () => {}, { roundingMode: 'ceil' }].forEach((roundTo) => throws(() => d.total(roundTo), RangeError));
     });
-    it('relativeTo is required for rounding calendar units even in durations without calendar units', () => {
+    it('relativeTo required to round calendar units even in durations w/o calendar units (object param)', () => {
       throws(() => d2.total({ unit: 'years' }), RangeError);
       throws(() => d2.total({ unit: 'months' }), RangeError);
       throws(() => d2.total({ unit: 'weeks' }), RangeError);
     });
-    it('relativeTo is required for rounding durations with calendar units', () => {
+    it('relativeTo required to round calendar units even in durations w/o calendar units (string param)', () => {
+      throws(() => d2.total('years'), RangeError);
+      throws(() => d2.total('months'), RangeError);
+      throws(() => d2.total('weeks'), RangeError);
+    });
+    it('relativeTo is required to round durations with calendar units (object param)', () => {
       throws(() => d.total({ unit: 'years' }), RangeError);
       throws(() => d.total({ unit: 'months' }), RangeError);
       throws(() => d.total({ unit: 'weeks' }), RangeError);
@@ -1551,6 +1607,18 @@ describe('Duration', () => {
       throws(() => d.total({ unit: 'milliseconds' }), RangeError);
       throws(() => d.total({ unit: 'microseconds' }), RangeError);
       throws(() => d.total({ unit: 'nanoseconds' }), RangeError);
+    });
+    it('relativeTo is required to round durations with calendar units (string param)', () => {
+      throws(() => d.total('years'), RangeError);
+      throws(() => d.total('months'), RangeError);
+      throws(() => d.total('weeks'), RangeError);
+      throws(() => d.total('days'), RangeError);
+      throws(() => d.total('hours'), RangeError);
+      throws(() => d.total('minutes'), RangeError);
+      throws(() => d.total('seconds'), RangeError);
+      throws(() => d.total('milliseconds'), RangeError);
+      throws(() => d.total('microseconds'), RangeError);
+      throws(() => d.total('nanoseconds'), RangeError);
     });
     const d2Nanoseconds =
       d2.days * 24 * 3.6e12 +

--- a/test/expected-failures.txt
+++ b/test/expected-failures.txt
@@ -1,0 +1,3 @@
+# Blocked on https://github.com/tc39/test262/pull/3304
+built-ins/Temporal/Instant/prototype/round/options-wrong-type.js
+built-ins/Temporal/Duration/prototype/total/options-wrong-type.js

--- a/test/instant.mjs
+++ b/test/instant.mjs
@@ -1220,10 +1220,17 @@ describe('Instant', () => {
       throws(() => inst.round({}), RangeError);
       throws(() => inst.round({ roundingIncrement: 1, roundingMode: 'ceil' }), RangeError);
     });
-    it('throws on disallowed or invalid smallestUnit', () => {
+    it('throws on disallowed or invalid smallestUnit (object param)', () => {
       ['era', 'year', 'month', 'week', 'day', 'years', 'months', 'weeks', 'days', 'nonsense'].forEach(
         (smallestUnit) => {
           throws(() => inst.round({ smallestUnit }), RangeError);
+        }
+      );
+    });
+    it('throws on disallowed or invalid smallestUnit (string param)', () => {
+      ['era', 'year', 'month', 'week', 'day', 'years', 'months', 'weeks', 'days', 'nonsense'].forEach(
+        (smallestUnit) => {
+          throws(() => inst.round(smallestUnit), RangeError);
         }
       );
     });
@@ -1319,12 +1326,14 @@ describe('Instant', () => {
       throws(() => inst.round({ smallestUnit: 'nanosecond', roundingIncrement: 29 }), RangeError);
     });
     it('accepts plural units', () => {
-      assert(inst.round({ smallestUnit: 'hours' }).equals(inst.round({ smallestUnit: 'hour' })));
-      assert(inst.round({ smallestUnit: 'minutes' }).equals(inst.round({ smallestUnit: 'minute' })));
-      assert(inst.round({ smallestUnit: 'seconds' }).equals(inst.round({ smallestUnit: 'second' })));
-      assert(inst.round({ smallestUnit: 'milliseconds' }).equals(inst.round({ smallestUnit: 'millisecond' })));
-      assert(inst.round({ smallestUnit: 'microseconds' }).equals(inst.round({ smallestUnit: 'microsecond' })));
-      assert(inst.round({ smallestUnit: 'nanoseconds' }).equals(inst.round({ smallestUnit: 'nanosecond' })));
+      ['hour', 'minute', 'second', 'millisecond', 'microsecond', 'nanosecond'].forEach((smallestUnit) => {
+        assert(inst.round({ smallestUnit }).equals(inst.round({ smallestUnit: `${smallestUnit}s` })));
+      });
+    });
+    it('accepts string parameter as shortcut for {smallestUnit}', () => {
+      ['hour', 'minute', 'second', 'millisecond', 'microsecond', 'nanosecond'].forEach((smallestUnit) => {
+        assert(inst.round(smallestUnit).equals(inst.round({ smallestUnit })));
+      });
     });
   });
   describe('Min/max range', () => {

--- a/test/plaindatetime.mjs
+++ b/test/plaindatetime.mjs
@@ -1205,9 +1205,14 @@ describe('DateTime', () => {
       throws(() => dt.round({}), RangeError);
       throws(() => dt.round({ roundingIncrement: 1, roundingMode: 'ceil' }), RangeError);
     });
-    it('throws on disallowed or invalid smallestUnit', () => {
+    it('throws on disallowed or invalid smallestUnit (object param)', () => {
       ['era', 'year', 'month', 'week', 'years', 'months', 'weeks', 'nonsense'].forEach((smallestUnit) => {
         throws(() => dt.round({ smallestUnit }), RangeError);
+      });
+    });
+    it('throws on disallowed or invalid smallestUnit (string param)', () => {
+      ['era', 'year', 'month', 'week', 'years', 'months', 'weeks', 'nonsense'].forEach((smallestUnit) => {
+        throws(() => dt.round(smallestUnit), RangeError);
       });
     });
     it('throws on invalid roundingMode', () => {
@@ -1329,13 +1334,14 @@ describe('DateTime', () => {
       });
     });
     it('accepts plural units', () => {
-      assert(dt.round({ smallestUnit: 'days' }).equals(dt.round({ smallestUnit: 'day' })));
-      assert(dt.round({ smallestUnit: 'hours' }).equals(dt.round({ smallestUnit: 'hour' })));
-      assert(dt.round({ smallestUnit: 'minutes' }).equals(dt.round({ smallestUnit: 'minute' })));
-      assert(dt.round({ smallestUnit: 'seconds' }).equals(dt.round({ smallestUnit: 'second' })));
-      assert(dt.round({ smallestUnit: 'milliseconds' }).equals(dt.round({ smallestUnit: 'millisecond' })));
-      assert(dt.round({ smallestUnit: 'microseconds' }).equals(dt.round({ smallestUnit: 'microsecond' })));
-      assert(dt.round({ smallestUnit: 'nanoseconds' }).equals(dt.round({ smallestUnit: 'nanosecond' })));
+      ['day', 'hour', 'minute', 'second', 'millisecond', 'microsecond', 'nanosecond'].forEach((smallestUnit) => {
+        assert(dt.round({ smallestUnit }).equals(dt.round({ smallestUnit: `${smallestUnit}s` })));
+      });
+    });
+    it('accepts string parameter as shortcut for {smallestUnit}', () => {
+      ['day', 'hour', 'minute', 'second', 'millisecond', 'microsecond', 'nanosecond'].forEach((smallestUnit) => {
+        assert(dt.round(smallestUnit).equals(dt.round({ smallestUnit })));
+      });
     });
   });
   describe('DateTime.from() works', () => {

--- a/test/plaintime.mjs
+++ b/test/plaintime.mjs
@@ -812,10 +812,17 @@ describe('Time', () => {
       throws(() => time.round({}), RangeError);
       throws(() => time.round({ roundingIncrement: 1, roundingMode: 'ceil' }), RangeError);
     });
-    it('throws on disallowed or invalid smallestUnit', () => {
+    it('throws on disallowed or invalid smallestUnit (object param)', () => {
       ['era', 'year', 'month', 'week', 'day', 'years', 'months', 'weeks', 'days', 'nonsense'].forEach(
         (smallestUnit) => {
           throws(() => time.round({ smallestUnit }), RangeError);
+        }
+      );
+    });
+    it('throws on disallowed or invalid smallestUnit (string param)', () => {
+      ['era', 'year', 'month', 'week', 'day', 'years', 'months', 'weeks', 'days', 'nonsense'].forEach(
+        (smallestUnit) => {
+          throws(() => time.round(smallestUnit), RangeError);
         }
       );
     });
@@ -925,12 +932,14 @@ describe('Time', () => {
       });
     });
     it('accepts plural units', () => {
-      assert(time.round({ smallestUnit: 'hours' }).equals(time.round({ smallestUnit: 'hour' })));
-      assert(time.round({ smallestUnit: 'minutes' }).equals(time.round({ smallestUnit: 'minute' })));
-      assert(time.round({ smallestUnit: 'seconds' }).equals(time.round({ smallestUnit: 'second' })));
-      assert(time.round({ smallestUnit: 'milliseconds' }).equals(time.round({ smallestUnit: 'millisecond' })));
-      assert(time.round({ smallestUnit: 'microseconds' }).equals(time.round({ smallestUnit: 'microsecond' })));
-      assert(time.round({ smallestUnit: 'nanoseconds' }).equals(time.round({ smallestUnit: 'nanosecond' })));
+      ['hour', 'minute', 'second', 'millisecond', 'microsecond', 'nanosecond'].forEach((smallestUnit) => {
+        assert(time.round({ smallestUnit }).equals(time.round({ smallestUnit: `${smallestUnit}s` })));
+      });
+    });
+    it('accepts string parameter as shortcut for {smallestUnit}', () => {
+      ['hour', 'minute', 'second', 'millisecond', 'microsecond', 'nanosecond'].forEach((smallestUnit) => {
+        assert(time.round(smallestUnit).equals(time.round({ smallestUnit })));
+      });
     });
   });
   describe('Time.compare() works', () => {

--- a/test/zoneddatetime.mjs
+++ b/test/zoneddatetime.mjs
@@ -1959,9 +1959,14 @@ describe('ZonedDateTime', () => {
       throws(() => zdt.round({}), RangeError);
       throws(() => zdt.round({ roundingIncrement: 1, roundingMode: 'ceil' }), RangeError);
     });
-    it('throws on disallowed or invalid smallestUnit', () => {
+    it('throws on disallowed or invalid smallestUnit (object param)', () => {
       ['era', 'year', 'month', 'week', 'years', 'months', 'weeks', 'nonsense'].forEach((smallestUnit) => {
         throws(() => zdt.round({ smallestUnit }), RangeError);
+      });
+    });
+    it('throws on disallowed or invalid smallestUnit (string param)', () => {
+      ['era', 'year', 'month', 'week', 'years', 'months', 'weeks', 'nonsense'].forEach((smallestUnit) => {
+        throws(() => zdt.round(smallestUnit), RangeError);
       });
     });
     it('throws on invalid roundingMode', () => {
@@ -2107,26 +2112,28 @@ describe('ZonedDateTime', () => {
       });
     });
     it('accepts plural units', () => {
-      assert(zdt.round({ smallestUnit: 'hours' }).equals(zdt.round({ smallestUnit: 'hour' })));
-      assert(zdt.round({ smallestUnit: 'minutes' }).equals(zdt.round({ smallestUnit: 'minute' })));
-      assert(zdt.round({ smallestUnit: 'seconds' }).equals(zdt.round({ smallestUnit: 'second' })));
-      assert(zdt.round({ smallestUnit: 'milliseconds' }).equals(zdt.round({ smallestUnit: 'millisecond' })));
-      assert(zdt.round({ smallestUnit: 'microseconds' }).equals(zdt.round({ smallestUnit: 'microsecond' })));
-      assert(zdt.round({ smallestUnit: 'nanoseconds' }).equals(zdt.round({ smallestUnit: 'nanosecond' })));
+      ['day', 'hour', 'minute', 'second', 'millisecond', 'microsecond', 'nanosecond'].forEach((smallestUnit) => {
+        assert(zdt.round({ smallestUnit }).equals(zdt.round({ smallestUnit: `${smallestUnit}s` })));
+      });
+    });
+    it('accepts string parameter as shortcut for {smallestUnit}', () => {
+      ['day', 'hour', 'minute', 'second', 'millisecond', 'microsecond', 'nanosecond'].forEach((smallestUnit) => {
+        assert(zdt.round(smallestUnit).equals(zdt.round({ smallestUnit })));
+      });
     });
     it('rounds correctly to a 25-hour day', () => {
-      const options = { smallestUnit: 'day' };
+      const roundTo = { smallestUnit: 'day' };
       const roundMeDown = ZonedDateTime.from('2020-11-01T12:29:59-08:00[America/Vancouver]');
-      equal(`${roundMeDown.round(options)}`, '2020-11-01T00:00:00-07:00[America/Vancouver]');
+      equal(`${roundMeDown.round(roundTo)}`, '2020-11-01T00:00:00-07:00[America/Vancouver]');
       const roundMeUp = ZonedDateTime.from('2020-11-01T12:30:01-08:00[America/Vancouver]');
-      equal(`${roundMeUp.round(options)}`, '2020-11-02T00:00:00-08:00[America/Vancouver]');
+      equal(`${roundMeUp.round(roundTo)}`, '2020-11-02T00:00:00-08:00[America/Vancouver]');
     });
     it('rounds correctly to a 23-hour day', () => {
-      const options = { smallestUnit: 'day' };
+      const roundTo = { smallestUnit: 'day' };
       const roundMeDown = ZonedDateTime.from('2020-03-08T11:29:59-07:00[America/Vancouver]');
-      equal(`${roundMeDown.round(options)}`, '2020-03-08T00:00:00-08:00[America/Vancouver]');
+      equal(`${roundMeDown.round(roundTo)}`, '2020-03-08T00:00:00-08:00[America/Vancouver]');
       const roundMeUp = ZonedDateTime.from('2020-03-08T11:30:01-07:00[America/Vancouver]');
-      equal(`${roundMeUp.round(options)}`, '2020-03-09T00:00:00-07:00[America/Vancouver]');
+      equal(`${roundMeUp.round(roundTo)}`, '2020-03-09T00:00:00-07:00[America/Vancouver]');
     });
     it('rounding up to a nonexistent wall-clock time', () => {
       const almostSkipped = ZonedDateTime.from('2018-11-03T23:59:59.999999999-03:00[America/Sao_Paulo]');


### PR DESCRIPTION
Enable strings to be used as the param of `round` and `total` methods. Port of https://github.com/tc39/proposal-temporal/pull/1875.

Note that this will fail two Test262 tests because passing invalid strings to this method used to throw a TypeError but now will throw a RangeError. 

After #1875 is merged, those tests should start passing. For that reason, we should probably wait to merge this PR until #1875 has landed over in proposal-temporal.