### PR TITLE
Include the valueOf function in Temporal.Duration.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -542,6 +542,7 @@ export namespace Temporal {
     toLocaleString(locales?: string | string[], options?: Intl.DateTimeFormatOptions): string;
     toJSON(): string;
     toString(options?: ToStringPrecisionOptions): string;
+    valueOf(): never;
     readonly [Symbol.toStringTag]: 'Temporal.Duration';
   }
 


### PR DESCRIPTION
This was missed out in https://github.com/js-temporal/temporal-polyfill/commit/46b663cfe40c6b9381263d166615f8d5f7fadef5.