### PR TITLE
GetFormatterParts tests and error cases

### DIFF
--- a/lib/ecmascript.ts
+++ b/lib/ecmascript.ts
@@ -2861,16 +2861,42 @@ export function GetIANATimeZonePreviousTransition(epochNanoseconds: JSBI, id: st
   return result;
 }
 
+// ts-prune-ignore-next TODO: remove this after tests are converted to TS
 export function parseFromEnUsFormat(datetime: string) {
-  const [month, day, year, era, hour, minute, second] = datetime.split(/[^\w]+/);
-  return {
-    year: era.toUpperCase().startsWith('B') ? -year + 1 : +year,
-    month: +month,
-    day: +day,
-    hour: hour === '24' ? 0 : +hour, // bugs.chromium.org/p/chromium/issues/detail?id=1045791
-    minute: +minute,
-    second: +second
-  };
+  const parts = datetime.split(/[^\w]+/);
+
+  if (parts.length !== 7) {
+    throw new RangeError(`expected 7 parts in "${datetime}`);
+  }
+
+  const month = +parts[0];
+  const day = +parts[1];
+  let year = +parts[2];
+  const era = parts[3].toUpperCase();
+  if (era === 'B' || era === 'BC') {
+    year = -year + 1;
+  } else if (era !== 'A' && era !== 'AD') {
+    throw new RangeError(`Unknown era ${era} in "${datetime}`);
+  }
+  let hour = +parts[4];
+  if (hour === 24) {
+    hour = 0;
+  }
+  const minute = +parts[5];
+  const second = +parts[6];
+
+  if (
+    !NumberIsFinite(year) ||
+    !NumberIsFinite(month) ||
+    !NumberIsFinite(day) ||
+    !NumberIsFinite(hour) ||
+    !NumberIsFinite(minute) ||
+    !NumberIsFinite(second)
+  ) {
+    throw new RangeError(`Invalid number in "${datetime}`);
+  }
+
+  return { year, month, day, hour, minute, second };
 }
 
 // ts-prune-ignore-next TODO: remove this after tests are converted to TS

--- a/lib/ecmascript.ts
+++ b/lib/ecmascript.ts
@@ -2861,11 +2861,7 @@ export function GetIANATimeZonePreviousTransition(epochNanoseconds: JSBI, id: st
   return result;
 }
 
-// ts-prune-ignore-next TODO: remove this after tests are converted to TS
-export function GetFormatterParts(timeZone: string, epochMilliseconds: number) {
-  const formatter = getIntlDateTimeFormatEnUsForTimeZone(timeZone);
-  // Using `format` instead of `formatToParts` for compatibility with older clients
-  const datetime = formatter.format(new Date(epochMilliseconds));
+export function parseFromEnUsFormat(datetime: string) {
   const [month, day, year, era, hour, minute, second] = datetime.split(/[^\w]+/);
   return {
     year: era.toUpperCase().startsWith('B') ? -year + 1 : +year,
@@ -2875,6 +2871,14 @@ export function GetFormatterParts(timeZone: string, epochMilliseconds: number) {
     minute: +minute,
     second: +second
   };
+}
+
+// ts-prune-ignore-next TODO: remove this after tests are converted to TS
+export function GetFormatterParts(timeZone: string, epochMilliseconds: number) {
+  const formatter = getIntlDateTimeFormatEnUsForTimeZone(timeZone);
+  // Using `format` instead of `formatToParts` for compatibility with older clients
+  const datetime = formatter.format(new Date(epochMilliseconds));
+  return parseFromEnUsFormat(datetime);
 }
 
 export function GetIANATimeZoneEpochValue(

--- a/lib/ecmascript.ts
+++ b/lib/ecmascript.ts
@@ -2880,6 +2880,7 @@ export function parseFromEnUsFormat(datetime: string) {
   }
   let hour = +parts[4];
   if (hour === 24) {
+    // bugs.chromium.org/p/chromium/issues/detail?id=1045791
     hour = 0;
   }
   const minute = +parts[5];

--- a/test/ecmascript.mjs
+++ b/test/ecmascript.mjs
@@ -406,23 +406,37 @@ describe('ECMAScript', () => {
   });
 
   describe('parseFromEnUsFormat', () => {
+    describe('succeeds', () => {
+      // newer Firefox
+      test('9/16/2021 A, 16:09:00', { year: 2021, month: 9, day: 16, hour: 16, minute: 9, second: 0 });
 
-    // newer Firefox
-    test('9/16/2021 A, 16:09:00', { year: 2021, month: 9, day: 16, hour: 16, minute: 9, second: 0 });
+      // other browsers
+      test('9 16, 2021 AD, 16:09:00', { year: 2021, month: 9, day: 16, hour: 16, minute: 9, second: 0 });
 
-    // other browsers
-    test('9 16, 2021 AD, 16:09:00', { year: 2021, month: 9, day: 16, hour: 16, minute: 9, second: 0 });
+      // verify BC years
+      test('1 15, 501 BC, 16:07:45', { year: -500, month: 1, day: 15, hour: 16, minute: 7, second: 45 });
 
-    // verify BC years
-    test('1 15, 501 BC, 16:07:45', { year: -500, month: 1, day: 15, hour: 16, minute: 7, second: 45 });
-    
-    // verify hour 24
-    test('1 1, 2000 AD, 24:00:00', { year: 2000, month: 1, day: 1, hour: 0, minute: 0, second: 0 });
+      // verify hour 24
+      test('1 1, 2000 AD, 24:00:00', { year: 2000, month: 1, day: 1, hour: 0, minute: 0, second: 0 });
 
-    function test(dateTimeString, expected) {
-      it(dateTimeString, () => deepEqual(ES.parseFromEnUsFormat(dateTimeString), expected));
-    }
-  })
+      function test(dateTimeString, expected) {
+        it(dateTimeString, () => deepEqual(ES.parseFromEnUsFormat(dateTimeString), expected));
+      }
+    });
+
+    describe('throws', () => {
+      test('');
+      test('1234');
+      test('1 2 3 4 5 6');
+      test('1 2 3 4 5 6 7');
+      test('this is not a date');
+      test('one two three four five six seven');
+
+      function test(dateTimeString) {
+        it(dateTimeString, () => throws(() => ES.parseFromEnUsFormat(dateTimeString)));
+      }
+    });
+  });
 
   describe('GetOptionsObject', () => {
     it('Options parameter can only be an object or undefined', () => {

--- a/test/ecmascript.mjs
+++ b/test/ecmascript.mjs
@@ -405,6 +405,25 @@ describe('ECMAScript', () => {
     }
   });
 
+  describe('parseFromEnUsFormat', () => {
+
+    // newer Firefox
+    test('9/16/2021 A, 16:09:00', { year: 2021, month: 9, day: 16, hour: 16, minute: 9, second: 0 });
+
+    // other browsers
+    test('9 16, 2021 AD, 16:09:00', { year: 2021, month: 9, day: 16, hour: 16, minute: 9, second: 0 });
+
+    // verify BC years
+    test('1 15, 501 BC, 16:07:45', { year: -500, month: 1, day: 15, hour: 16, minute: 7, second: 45 });
+    
+    // verify hour 24
+    test('1 1, 2000 AD, 24:00:00', { year: 2000, month: 1, day: 1, hour: 0, minute: 0, second: 0 });
+
+    function test(dateTimeString, expected) {
+      it(dateTimeString, () => deepEqual(ES.parseFromEnUsFormat(dateTimeString), expected));
+    }
+  })
+
   describe('GetOptionsObject', () => {
     it('Options parameter can only be an object or undefined', () => {
       [null, 1, 'hello', true, Symbol('1'), 1n].forEach((options) =>


### PR DESCRIPTION
As a follow-up to #97 this adds tests for the relevant code parts and lets it throw on unexpected input (instead of failing with NaN values later somewhere else)

Should a browser change the format again, it will fail with a helpful error message in the correct place.