### PR TITLE
GetIntrinsic: remove from PlainDate, add monkeypatching test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ tsc-out/
 .vscode/*
 !.vscode/launch.json
 *.tgz
+.DS_Store

--- a/lib/plaindate.ts
+++ b/lib/plaindate.ts
@@ -1,5 +1,5 @@
 import * as ES from './ecmascript';
-import { GetIntrinsic, MakeIntrinsicClass } from './intrinsicclass';
+import { MakeIntrinsicClass } from './intrinsicclass';
 import {
   ISO_YEAR,
   ISO_MONTH,
@@ -17,6 +17,7 @@ import {
 import { Temporal } from '..';
 import { DateTimeFormat } from './intl';
 import type { PlainDateParams as Params, PlainDateReturn as Return } from './internaltypes';
+import { Duration } from './duration';
 
 const DISALLOWED_UNITS = ['hour', 'minute', 'second', 'millisecond', 'microsecond', 'nanosecond'] as const;
 
@@ -188,7 +189,6 @@ export class PlainDate implements Temporal.PlainDate {
       this
     ));
 
-    const Duration = GetIntrinsic('%Temporal.Duration%');
     return new Duration(years, months, weeks, days, 0, 0, 0, 0, 0, 0);
   }
   since(otherParam: Params['since'][0], optionsParam: Params['since'][1] = undefined): Return['since'] {
@@ -212,7 +212,6 @@ export class PlainDate implements Temporal.PlainDate {
 
     const untilOptions = { ...options, largestUnit };
     let { years, months, weeks, days } = ES.CalendarDateUntil(calendar, this, other, untilOptions);
-    const Duration = GetIntrinsic('%Temporal.Duration%');
     if (smallestUnit === 'day' && roundingIncrement === 1) {
       return new Duration(-years, -months, -weeks, -days, 0, 0, 0, 0, 0, 0);
     }

--- a/test/all.mjs
+++ b/test/all.mjs
@@ -34,6 +34,9 @@ import './calendar.mjs';
 import './usertimezone.mjs';
 import './usercalendar.mjs';
 
+// monkeypatching
+import './monkeypatch.mjs';
+
 Promise.resolve()
   .then(() => {
     return Demitasse.report(Pretty.reporter);

--- a/test/monkeypatch.mjs
+++ b/test/monkeypatch.mjs
@@ -1,0 +1,28 @@
+#! /usr/bin/env -S node --experimental-modules
+
+import Demitasse from '@pipobscure/demitasse';
+const { describe, it, report } = Demitasse;
+
+import Pretty from '@pipobscure/demitasse-pretty';
+const { reporter } = Pretty;
+
+import { strict as assert } from 'assert';
+const { equal } = assert;
+
+import * as Temporal from '@js-temporal/polyfill';
+const { PlainDate } = Temporal;
+
+describe('Monkeypatch', () => {
+  describe('PlainDate', () => {
+    it("Monkeypatching Duration doesn't affect PlainDate", () => {
+      Temporal.Duration.prototype.constructor = null;
+      const date = PlainDate.from('2021-12-09');
+      equal(`${date.until('2021-12-10')}`, 'P1D');
+    });
+  });
+});
+
+import { normalize } from 'path';
+if (normalize(import.meta.url.slice(8)) === normalize(process.argv[1])) {
+  report(reporter).then((failed) => process.exit(failed ? 1 : 0));
+}


### PR DESCRIPTION
Hi all! As discussed in #103, it would be nice to remove `GetIntrinsic` and just import things.

This PR removes `GetIntrinsic` (as of writing this only from `plainDate.ts` in order to make sure that it makes sense before removing it elsewhere).

I also added a test that monkey-patches `Duration` (used by `PlainDate`) to make sure that it doesn't affect the behaviour of `PlainDate` -- not sure if I did it correctly, as I never used monkey-patching before.

As importing something from a file doesn't import from `globalThis` anyway (at least that's my understanding), monkey-patches done in userland should not the library. If someone with more knowledge of monkey-patching could verify this, that would probably be great.

Patching stuff in userland also seems the main usecase for [ES6 Proxies](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy), so maybe this isn't something to worry about anyway?