### PR TITLE
RFC: Fix null-check stuff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ tsc-out/
 .vscode/*
 !.vscode/launch.json
 *.tgz
+.DS_STORE

--- a/lib/calendar.ts
+++ b/lib/calendar.ts
@@ -117,7 +117,7 @@ export class Calendar implements Temporal.Calendar {
     return ES.ToString(this);
   }
   dateFromFields(
-    fields: Params['dateFromFields'][0],
+    fields?: Params['dateFromFields'][0],
     optionsParam: Params['dateFromFields'][1] = undefined
   ): Return['dateFromFields'] {
     if (!ES.IsTemporalCalendar(this)) throw new TypeError('invalid receiver');
@@ -178,7 +178,7 @@ export class Calendar implements Temporal.Calendar {
     if (!ES.IsTemporalCalendar(this)) throw new TypeError('invalid receiver');
     const date = ES.ToTemporalDate(dateParam);
     const duration = ES.ToTemporalDuration(durationParam);
-    const options = ES.GetOptionsObject(optionsParam);
+    const options = ES.GetOptionsObject<Temporal.ArithmeticOptions>(optionsParam);
     const overflow = ES.ToTemporalOverflow(options);
     const { days } = ES.BalanceDuration(
       GetSlot(duration, DAYS),

--- a/lib/calendar.ts
+++ b/lib/calendar.ts
@@ -1,6 +1,6 @@
 import { DEBUG } from './debug';
 import * as ES from './ecmascript';
-import { GetIntrinsic, MakeIntrinsicClass, DefineIntrinsic } from './intrinsicclass';
+import { MakeIntrinsicClass, DefineIntrinsic } from './intrinsicclass';
 import {
   CALENDAR_ID,
   ISO_YEAR,
@@ -28,6 +28,7 @@ import type {
   CalendarReturn as Return,
   FieldRecord
 } from './internaltypes';
+import { Duration } from './duration';
 
 const ArrayIncludes = Array.prototype.includes;
 const ArrayPrototypePush = Array.prototype.push;
@@ -216,7 +217,6 @@ export class Calendar implements Temporal.Calendar {
       'day'
     );
     const { years, months, weeks, days } = impl[GetSlot(this, CALENDAR_ID)].dateUntil(one, two, largestUnit);
-    const Duration = GetIntrinsic('%Temporal.Duration%');
     return new Duration(years, months, weeks, days, 0, 0, 0, 0, 0, 0);
   }
   year(dateParam: Params['year'][0]): Return['year'] {

--- a/lib/ecmascript.ts
+++ b/lib/ecmascript.ts
@@ -1069,8 +1069,8 @@ export function ToPartialRecord<B extends AnyTemporalLikeType>(
 }
 
 export function PrepareTemporalFields<B extends AnyTemporalLikeType>(
-  bag: B,
-  fields: ReadonlyArray<FieldRecord<B>>
+  bag?: B,
+  fields: ReadonlyArray<FieldRecord<B>> = []
 ): Required<B> | undefined {
   if (!IsObject(bag)) return undefined;
   const result = {} as B;
@@ -1109,8 +1109,8 @@ export function PrepareTemporalFields<B extends AnyTemporalLikeType>(
 
 // field access in the following operations is intentionally alphabetical
 export function ToTemporalDateFields(
-  bag: Temporal.PlainDateLike,
-  fieldNames: readonly (keyof Temporal.PlainDateLike)[]
+  bag?: Temporal.PlainDateLike,
+  fieldNames: readonly (keyof Temporal.PlainDateLike)[] = []
 ) {
   const entries: [keyof Temporal.PlainDateLike, 0 | undefined][] = [
     ['day', undefined],
@@ -1899,8 +1899,8 @@ export function CalendarFields<F extends Iterable<string>>(calendar: Temporal.Ca
 
 export function CalendarMergeFields(
   calendar: Temporal.CalendarProtocol,
-  fields: Record<string, unknown>,
-  additionalFields: Record<string, unknown>
+  fields?: Record<string, unknown>,
+  additionalFields?: Record<string, unknown>
 ) {
   const calMergeFields = calendar.mergeFields;
   if (!calMergeFields) {
@@ -2102,7 +2102,7 @@ export function ConsolidateCalendars(one: Temporal.CalendarProtocol, two: Tempor
 
 export function DateFromFields(
   calendar: Temporal.CalendarProtocol,
-  fields: CalendarProtocolParams['dateFromFields'][0],
+  fields?: CalendarProtocolParams['dateFromFields'][0],
   options?: Partial<CalendarProtocolParams['dateFromFields'][1]>
 ) {
   const result = calendar.dateFromFields(fields, options);
@@ -2112,7 +2112,7 @@ export function DateFromFields(
 
 export function YearMonthFromFields(
   calendar: Temporal.CalendarProtocol,
-  fields: CalendarProtocolParams['yearMonthFromFields'][0],
+  fields?: CalendarProtocolParams['yearMonthFromFields'][0],
   options?: CalendarProtocolParams['yearMonthFromFields'][1]
 ) {
   const result = calendar.yearMonthFromFields(fields, options);
@@ -2122,7 +2122,7 @@ export function YearMonthFromFields(
 
 export function MonthDayFromFields(
   calendar: Temporal.CalendarProtocol,
-  fields: CalendarProtocolParams['monthDayFromFields'][0],
+  fields?: CalendarProtocolParams['monthDayFromFields'][0],
   options?: CalendarProtocolParams['monthDayFromFields'][1]
 ) {
   const result = calendar.monthDayFromFields(fields, options);
@@ -4666,7 +4666,7 @@ export function RoundDuration(
   nanosecondsParam: number,
   increment: number,
   unit: Temporal.DateTimeUnit,
-  roundingMode: Temporal.RoundingMode,
+  roundingMode: Temporal.RoundingMode = 'trunc',
   relativeToParam: ReturnType<typeof ToRelativeTemporalObject> = undefined
 ) {
   let years = yearsParam;
@@ -4996,7 +4996,7 @@ export function ComparisonResult(value: number) {
   return value < 0 ? -1 : value > 0 ? 1 : (value as 0);
 }
 
-export function GetOptionsObject<T>(options: T) {
+export function GetOptionsObject<T>(options: T | undefined) {
   if (options === undefined) return ObjectCreate(null) as T;
   if (IsObject(options) && options !== null) return options;
   throw new TypeError(`Options parameter must be an object, not ${options === null ? 'null' : `${typeof options}`}`);

--- a/lib/instant.ts
+++ b/lib/instant.ts
@@ -1,12 +1,13 @@
 import { DEBUG } from './debug';
 import * as ES from './ecmascript';
-import { GetIntrinsic, MakeIntrinsicClass } from './intrinsicclass';
+import { MakeIntrinsicClass } from './intrinsicclass';
 import { EPOCHNANOSECONDS, CreateSlots, GetSlot, SetSlot } from './slots';
 import { Temporal } from '..';
 import { DateTimeFormat } from './intl';
 import type { InstantParams as Params, InstantReturn as Return } from './internaltypes';
 
 import bigInt from 'big-integer';
+import { Duration } from './duration';
 
 const DISALLOWED_UNITS = ['year', 'month', 'week', 'day'] as const;
 const MAX_DIFFERENCE_INCREMENTS = {
@@ -126,7 +127,6 @@ export class Instant implements Temporal.Instant {
       nanoseconds,
       largestUnit
     ));
-    const Duration = GetIntrinsic('%Temporal.Duration%');
     return new Duration(0, 0, 0, 0, hours, minutes, seconds, milliseconds, microseconds, nanoseconds);
   }
   since(otherParam: Params['since'][0], optionsParam: Params['since'][1] = undefined) {
@@ -159,7 +159,6 @@ export class Instant implements Temporal.Instant {
       nanoseconds,
       largestUnit
     ));
-    const Duration = GetIntrinsic('%Temporal.Duration%');
     return new Duration(0, 0, 0, 0, hours, minutes, seconds, milliseconds, microseconds, nanoseconds);
   }
   round(optionsParam: Params['round'][0]): Return['round'] {

--- a/lib/intl.ts
+++ b/lib/intl.ts
@@ -1,5 +1,4 @@
 import * as ES from './ecmascript';
-import { GetIntrinsic } from './intrinsicclass';
 import {
   GetSlot,
   INSTANT,
@@ -26,6 +25,7 @@ import {
   PlainTimeParams,
   PlainYearMonthParams
 } from './internaltypes';
+import { PlainDateTime } from './plaindatetime';
 
 const DATE = Symbol('date');
 const YM = Symbol('ym');
@@ -505,8 +505,6 @@ type TypesWithToLocaleString =
   | Temporal.ZonedDateTime;
 
 function extractOverrides(temporalObj: Params['format'][0], main: DateTimeFormatImpl) {
-  const DateTime = GetIntrinsic('%Temporal.PlainDateTime%');
-
   if (ES.IsTemporalTime(temporalObj)) {
     const hour = GetSlot(temporalObj, ISO_HOUR);
     const minute = GetSlot(temporalObj, ISO_MINUTE);
@@ -514,7 +512,18 @@ function extractOverrides(temporalObj: Params['format'][0], main: DateTimeFormat
     const millisecond = GetSlot(temporalObj, ISO_MILLISECOND);
     const microsecond = GetSlot(temporalObj, ISO_MICROSECOND);
     const nanosecond = GetSlot(temporalObj, ISO_NANOSECOND);
-    const datetime = new DateTime(1970, 1, 1, hour, minute, second, millisecond, microsecond, nanosecond, main[CAL_ID]);
+    const datetime = new PlainDateTime(
+      1970,
+      1,
+      1,
+      hour,
+      minute,
+      second,
+      millisecond,
+      microsecond,
+      nanosecond,
+      main[CAL_ID]
+    );
     return {
       instant: ES.BuiltinTimeZoneGetInstantFor(getResolvedTimeZoneLazy(main), datetime, 'compatible'),
       formatter: getPropLazy(main, TIME)
@@ -531,7 +540,7 @@ function extractOverrides(temporalObj: Params['format'][0], main: DateTimeFormat
         `cannot format PlainYearMonth with calendar ${calendar} in locale with calendar ${main[CAL_ID]}`
       );
     }
-    const datetime = new DateTime(isoYear, isoMonth, referenceISODay, 12, 0, 0, 0, 0, 0, calendar);
+    const datetime = new PlainDateTime(isoYear, isoMonth, referenceISODay, 12, 0, 0, 0, 0, 0, calendar);
     return {
       instant: ES.BuiltinTimeZoneGetInstantFor(getResolvedTimeZoneLazy(main), datetime, 'compatible'),
       formatter: getPropLazy(main, YM)
@@ -548,7 +557,7 @@ function extractOverrides(temporalObj: Params['format'][0], main: DateTimeFormat
         `cannot format PlainMonthDay with calendar ${calendar} in locale with calendar ${main[CAL_ID]}`
       );
     }
-    const datetime = new DateTime(referenceISOYear, isoMonth, isoDay, 12, 0, 0, 0, 0, 0, calendar);
+    const datetime = new PlainDateTime(referenceISOYear, isoMonth, isoDay, 12, 0, 0, 0, 0, 0, calendar);
     return {
       instant: ES.BuiltinTimeZoneGetInstantFor(getResolvedTimeZoneLazy(main), datetime, 'compatible'),
       formatter: getPropLazy(main, MD)
@@ -563,7 +572,7 @@ function extractOverrides(temporalObj: Params['format'][0], main: DateTimeFormat
     if (calendar !== 'iso8601' && calendar !== main[CAL_ID]) {
       throw new RangeError(`cannot format PlainDate with calendar ${calendar} in locale with calendar ${main[CAL_ID]}`);
     }
-    const datetime = new DateTime(isoYear, isoMonth, isoDay, 12, 0, 0, 0, 0, 0, main[CAL_ID]);
+    const datetime = new PlainDateTime(isoYear, isoMonth, isoDay, 12, 0, 0, 0, 0, 0, main[CAL_ID]);
     return {
       instant: ES.BuiltinTimeZoneGetInstantFor(getResolvedTimeZoneLazy(main), datetime, 'compatible'),
       formatter: getPropLazy(main, DATE)
@@ -588,7 +597,7 @@ function extractOverrides(temporalObj: Params['format'][0], main: DateTimeFormat
     }
     let datetime = temporalObj;
     if (calendar === 'iso8601') {
-      datetime = new DateTime(
+      datetime = new PlainDateTime(
         isoYear,
         isoMonth,
         isoDay,

--- a/lib/intrinsicclass.ts
+++ b/lib/intrinsicclass.ts
@@ -135,6 +135,3 @@ export function DefineIntrinsic<KeyT extends IntrinsicDefinitionKeys>(name: KeyT
   if (INTRINSICS[key] !== undefined) throw new Error(`intrinsic ${name} already exists`);
   INTRINSICS[key] = value;
 }
-export function GetIntrinsic<KeyT extends keyof typeof INTRINSICS>(intrinsic: KeyT): typeof INTRINSICS[KeyT] {
-  return INTRINSICS[intrinsic];
-}

--- a/lib/now.ts
+++ b/lib/now.ts
@@ -1,9 +1,8 @@
 import * as ES from './ecmascript';
-import { GetIntrinsic } from './intrinsicclass';
 import { Temporal } from '..';
+import { Instant } from './instant';
 
 const instant: typeof Temporal.Now['instant'] = () => {
-  const Instant = GetIntrinsic('%Temporal.Instant%');
   return new Instant(ES.SystemUTCEpochNanoSeconds());
 };
 const plainDateTime: typeof Temporal.Now['plainDateTime'] = (calendarLike, temporalTimeZoneLike = timeZone()) => {

--- a/lib/plaindate.ts
+++ b/lib/plaindate.ts
@@ -1,5 +1,5 @@
 import * as ES from './ecmascript';
-import { GetIntrinsic, MakeIntrinsicClass } from './intrinsicclass';
+import { MakeIntrinsicClass } from './intrinsicclass';
 import {
   ISO_YEAR,
   ISO_MONTH,
@@ -188,8 +188,8 @@ export class PlainDate implements Temporal.PlainDate {
       this
     ));
 
-    const Duration = GetIntrinsic('%Temporal.Duration%');
-    return new Duration(years, months, weeks, days, 0, 0, 0, 0, 0, 0);
+    // const Duration = GetIntrinsic('%Temporal.Duration%')!;
+    return new Temporal.Duration(years, months, weeks, days, 0, 0, 0, 0, 0, 0);
   }
   since(otherParam: Params['since'][0], optionsParam: Params['since'][1] = undefined): Return['since'] {
     if (!ES.IsTemporalDate(this)) throw new TypeError('invalid receiver');
@@ -212,9 +212,8 @@ export class PlainDate implements Temporal.PlainDate {
 
     const untilOptions = { ...options, largestUnit };
     let { years, months, weeks, days } = ES.CalendarDateUntil(calendar, this, other, untilOptions);
-    const Duration = GetIntrinsic('%Temporal.Duration%');
     if (smallestUnit === 'day' && roundingIncrement === 1) {
-      return new Duration(-years, -months, -weeks, -days, 0, 0, 0, 0, 0, 0);
+      return new Temporal.Duration(-years, -months, -weeks, -days, 0, 0, 0, 0, 0, 0);
     }
     ({ years, months, weeks, days } = ES.RoundDuration(
       years,
@@ -233,7 +232,7 @@ export class PlainDate implements Temporal.PlainDate {
       this
     ));
 
-    return new Duration(-years, -months, -weeks, -days, 0, 0, 0, 0, 0, 0);
+    return new Temporal.Duration(-years, -months, -weeks, -days, 0, 0, 0, 0, 0, 0);
   }
   equals(otherParam: Params['equals'][0]): Return['equals'] {
     if (!ES.IsTemporalDate(this)) throw new TypeError('invalid receiver');

--- a/lib/plaindate.ts
+++ b/lib/plaindate.ts
@@ -17,6 +17,7 @@ import {
 import { Temporal } from '..';
 import { DateTimeFormat } from './intl';
 import type { PlainDateParams as Params, PlainDateReturn as Return } from './internaltypes';
+import { Duration } from './duration';
 
 const DISALLOWED_UNITS = ['hour', 'minute', 'second', 'millisecond', 'microsecond', 'nanosecond'] as const;
 
@@ -188,8 +189,7 @@ export class PlainDate implements Temporal.PlainDate {
       this
     ));
 
-    // const Duration = GetIntrinsic('%Temporal.Duration%')!;
-    return new Temporal.Duration(years, months, weeks, days, 0, 0, 0, 0, 0, 0);
+    return new Duration(years, months, weeks, days, 0, 0, 0, 0, 0, 0);
   }
   since(otherParam: Params['since'][0], optionsParam: Params['since'][1] = undefined): Return['since'] {
     if (!ES.IsTemporalDate(this)) throw new TypeError('invalid receiver');
@@ -350,6 +350,7 @@ export class PlainDate implements Temporal.PlainDate {
       calendar
     );
     const instant = ES.BuiltinTimeZoneGetInstantFor(timeZone, dt, 'compatible');
+    if (!instant) throw new TypeError(`Could not create instant for timezone "${timeZone}" and dateTime "${dt}"`);
     return ES.CreateTemporalZonedDateTime(GetSlot(instant, EPOCHNANOSECONDS), timeZone, calendar);
   }
   toPlainYearMonth(): Return['toPlainYearMonth'] {

--- a/lib/plaindatetime.ts
+++ b/lib/plaindatetime.ts
@@ -1,5 +1,5 @@
 import * as ES from './ecmascript';
-import { GetIntrinsic, MakeIntrinsicClass } from './intrinsicclass';
+import { MakeIntrinsicClass } from './intrinsicclass';
 
 import {
   ISO_YEAR,
@@ -18,6 +18,7 @@ import {
 import { Temporal } from '..';
 import { DateTimeFormat } from './intl';
 import type { PlainDateTimeParams as Params, PlainDateTimeReturn as Return } from './internaltypes';
+import { Duration } from './duration';
 
 export class PlainDateTime implements Temporal.PlainDateTime {
   constructor(
@@ -428,7 +429,6 @@ export class PlainDateTime implements Temporal.PlainDateTime {
       largestUnit
     ));
 
-    const Duration = GetIntrinsic('%Temporal.Duration%');
     return new Duration(years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds);
   }
   since(otherParam: Params['since'][0], optionsParam: Params['since'][1] = undefined): Return['since'] {
@@ -503,7 +503,6 @@ export class PlainDateTime implements Temporal.PlainDateTime {
       largestUnit
     ));
 
-    const Duration = GetIntrinsic('%Temporal.Duration%');
     return new Duration(
       -years,
       -months,

--- a/lib/plaintime.ts
+++ b/lib/plaintime.ts
@@ -1,6 +1,6 @@
 import { DEBUG } from './debug';
 import * as ES from './ecmascript';
-import { GetIntrinsic, MakeIntrinsicClass } from './intrinsicclass';
+import { MakeIntrinsicClass } from './intrinsicclass';
 
 import {
   ISO_YEAR,
@@ -21,6 +21,8 @@ import {
 import { Temporal } from '..';
 import { DateTimeFormat } from './intl';
 import type { PlainTimeParams as Params, PlainTimeReturn as Return } from './internaltypes';
+import { Duration } from './duration';
+import { PlainDateTime } from './plaindatetime';
 
 const ObjectAssign = Object.assign;
 
@@ -291,7 +293,6 @@ export class PlainTime implements Temporal.PlainTime {
       nanoseconds,
       largestUnit
     ));
-    const Duration = GetIntrinsic('%Temporal.Duration%');
     return new Duration(0, 0, 0, 0, hours, minutes, seconds, milliseconds, microseconds, nanoseconds);
   }
   since(otherParam: Params['since'][0], optionsParam: Params['since'][1] = undefined): Return['since'] {
@@ -348,7 +349,6 @@ export class PlainTime implements Temporal.PlainTime {
       nanoseconds,
       largestUnit
     ));
-    const Duration = GetIntrinsic('%Temporal.Duration%');
     return new Duration(0, 0, 0, 0, hours, minutes, seconds, milliseconds, microseconds, nanoseconds);
   }
   round(optionsParam: Params['round'][0]): Return['round'] {
@@ -475,7 +475,6 @@ export class PlainTime implements Temporal.PlainTime {
     const microsecond = GetSlot(this, ISO_MICROSECOND);
     const nanosecond = GetSlot(this, ISO_NANOSECOND);
 
-    const PlainDateTime = GetIntrinsic('%Temporal.PlainDateTime%');
     const dt = new PlainDateTime(
       year,
       month,

--- a/lib/plainyearmonth.ts
+++ b/lib/plainyearmonth.ts
@@ -1,9 +1,10 @@
 import * as ES from './ecmascript';
-import { GetIntrinsic, MakeIntrinsicClass } from './intrinsicclass';
+import { MakeIntrinsicClass } from './intrinsicclass';
 import { ISO_YEAR, ISO_MONTH, ISO_DAY, CALENDAR, GetSlot } from './slots';
 import { Temporal } from '..';
 import { DateTimeFormat } from './intl';
 import type { FieldRecord, PlainYearMonthParams as Params, PlainYearMonthReturn as Return } from './internaltypes';
+import { Duration } from './duration';
 
 const ObjectCreate = Object.create;
 
@@ -203,7 +204,6 @@ export class PlainYearMonth implements Temporal.PlainYearMonth {
       thisDate
     ));
 
-    const Duration = GetIntrinsic('%Temporal.Duration%');
     return new Duration(years, months, 0, 0, 0, 0, 0, 0, 0, 0);
   }
   since(otherParam: Params['since'][0], optionsParam: Params['since'][1] = undefined): Return['since'] {
@@ -233,7 +233,6 @@ export class PlainYearMonth implements Temporal.PlainYearMonth {
 
     const untilOptions = { ...options, largestUnit };
     let { years, months } = ES.CalendarDateUntil(calendar, thisDate, otherDate, untilOptions);
-    const Duration = GetIntrinsic('%Temporal.Duration%');
     if (smallestUnit === 'month' && roundingIncrement === 1) {
       return new Duration(-years, -months, 0, 0, 0, 0, 0, 0, 0, 0);
     }

--- a/lib/slots.ts
+++ b/lib/slots.ts
@@ -275,9 +275,10 @@ export function HasSlot(container: unknown, ...ids: (keyof Slots)[]): boolean {
   return !!myslots && ids.reduce((all: boolean, id) => all && id in myslots, true);
 }
 export function GetSlot<KeyT extends keyof Slots>(
-  container: Slots[typeof id]['usedBy'],
+  container: Slots[typeof id]['usedBy'] | undefined,
   id: KeyT
 ): Slots[KeyT]['value'] {
+  if (container === undefined) throw new TypeError('Missing container');
   const value = GetSlots(container)[id];
   if (value === undefined) throw new TypeError(`Missing internal slot ${id}`);
   return value;

--- a/lib/slots.ts
+++ b/lib/slots.ts
@@ -275,7 +275,7 @@ export function HasSlot(container: unknown, ...ids: (keyof Slots)[]): boolean {
   return !!myslots && ids.reduce((all: boolean, id) => all && id in myslots, true);
 }
 export function GetSlot<KeyT extends keyof Slots>(
-  container: Slots[typeof id]['usedBy'] | undefined,
+  container: Slots[typeof id]['usedBy'],
   id: KeyT
 ): Slots[KeyT]['value'] {
   if (container === undefined) throw new TypeError('Missing container');

--- a/lib/timezone.ts
+++ b/lib/timezone.ts
@@ -1,6 +1,6 @@
 import { DEBUG } from './debug';
 import * as ES from './ecmascript';
-import { GetIntrinsic, MakeIntrinsicClass, DefineIntrinsic } from './intrinsicclass';
+import { MakeIntrinsicClass, DefineIntrinsic } from './intrinsicclass';
 import {
   TIMEZONE_ID,
   EPOCHNANOSECONDS,
@@ -19,6 +19,7 @@ import {
 } from './slots';
 import { Temporal } from '..';
 import type { TimeZoneParams as Params, TimeZoneReturn as Return } from './internaltypes';
+import { Instant } from './instant';
 
 export class TimeZone implements Temporal.TimeZone {
   constructor(timeZoneIdentifierParam: string) {
@@ -80,7 +81,6 @@ export class TimeZone implements Temporal.TimeZone {
   getPossibleInstantsFor(dateTimeParam: Params['getPossibleInstantsFor'][0]): Return['getPossibleInstantsFor'] {
     if (!ES.IsTemporalTimeZone(this)) throw new TypeError('invalid receiver');
     const dateTime = ES.ToTemporalDateTime(dateTimeParam);
-    const Instant = GetIntrinsic('%Temporal.Instant%');
     const id = GetSlot(this, TIMEZONE_ID);
 
     const offsetNs = ES.ParseOffsetString(id);
@@ -125,7 +125,6 @@ export class TimeZone implements Temporal.TimeZone {
     }
 
     let epochNanoseconds = GetSlot(startingPoint, EPOCHNANOSECONDS);
-    const Instant = GetIntrinsic('%Temporal.Instant%');
     epochNanoseconds = ES.GetIANATimeZoneNextTransition(epochNanoseconds, id);
     return epochNanoseconds === null ? null : new Instant(epochNanoseconds);
   }
@@ -140,7 +139,6 @@ export class TimeZone implements Temporal.TimeZone {
     }
 
     let epochNanoseconds = GetSlot(startingPoint, EPOCHNANOSECONDS);
-    const Instant = GetIntrinsic('%Temporal.Instant%');
     epochNanoseconds = ES.GetIANATimeZonePreviousTransition(epochNanoseconds, id);
     return epochNanoseconds === null ? null : new Instant(epochNanoseconds);
   }

--- a/lib/zoneddatetime.ts
+++ b/lib/zoneddatetime.ts
@@ -1,5 +1,5 @@
 import * as ES from './ecmascript';
-import { GetIntrinsic, MakeIntrinsicClass } from './intrinsicclass';
+import { MakeIntrinsicClass } from './intrinsicclass';
 import {
   CALENDAR,
   EPOCHNANOSECONDS,
@@ -21,6 +21,10 @@ import { DateTimeFormat } from './intl';
 import type { ZonedDateTimeParams as Params, ZonedDateTimeReturn as Return } from './internaltypes';
 
 import bigInt from 'big-integer';
+import { PlainDateTime } from './plaindatetime';
+import { PlainTime } from './plaintime';
+import { Duration } from './duration';
+import { Instant } from './instant';
 
 const ArrayPrototypePush = Array.prototype.push;
 
@@ -133,13 +137,12 @@ export class ZonedDateTime implements Temporal.ZonedDateTime {
   get hoursInDay(): Return['hoursInDay'] {
     if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
     const dt = dateTime(this);
-    const DateTime = GetIntrinsic('%Temporal.PlainDateTime%');
     const year = GetSlot(dt, ISO_YEAR);
     const month = GetSlot(dt, ISO_MONTH);
     const day = GetSlot(dt, ISO_DAY);
-    const today = new DateTime(year, month, day, 0, 0, 0, 0, 0, 0);
+    const today = new PlainDateTime(year, month, day, 0, 0, 0, 0, 0, 0);
     const tomorrowFields = ES.AddISODate(year, month, day, 0, 0, 0, 1, 'reject');
-    const tomorrow = new DateTime(tomorrowFields.year, tomorrowFields.month, tomorrowFields.day, 0, 0, 0, 0, 0, 0);
+    const tomorrow = new PlainDateTime(tomorrowFields.year, tomorrowFields.month, tomorrowFields.day, 0, 0, 0, 0, 0, 0);
     const timeZone = GetSlot(this, TIME_ZONE);
     const todayNs = GetSlot(ES.BuiltinTimeZoneGetInstantFor(timeZone, today, 'compatible'), EPOCHNANOSECONDS);
     const tomorrowNs = GetSlot(ES.BuiltinTimeZoneGetInstantFor(timeZone, tomorrow, 'compatible'), EPOCHNANOSECONDS);
@@ -269,7 +272,6 @@ export class ZonedDateTime implements Temporal.ZonedDateTime {
 
     calendar = ES.ConsolidateCalendars(GetSlot(this, CALENDAR), calendar);
     const timeZone = GetSlot(this, TIME_ZONE);
-    const PlainDateTime = GetIntrinsic('%Temporal.PlainDateTime%');
     const dt = new PlainDateTime(
       year,
       month,
@@ -288,7 +290,6 @@ export class ZonedDateTime implements Temporal.ZonedDateTime {
   withPlainTime(temporalTimeParam: Params['withPlainTime'][0] = undefined): Return['withPlainTime'] {
     if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
 
-    const PlainTime = GetIntrinsic('%Temporal.PlainTime%');
     const temporalTime = temporalTimeParam == undefined ? new PlainTime() : ES.ToTemporalTime(temporalTimeParam);
 
     const thisDt = dateTime(this);
@@ -304,7 +305,6 @@ export class ZonedDateTime implements Temporal.ZonedDateTime {
     const nanosecond = GetSlot(temporalTime, ISO_NANOSECOND);
 
     const timeZone = GetSlot(this, TIME_ZONE);
-    const PlainDateTime = GetIntrinsic('%Temporal.PlainDateTime%');
     const dt = new PlainDateTime(
       year,
       month,
@@ -474,7 +474,6 @@ export class ZonedDateTime implements Temporal.ZonedDateTime {
         ));
     }
 
-    const Duration = GetIntrinsic('%Temporal.Duration%');
     return new Duration(years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds);
   }
   since(otherParam: Params['since'][0], optionsParam: Params['since'][1] = undefined) {
@@ -569,7 +568,6 @@ export class ZonedDateTime implements Temporal.ZonedDateTime {
         ));
     }
 
-    const Duration = GetIntrinsic('%Temporal.Duration%');
     return new Duration(
       -years,
       -months,
@@ -616,10 +614,19 @@ export class ZonedDateTime implements Temporal.ZonedDateTime {
     let microsecond = GetSlot(dt, ISO_MICROSECOND);
     let nanosecond = GetSlot(dt, ISO_NANOSECOND);
 
-    const DateTime = GetIntrinsic('%Temporal.PlainDateTime%');
     const timeZone = GetSlot(this, TIME_ZONE);
     const calendar = GetSlot(this, CALENDAR);
-    const dtStart = new DateTime(GetSlot(dt, ISO_YEAR), GetSlot(dt, ISO_MONTH), GetSlot(dt, ISO_DAY), 0, 0, 0, 0, 0, 0);
+    const dtStart = new PlainDateTime(
+      GetSlot(dt, ISO_YEAR),
+      GetSlot(dt, ISO_MONTH),
+      GetSlot(dt, ISO_DAY),
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    );
     const instantStart = ES.BuiltinTimeZoneGetInstantFor(timeZone, dtStart, 'compatible');
     const endNs = ES.AddZonedDateTime(instantStart, timeZone, calendar, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0);
     const dayLengthNs = endNs.subtract(GetSlot(instantStart, EPOCHNANOSECONDS));
@@ -710,9 +717,8 @@ export class ZonedDateTime implements Temporal.ZonedDateTime {
   startOfDay(): Return['startOfDay'] {
     if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
     const dt = dateTime(this);
-    const DateTime = GetIntrinsic('%Temporal.PlainDateTime%');
     const calendar = GetSlot(this, CALENDAR);
-    const dtStart = new DateTime(
+    const dtStart = new PlainDateTime(
       GetSlot(dt, ISO_YEAR),
       GetSlot(dt, ISO_MONTH),
       GetSlot(dt, ISO_DAY),
@@ -730,8 +736,7 @@ export class ZonedDateTime implements Temporal.ZonedDateTime {
   }
   toInstant(): Return['toInstant'] {
     if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
-    const TemporalInstant = GetIntrinsic('%Temporal.Instant%');
-    return new TemporalInstant(GetSlot(this, EPOCHNANOSECONDS));
+    return new Instant(GetSlot(this, EPOCHNANOSECONDS));
   }
   toPlainDate(): Return['toPlainDate'] {
     if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');


### PR DESCRIPTION
Hi all!

As mentioned in #98, there are currently quite a few alerts when enabling strict null checks etc in the tsconfig. If it makes sense I'd really like to help, but I'm not sure what the preferred way of handling undefined stuff is.

This PR fixes all TS issues in `plainDate.ts` when turning on the all the currently commented-out flags in the tsconfig. In most cases, the only change is to allow methods that are called with possibly undefined values to handle that gracefully. Or do you prefer to throw more often if something is undefined?

If this looks ok to you I can start fixing the remaining TS issues.