### PR TITLE
Remove getOffsetNanosecondsFor fallback from polyfill

### DIFF
--- a/lib/ecmascript.ts
+++ b/lib/ecmascript.ts
@@ -2179,8 +2179,8 @@ export function GetOffsetNanosecondsFor(
   instant: TimeZoneProtocolParams['getOffsetNanosecondsFor'][0]
 ) {
   let getOffsetNanosecondsFor = timeZone.getOffsetNanosecondsFor;
-  if (getOffsetNanosecondsFor === undefined) {
-    getOffsetNanosecondsFor = GetIntrinsic('%Temporal.TimeZone.prototype.getOffsetNanosecondsFor%');
+  if (typeof getOffsetNanosecondsFor !== 'function') {
+    throw new TypeError('getOffsetNanosecondsFor not callable');
   }
   const offsetNs = Reflect.apply(getOffsetNanosecondsFor, timeZone, [instant]);
   if (typeof offsetNs !== 'number') {

--- a/lib/intrinsicclass.ts
+++ b/lib/intrinsicclass.ts
@@ -34,7 +34,6 @@ type TemporalIntrinsicPrototypeRegisteredKeys = {
 
 interface StandaloneIntrinsics {
   'Temporal.Calendar.from': typeof Temporal.Calendar.from;
-  'Temporal.TimeZone.prototype.getOffsetNanosecondsFor': typeof Temporal.TimeZone.prototype.getOffsetNanosecondsFor;
 }
 type RegisteredStandaloneIntrinsics = { [key in keyof StandaloneIntrinsics as `%${key}%`]: StandaloneIntrinsics[key] };
 const INTRINSICS: Partial<TemporalIntrinsicRegisteredKeys> &

--- a/lib/timezone.ts
+++ b/lib/timezone.ts
@@ -1,6 +1,6 @@
 import { DEBUG } from './debug';
 import * as ES from './ecmascript';
-import { GetIntrinsic, MakeIntrinsicClass, DefineIntrinsic } from './intrinsicclass';
+import { GetIntrinsic, MakeIntrinsicClass } from './intrinsicclass';
 import {
   TIMEZONE_ID,
   EPOCHNANOSECONDS,
@@ -158,4 +158,3 @@ export class TimeZone implements Temporal.TimeZone {
 }
 
 MakeIntrinsicClass(TimeZone, 'Temporal.TimeZone');
-DefineIntrinsic('Temporal.TimeZone.prototype.getOffsetNanosecondsFor', TimeZone.prototype.getOffsetNanosecondsFor);

--- a/test/expected-failures.txt
+++ b/test/expected-failures.txt
@@ -3,10 +3,6 @@
 # polyfill, see expected-failures-transpiled.txt and
 # expected-failures-optimized.txt respectively.
 
-# Blocked on https://github.com/tc39/test262/pull/3304
-built-ins/Temporal/Instant/prototype/round/options-wrong-type.js
-built-ins/Temporal/Duration/prototype/total/options-wrong-type.js
-
 # https://github.com/tc39/test262/pull/3316
 intl402/Temporal/TimeZone/from/argument-invalid.js
 


### PR DESCRIPTION
When porting over [063dd4d7a33cef728db6744d68cb4a21a720290b](https://github.com/tc39/proposal-temporal/commit/063dd4d7a33cef728db6744d68cb4a21a720290b) I found when retrieving the `getOffsetNanosecondsFor` method we don't actually check the type is callable. Fixing this then lead me to remove the registration of the intrinsic, as it's now unused (`undefined` is not callable, and will throw a TypeError). The [corresponding function](https://github.com/tc39/proposal-temporal/blob/f2405e18f5f9fdf2d80250b1075f16f40547c911/polyfill/lib/ecmascript.mjs#L1759-L1769) in the proposal repo doesn't have this fallback either.