### PR TITLE
Change type-only imports to use import type

### DIFF
--- a/lib/calendar.ts
+++ b/lib/calendar.ts
@@ -21,7 +21,7 @@ import {
   HasSlot,
   SetSlot
 } from './slots';
-import { Temporal } from '..';
+import type { Temporal } from '..';
 import type {
   BuiltinCalendarId,
   CalendarParams as Params,

--- a/lib/duration.ts
+++ b/lib/duration.ts
@@ -16,7 +16,7 @@ import {
   GetSlot,
   SetSlot
 } from './slots';
-import { Temporal } from '..';
+import type { Temporal } from '..';
 import type { DurationParams as Params, DurationReturn as Return } from './internaltypes';
 import JSBI from 'jsbi';
 

--- a/lib/instant.ts
+++ b/lib/instant.ts
@@ -2,7 +2,7 @@ import { DEBUG } from './debug';
 import * as ES from './ecmascript';
 import { GetIntrinsic, MakeIntrinsicClass } from './intrinsicclass';
 import { EPOCHNANOSECONDS, CreateSlots, GetSlot, SetSlot } from './slots';
-import { Temporal } from '..';
+import type { Temporal } from '..';
 import { DateTimeFormat } from './intl';
 import type { InstantParams as Params, InstantReturn as Return } from './internaltypes';
 

--- a/lib/internaltypes.d.ts
+++ b/lib/internaltypes.d.ts
@@ -1,4 +1,4 @@
-import { Intl, Temporal } from '..';
+import type { Intl, Temporal } from '..';
 
 export type BuiltinCalendarId =
   | 'iso8601'

--- a/lib/intl.ts
+++ b/lib/intl.ts
@@ -15,8 +15,8 @@ import {
   CALENDAR,
   TIME_ZONE
 } from './slots';
-import { Temporal, Intl } from '..';
-import { DateTimeFormatParams as Params, DateTimeFormatReturn as Return } from './internaltypes';
+import type { Temporal, Intl } from '..';
+import type { DateTimeFormatParams as Params, DateTimeFormatReturn as Return } from './internaltypes';
 
 const DATE = Symbol('date');
 const YM = Symbol('ym');

--- a/lib/intrinsicclass.ts
+++ b/lib/intrinsicclass.ts
@@ -1,5 +1,5 @@
-import JSBI from 'jsbi';
-import { Temporal } from '..';
+import type JSBI from 'jsbi';
+import type { Temporal } from '..';
 
 import { DEBUG } from './debug';
 

--- a/lib/now.ts
+++ b/lib/now.ts
@@ -1,6 +1,6 @@
 import * as ES from './ecmascript';
 import { GetIntrinsic } from './intrinsicclass';
-import { Temporal } from '..';
+import type { Temporal } from '..';
 
 const instant: typeof Temporal.Now['instant'] = () => {
   const Instant = GetIntrinsic('%Temporal.Instant%');

--- a/lib/plaindate.ts
+++ b/lib/plaindate.ts
@@ -14,7 +14,7 @@ import {
   EPOCHNANOSECONDS,
   GetSlot
 } from './slots';
-import { Temporal } from '..';
+import type { Temporal } from '..';
 import { DateTimeFormat } from './intl';
 import type { PlainDateParams as Params, PlainDateReturn as Return } from './internaltypes';
 

--- a/lib/plaindatetime.ts
+++ b/lib/plaindatetime.ts
@@ -15,7 +15,7 @@ import {
   EPOCHNANOSECONDS,
   GetSlot
 } from './slots';
-import { Temporal } from '..';
+import type { Temporal } from '..';
 import { DateTimeFormat } from './intl';
 import type { PlainDateTimeParams as Params, PlainDateTimeReturn as Return } from './internaltypes';
 

--- a/lib/plainmonthday.ts
+++ b/lib/plainmonthday.ts
@@ -1,7 +1,7 @@
 import * as ES from './ecmascript';
 import { MakeIntrinsicClass } from './intrinsicclass';
 import { ISO_MONTH, ISO_DAY, ISO_YEAR, CALENDAR, GetSlot } from './slots';
-import { Temporal } from '..';
+import type { Temporal } from '..';
 import { DateTimeFormat } from './intl';
 import type { FieldRecord, PlainMonthDayParams as Params, PlainMonthDayReturn as Return } from './internaltypes';
 

--- a/lib/plaintime.ts
+++ b/lib/plaintime.ts
@@ -18,7 +18,7 @@ import {
   GetSlot,
   SetSlot
 } from './slots';
-import { Temporal } from '..';
+import type { Temporal } from '..';
 import { DateTimeFormat } from './intl';
 import type { PlainTimeParams as Params, PlainTimeReturn as Return } from './internaltypes';
 

--- a/lib/plainyearmonth.ts
+++ b/lib/plainyearmonth.ts
@@ -1,7 +1,7 @@
 import * as ES from './ecmascript';
 import { GetIntrinsic, MakeIntrinsicClass } from './intrinsicclass';
 import { ISO_YEAR, ISO_MONTH, ISO_DAY, CALENDAR, GetSlot } from './slots';
-import { Temporal } from '..';
+import type { Temporal } from '..';
 import { DateTimeFormat } from './intl';
 import type { FieldRecord, PlainYearMonthParams as Params, PlainYearMonthReturn as Return } from './internaltypes';
 

--- a/lib/slots.ts
+++ b/lib/slots.ts
@@ -1,4 +1,4 @@
-import JSBI from 'jsbi';
+import type JSBI from 'jsbi';
 import type { Temporal } from '..';
 import type { BuiltinCalendarId, AnyTemporalType } from './internaltypes';
 

--- a/lib/timezone.ts
+++ b/lib/timezone.ts
@@ -18,7 +18,7 @@ import {
   SetSlot
 } from './slots';
 import JSBI from 'jsbi';
-import { Temporal } from '..';
+import type { Temporal } from '..';
 import type { TimeZoneParams as Params, TimeZoneReturn as Return } from './internaltypes';
 
 export class TimeZone implements Temporal.TimeZone {

--- a/lib/zoneddatetime.ts
+++ b/lib/zoneddatetime.ts
@@ -16,7 +16,7 @@ import {
   TIME_ZONE,
   GetSlot
 } from './slots';
-import { Temporal } from '..';
+import type { Temporal } from '..';
 import { DateTimeFormat } from './intl';
 import type { ZonedDateTimeParams as Params, ZonedDateTimeReturn as Return } from './internaltypes';
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,6 +26,7 @@
     "stripInternal": true,
     "target": "es2020",
     "outDir": "tsc-out/",
-    "types": []
+    "types": [],
+    "importsNotUsedAsValues": "error"
   }
 }


### PR DESCRIPTION
Closes  #117

Updates type-only imports in the TypeScript source code, and turns on a typescript rule to show an error if any new imports in the old format are introduced.