### PR TITLE
Refactor non-ISO calendars to use ES6 classes

### DIFF
--- a/lib/calendar.ts
+++ b/lib/calendar.ts
@@ -1149,23 +1149,13 @@ abstract class HelperBase {
   }
   addCalendar(
     calendarDate: CalendarYMD,
-    {
-      years,
-      months,
-      weeks,
-      days
-    }: {
-      years?: number | undefined;
-      months?: number | undefined;
-      weeks?: number | undefined;
-      days?: number | undefined;
-    },
+    { years = 0, months = 0, weeks = 0, days = 0 },
     overflow: Overflow,
     cache: OneObjectCache
   ): FullCalendarDate {
     const { year, month, day } = calendarDate;
-    const addedMonths = this.addMonthsCalendar({ year: year + (years ?? 0), month, day }, months ?? 0, overflow, cache);
-    const initialDays = (days ?? 0) + (weeks ?? 0) * 7;
+    const addedMonths = this.addMonthsCalendar({ year: year + years, month, day }, months, overflow, cache);
+    const initialDays = days + weeks * 7;
     const addedDays = this.addDaysCalendar(addedMonths, initialDays, cache);
     return addedDays;
   }


### PR DESCRIPTION
The implementation of non-ISO calendars has always been a bit sloppy and confusing since I wrote it as a proof-of-concept a year ago. Now that non-ISO calendar implementations are fully typed in #109, it's easier and safer to refactor them into a more maintainable set of ES6 classes. The inheritance structure is below, with bold classes are actual ICU calendars, the non-bold ones are base classes. 

* HelperBase - shared code for all non-ISO calendars
  * **HebrewHelper**
  * **PersianHelper**
  * **IndianHelper**
  * GregorianBaseHelper
    * **RocHelper**
    * **BuddhistHelper**
    * **GregoryHelper**
    * **JapaneseHelper**
    * OrthodoxBaseHelper
      * **EthiopicHelper**
      * **EthioaaHelper**
      * **CopticHelper**
  * ChineseBaseHelper
    * **ChineseHelper**
    * **DangiHelper**
  * IslamicBaseHelper
    * **IslamicHelper**
    * **IslamicUmalquraHelper**
    * **IslamicTblaHelper**
    * **IslamicCivilHelper**
    * **IslamicRgsaHelper**
    * **IslamicCcHelper**

This PR removes a lot of extra TS type code that is not needed using classes where types for inherited methods is implicit. 

This is a pretty big PR but I wasn't sure how to split it into multiple commits given that things are pretty intertwined... once I started pulling on the ES6 thread, the whole sweater came with it. 😄 