### PR TITLE
Fix GetFormatterParts for Firefox Nightly

### DIFF
--- a/lib/ecmascript.ts
+++ b/lib/ecmascript.ts
@@ -2845,7 +2845,7 @@ export function GetIANATimeZonePreviousTransition(epochNanoseconds: bigInt.BigIn
 // ts-prune-ignore-next TODO: remove this after tests are converted to TS
 export function GetFormatterParts(timeZone: string, epochMilliseconds: number) {
   const formatter = getIntlDateTimeFormatEnUsForTimeZone(timeZone);
-  // FIXME: can this use formatToParts instead?
+  // Using `format` instead of `formatToParts` for compatibility with older clients
   const datetime = formatter.format(new Date(epochMilliseconds));
   const [month, day, year, era, hour, minute, second] = datetime.split(/[^\w]+/);
   return {

--- a/lib/ecmascript.ts
+++ b/lib/ecmascript.ts
@@ -2847,10 +2847,7 @@ export function GetFormatterParts(timeZone: string, epochMilliseconds: number) {
   const formatter = getIntlDateTimeFormatEnUsForTimeZone(timeZone);
   // FIXME: can this use formatToParts instead?
   const datetime = formatter.format(new Date(epochMilliseconds));
-  const [date, fullYear, time] = datetime.split(/,\s+/);
-  const [month, day] = date.split(' ');
-  const [year, era] = fullYear.split(' ');
-  const [hour, minute, second] = time.split(':');
+  const [month, day, year, era, hour, minute, second] = datetime.split(/[^\w]+/);
   return {
     year: era === 'BC' ? -year + 1 : +year,
     month: +month,

--- a/lib/ecmascript.ts
+++ b/lib/ecmascript.ts
@@ -2849,7 +2849,7 @@ export function GetFormatterParts(timeZone: string, epochMilliseconds: number) {
   const datetime = formatter.format(new Date(epochMilliseconds));
   const [month, day, year, era, hour, minute, second] = datetime.split(/[^\w]+/);
   return {
-    year: era === 'BC' ? -year + 1 : +year,
+    year: era.toUpperCase().startsWith('B') ? -year + 1 : +year,
     month: +month,
     day: +day,
     hour: hour === '24' ? 0 : +hour, // bugs.chromium.org/p/chromium/issues/detail?id=1045791


### PR DESCRIPTION
This fixes #92 with the suggestions by @justingrant 

-   Accept 1+ non-alphanumeric characters as separators. No need to restrict to spaces.
-   Only look at the first character of the era, to match both "B" and "BC". Might as well make the comparison case-insensitive while we're at it.

Tested on Firefox Nightly 96.0a1, Firefox Developer 95.0b12 (with the previous behavior) and Chrome 96.0.4664.45