### PR TITLE
Catch up on proposal-temporal PRs

### DIFF
--- a/lib/regex.ts
+++ b/lib/regex.ts
@@ -18,12 +18,8 @@ export const offset = /([+\u2212-])([01][0-9]|2[0-3])(?::?([0-5][0-9])(?::?([0-5
 const zonesplit = new RegExp(`(?:([zZ])|(?:${offset.source})?)(?:\\[(${timeZoneID.source})\\])?`);
 const calendar = new RegExp(`\\[u-ca=(${calendarID.source})\\]`);
 
-export const instant = new RegExp(
+export const zoneddatetime = new RegExp(
   `^${datesplit.source}(?:(?:T|\\s+)${timesplit.source})?${zonesplit.source}(?:${calendar.source})?$`,
-  'i'
-);
-export const datetime = new RegExp(
-  `^${datesplit.source}(?:(?:T|\\s+)${timesplit.source})?(?:${zonesplit.source})?(?:${calendar.source})?$`,
   'i'
 );
 

--- a/lib/timezone.ts
+++ b/lib/timezone.ts
@@ -50,9 +50,9 @@ export class TimeZone implements Temporal.TimeZone {
     const instant = ES.ToTemporalInstant(instantParam);
     const id = GetSlot(this, TIMEZONE_ID);
 
-    const offsetNs = ES.ParseOffsetString(id);
-    if (offsetNs !== null) return offsetNs;
-
+    if (ES.TestTimeZoneOffsetString(id)) {
+      return ES.ParseTimeZoneOffsetString(id);
+    }
     return ES.GetIANATimeZoneOffsetNanoseconds(GetSlot(instant, EPOCHNANOSECONDS), id);
   }
   getOffsetStringFor(instantParam: Params['getOffsetStringFor'][0]): Return['getOffsetStringFor'] {
@@ -84,8 +84,7 @@ export class TimeZone implements Temporal.TimeZone {
     const Instant = GetIntrinsic('%Temporal.Instant%');
     const id = GetSlot(this, TIMEZONE_ID);
 
-    const offsetNs = ES.ParseOffsetString(id);
-    if (offsetNs !== null) {
+    if (ES.TestTimeZoneOffsetString(id)) {
       const epochNs = ES.GetEpochFromISOParts(
         GetSlot(dateTime, ISO_YEAR),
         GetSlot(dateTime, ISO_MONTH),
@@ -98,6 +97,7 @@ export class TimeZone implements Temporal.TimeZone {
         GetSlot(dateTime, ISO_NANOSECOND)
       );
       if (epochNs === null) throw new RangeError('DateTime outside of supported range');
+      const offsetNs = ES.ParseTimeZoneOffsetString(id);
       return [new Instant(JSBI.subtract(epochNs, JSBI.BigInt(offsetNs)))];
     }
 
@@ -121,7 +121,7 @@ export class TimeZone implements Temporal.TimeZone {
     const id = GetSlot(this, TIMEZONE_ID);
 
     // Offset time zones or UTC have no transitions
-    if (ES.ParseOffsetString(id) !== null || id === 'UTC') {
+    if (ES.TestTimeZoneOffsetString(id) || id === 'UTC') {
       return null;
     }
 
@@ -136,7 +136,7 @@ export class TimeZone implements Temporal.TimeZone {
     const id = GetSlot(this, TIMEZONE_ID);
 
     // Offset time zones or UTC have no transitions
-    if (ES.ParseOffsetString(id) !== null || id === 'UTC') {
+    if (ES.TestTimeZoneOffsetString(id) || id === 'UTC') {
       return null;
     }
 

--- a/lib/zoneddatetime.ts
+++ b/lib/zoneddatetime.ts
@@ -230,7 +230,7 @@ export class ZonedDateTime implements Temporal.ZonedDateTime {
     fields = ES.PrepareTemporalFields(fields, entries as any);
     const { year, month, day, hour, minute, second, millisecond, microsecond, nanosecond } =
       ES.InterpretTemporalDateTimeFields(calendar, fields, options);
-    const offsetNs = ES.ParseOffsetString(fields.offset);
+    const offsetNs = ES.ParseTimeZoneOffsetString(fields.offset);
     const epochNanoseconds = ES.InterpretISODateTimeOffset(
       year,
       month,

--- a/test/duration.mjs
+++ b/test/duration.mjs
@@ -687,6 +687,15 @@ describe('Duration', () => {
       throws(() => oneDay.add(hours24, { relativeTo: { year: 2019, month: 11 } }), TypeError);
       throws(() => oneDay.add(hours24, { relativeTo: { year: 2019, day: 3 } }), TypeError);
     });
+    it('throws with invalid offset in relativeTo', () => {
+      throws(
+        () =>
+          Temporal.Duration.from('P2D').add('P1M', {
+            relativeTo: { year: 2021, month: 11, day: 26, offset: '+088:00', timeZone: 'Europe/London' }
+          }),
+        RangeError
+      );
+    });
   });
   describe('Duration.subtract()', () => {
     const duration = Duration.from({ days: 3, hours: 1, minutes: 10 });
@@ -929,6 +938,15 @@ describe('Duration', () => {
       equal(zero2.milliseconds, 0);
       equal(zero2.microseconds, 0);
       equal(zero2.nanoseconds, 0);
+    });
+    it('throws with invalid offset in relativeTo', () => {
+      throws(
+        () =>
+          Temporal.Duration.from('P2D').subtract('P1M', {
+            relativeTo: { year: 2021, month: 11, day: 26, offset: '+088:00', timeZone: 'Europe/London' }
+          }),
+        RangeError
+      );
     });
   });
   describe('Duration.abs()', () => {
@@ -1514,6 +1532,16 @@ describe('Duration', () => {
       equal(`${yearAndHalf.round({ relativeTo: '2020-01-01', smallestUnit: 'years' })}`, 'P1Y');
       equal(`${yearAndHalf.round({ relativeTo: '2020-07-01', smallestUnit: 'years' })}`, 'P2Y');
     });
+    it('throws with invalid offset in relativeTo', () => {
+      throws(
+        () =>
+          Temporal.Duration.from('P1M280D').round({
+            smallestUnit: 'month',
+            relativeTo: { year: 2021, month: 11, day: 26, offset: '+088:00', timeZone: 'Europe/London' }
+          }),
+        RangeError
+      );
+    });
   });
   describe('Duration.total()', () => {
     const d = new Duration(5, 5, 5, 5, 5, 5, 5, 5, 5, 5);
@@ -1853,6 +1881,16 @@ describe('Duration', () => {
       equal(d.total({ unit: 'microsecond', relativeTo }), d.total({ unit: 'microseconds', relativeTo }));
       equal(d.total({ unit: 'nanosecond', relativeTo }), d.total({ unit: 'nanoseconds', relativeTo }));
     });
+    it('throws with invalid offset in relativeTo', () => {
+      throws(
+        () =>
+          Temporal.Duration.from('P1M280D').total({
+            unit: 'month',
+            relativeTo: { year: 2021, month: 11, day: 26, offset: '+088:00', timeZone: 'Europe/London' }
+          }),
+        RangeError
+      );
+    });
   });
   describe('Duration.compare', () => {
     describe('time units only', () => {
@@ -1948,6 +1986,15 @@ describe('Duration', () => {
     });
     it('does not lose precision when totaling everything down to nanoseconds', () => {
       notEqual(Duration.compare({ days: 200 }, { days: 200, nanoseconds: 1 }), 0);
+    });
+    it('throws with invalid offset in relativeTo', () => {
+      throws(() => {
+        const d1 = Temporal.Duration.from('P1M280D');
+        const d2 = Temporal.Duration.from('P1M281D');
+        Temporal.Duration.compare(d1, d2, {
+          relativeTo: { year: 2021, month: 11, day: 26, offset: '+088:00', timeZone: 'Europe/London' }
+        });
+      }, RangeError);
     });
   });
 });

--- a/test/zoneddatetime.mjs
+++ b/test/zoneddatetime.mjs
@@ -589,6 +589,23 @@ describe('ZonedDateTime', () => {
       });
       equal(`${zdt}`, '1976-11-18T00:00:00-10:30[-10:30]');
     });
+    it('throws with invalid offset', () => {
+      const offsets = ['use', 'prefer', 'ignore', 'reject'];
+      offsets.forEach((offset) => {
+        throws(() => {
+          Temporal.ZonedDateTime.from(
+            {
+              year: 2021,
+              month: 11,
+              day: 26,
+              offset: '+099:00',
+              timeZone: 'Europe/London'
+            },
+            { offset }
+          );
+        }, RangeError);
+      });
+    });
     describe('Overflow option', () => {
       const bad = { year: 2019, month: 1, day: 32, timeZone: lagos };
       it('reject', () => throws(() => ZonedDateTime.from(bad, { overflow: 'reject' }), RangeError));
@@ -1024,6 +1041,14 @@ describe('ZonedDateTime', () => {
       throws(() => zdt.with('1976-11-18'), TypeError);
       throws(() => zdt.with('12:00'), TypeError);
       throws(() => zdt.with('invalid'), TypeError);
+    });
+    it('throws with invalid offset', () => {
+      const offsets = ['use', 'prefer', 'ignore', 'reject'];
+      offsets.forEach((offset) => {
+        throws(() => {
+          Temporal.ZonedDateTime.from('2022-11-26[Europe/London]').with({ offset: '+088:00' }, { offset });
+        }, RangeError);
+      });
     });
   });
 
@@ -1617,6 +1642,18 @@ describe('ZonedDateTime', () => {
       equal(`${dt1.until(dt2, { smallestUnit: 'years', roundingMode: 'halfExpand' })}`, 'P2Y');
       equal(`${dt2.until(dt1, { smallestUnit: 'years', roundingMode: 'halfExpand' })}`, '-P1Y');
     });
+    it('throws with invalid offset', () => {
+      throws(() => {
+        const zdt = ZonedDateTime.from('2019-01-01T00:00+00:00[UTC]');
+        zdt.until({
+          year: 2021,
+          month: 11,
+          day: 26,
+          offset: '+099:00',
+          timeZone: 'Europe/London'
+        });
+      }, RangeError);
+    });
   });
   describe('ZonedDateTime.since()', () => {
     const zdt = ZonedDateTime.from('1976-11-18T15:23:30.123456789+01:00[Europe/Vienna]');
@@ -1948,6 +1985,18 @@ describe('ZonedDateTime', () => {
       equal(`${dt2.since(dt1, { smallestUnit: 'years', roundingMode: 'halfExpand' })}`, 'P1Y');
       equal(`${dt1.since(dt2, { smallestUnit: 'years', roundingMode: 'halfExpand' })}`, '-P2Y');
     });
+    it('throws with invalid offset', () => {
+      throws(() => {
+        const zdt = ZonedDateTime.from('2019-01-01T00:00+00:00[UTC]');
+        zdt.since({
+          year: 2021,
+          month: 11,
+          day: 26,
+          offset: '+099:00',
+          timeZone: 'Europe/London'
+        });
+      }, RangeError);
+    });
   });
 
   describe('ZonedDateTime.round()', () => {
@@ -2187,6 +2236,17 @@ describe('ZonedDateTime', () => {
         () => zdt.equals({ years: 1969, months: 12, days: 31, timeZone: 'America/New_York', calendarName: 'gregory' }),
         TypeError
       );
+    });
+    it('throws with invalid offset', () => {
+      throws(() => {
+        zdt.equals({
+          year: 2021,
+          month: 11,
+          day: 26,
+          offset: '+099:00',
+          timeZone: 'Europe/London'
+        });
+      }, RangeError);
     });
   });
   describe('ZonedDateTime.toString()', () => {
@@ -2894,6 +2954,17 @@ describe('ZonedDateTime', () => {
       const clockAfter = ZonedDateTime.from('2000-01-01T01:30-04:00[America/Halifax]');
       equal(ZonedDateTime.compare(clockBefore, clockAfter), 1);
       equal(Temporal.PlainDateTime.compare(clockBefore.toPlainDateTime(), clockAfter.toPlainDateTime()), -1);
+    });
+    it('throws with invalid offset', () => {
+      throws(() => {
+        Temporal.ZonedDateTime.compare(zdt1, {
+          year: 2021,
+          month: 11,
+          day: 26,
+          offset: '+099:00',
+          timeZone: 'Europe/London'
+        });
+      }, RangeError);
     });
   });
 });


### PR DESCRIPTION
Three commits here to catch up with recent PRs over in proposal-temporal:

* Throw RangeError for invalid offset strings - tc39/proposal-temporal#1976
* Remove zoneRequired param - tc39/proposal-temporal#1979
* Refactor ecmascript.ts - tc39/proposal-temporal#1976 and tc39/proposal-temporal#1980 (the latter was a subset of the lines covered by the former PR, so I just combined into one commit)
