### PR TITLE
Fix `TimeZone.p.getXxxTransition()` worst-case perf

### DIFF
--- a/lib/ecmascript.ts
+++ b/lib/ecmascript.ts
@@ -88,7 +88,10 @@ const NS_MIN = JSBI.multiply(JSBI.BigInt(-86400), JSBI.BigInt(1e17));
 const NS_MAX = JSBI.multiply(JSBI.BigInt(86400), JSBI.BigInt(1e17));
 const YEAR_MIN = -271821;
 const YEAR_MAX = 275760;
-const BEFORE_FIRST_DST = JSBI.multiply(JSBI.BigInt(-388152), JSBI.BigInt(1e13)); // 1847-01-01T00:00:00Z
+const BEFORE_FIRST_OFFSET_TRANSITION = JSBI.multiply(JSBI.BigInt(-388152), JSBI.BigInt(1e13)); // 1847-01-01T00:00:00Z
+const ABOUT_TEN_YEARS_NANOS = JSBI.multiply(DAY_NANOS, JSBI.BigInt(366 * 10));
+const ABOUT_ONE_YEAR_NANOS = JSBI.multiply(DAY_NANOS, JSBI.BigInt(366 * 1));
+const TWO_WEEKS_NANOS = JSBI.multiply(DAY_NANOS, JSBI.BigInt(2 * 7));
 
 function IsInteger(value: unknown): value is number {
   if (typeof value !== 'number' || !NumberIsFinite(value)) return false;
@@ -2835,14 +2838,45 @@ export function GetIANATimeZoneDateTimeParts(epochNanoseconds: JSBI, id: string)
   return BalanceISODateTime(year, month, day, hour, minute, second, millisecond, microsecond, nanosecond);
 }
 
-export function GetIANATimeZoneNextTransition(epochNanoseconds: JSBI, id: string) {
-  const uppercap = JSBI.add(SystemUTCEpochNanoSeconds(), JSBI.multiply(DAY_NANOS, JSBI.BigInt(366)));
-  let leftNanos = epochNanoseconds;
+function maxJSBI(one: JSBI, two: JSBI) {
+  return JSBI.lessThan(one, two) ? two : one;
+}
+
+/**
+ * Our best guess at how far in advance new rules will be put into the TZDB for
+ * future offset transitions. We'll pick 10 years but can always revise it if
+ * we find that countries are being unusually proactive in their announcing
+ * of offset changes.
+ */
+function afterLatestPossibleTzdbRuleChange() {
+  return JSBI.add(SystemUTCEpochNanoSeconds(), ABOUT_TEN_YEARS_NANOS);
+}
+
+export function GetIANATimeZoneNextTransition(epochNanoseconds: JSBI, id: string): JSBI | null {
+  // Decide how far in the future after `epochNanoseconds` we'll look for an
+  // offset change. There are two cases:
+  // 1. If it's a past date (or a date in the near future) then it's possible
+  //    that the time zone may have newly added DST in the next few years. So
+  //    we'll have to look from the provided time until a few years after the
+  //    current system time. (Changes to DST policy are usually announced a few
+  //    years in the future.) Note that the first DST anywhere started in 1847,
+  //    so we'll start checks in 1847 instead of wasting cycles on years where
+  //    there will never be transitions.
+  // 2. If it's a future date beyond the next few years, then we'll just assume
+  //    that the latest DST policy in TZDB will still be in effect.  In this
+  //    case, we only need to look one year in the future to see if there are
+  //    any DST transitions.  We actually only need to look 9-10 months because
+  //    DST has two transitions per year, but we'll use a year just to be safe.
+  const oneYearLater = JSBI.add(epochNanoseconds, ABOUT_ONE_YEAR_NANOS);
+  const uppercap = maxJSBI(afterLatestPossibleTzdbRuleChange(), oneYearLater);
+  // The first transition (in any timezone) recorded in the TZDB was in 1847, so
+  // start there if an earlier date is supplied.
+  let leftNanos = maxJSBI(BEFORE_FIRST_OFFSET_TRANSITION, epochNanoseconds);
   const leftOffsetNs = GetIANATimeZoneOffsetNanoseconds(leftNanos, id);
   let rightNanos = leftNanos;
   let rightOffsetNs = leftOffsetNs;
   while (leftOffsetNs === rightOffsetNs && JSBI.lessThan(JSBI.BigInt(leftNanos), uppercap)) {
-    rightNanos = JSBI.add(leftNanos, JSBI.multiply(DAY_NANOS, JSBI.BigInt(2 * 7)));
+    rightNanos = JSBI.add(leftNanos, TWO_WEEKS_NANOS);
     rightOffsetNs = GetIANATimeZoneOffsetNanoseconds(rightNanos, id);
     if (leftOffsetNs === rightOffsetNs) {
       leftNanos = rightNanos;
@@ -2859,20 +2893,50 @@ export function GetIANATimeZoneNextTransition(epochNanoseconds: JSBI, id: string
   return result;
 }
 
-export function GetIANATimeZonePreviousTransition(epochNanoseconds: JSBI, id: string) {
-  const lowercap = BEFORE_FIRST_DST; // 1847-01-01T00:00:00Z
+export function GetIANATimeZonePreviousTransition(epochNanoseconds: JSBI, id: string): JSBI | null {
+  // If a time zone uses DST (at the time of `epochNanoseconds`), then we only
+  // have to look back one year to find a transition. But if it doesn't use DST,
+  // then we need to look all the way back to 1847 (the earliest rule in the
+  // TZDB) to see if it had other offset transitions in the past. Looping back
+  // from a far-future date to 1847 is very slow (minutes of 100% CPU!), and is
+  // also unnecessary because DST rules aren't put into the TZDB more than a few
+  // years in the future because the political changes in time zones happen with
+  // only a few years' warning. Therefore, if a far-future date is provided,
+  // then we'll run the check in two parts:
+  // 1. First, we'll look back for up to one year to see if the latest TZDB
+  //    rules have DST.
+  // 2. If not, then we'll "fast-reverse" back to a few years later than the
+  //    current system time, and then look back to 1847. This reduces the
+  //    worst-case loop from 273K years to 175 years, for a ~1500x improvement
+  //    in worst-case perf.
+  const afterLatestRule = afterLatestPossibleTzdbRuleChange();
+  const isFarFuture = JSBI.greaterThan(epochNanoseconds, afterLatestRule);
+  const lowercap = isFarFuture ? JSBI.subtract(epochNanoseconds, ABOUT_ONE_YEAR_NANOS) : BEFORE_FIRST_OFFSET_TRANSITION;
   let rightNanos = JSBI.subtract(epochNanoseconds, ONE);
   const rightOffsetNs = GetIANATimeZoneOffsetNanoseconds(rightNanos, id);
   let leftNanos = rightNanos;
   let leftOffsetNs = rightOffsetNs;
   while (rightOffsetNs === leftOffsetNs && JSBI.greaterThan(rightNanos, lowercap)) {
-    leftNanos = JSBI.subtract(rightNanos, JSBI.multiply(DAY_NANOS, JSBI.BigInt(2 * 7)));
+    leftNanos = JSBI.subtract(rightNanos, TWO_WEEKS_NANOS);
     leftOffsetNs = GetIANATimeZoneOffsetNanoseconds(leftNanos, id);
     if (rightOffsetNs === leftOffsetNs) {
       rightNanos = leftNanos;
     }
   }
-  if (rightOffsetNs === leftOffsetNs) return null;
+  if (rightOffsetNs === leftOffsetNs) {
+    if (isFarFuture) {
+      // There was no DST after looking back one year, which means that the most
+      // recent TZDB rules don't have any recurring transitions. To check for
+      // transitions in older rules, back up to a few years after the current
+      // date and then look all the way back to 1847. Note that we move back one
+      // day from the latest possible rule so that when the recursion runs it
+      // won't consider the new time to be "far future" because the system clock
+      // has advanced in the meantime.
+      const newTimeToCheck = JSBI.subtract(afterLatestRule, DAY_NANOS);
+      return GetIANATimeZonePreviousTransition(newTimeToCheck, id);
+    }
+    return null;
+  }
   const result = bisect(
     (epochNs: JSBI) => GetIANATimeZoneOffsetNanoseconds(epochNs, id),
     leftNanos,


### PR DESCRIPTION
When passed very far-past or very far-future dates,`TimeZone.p.get(Next|Previous)Transition()` currently takes minutes of 100% CPU to finish because those methods include a loop that makes expensive system calls for every 2 weeks until it finds a transition. For periods where there are no transitions, this loop will run millions of times which is time consuming.

Note that native implementations have access to the TZDB data directly so this is not an issue there. We could in theory bundle TZDB data (or simply bundle a shorter list of per-timezone data showing the earliest and oldest TZDB rules for each) but doing so would add a lot of complexity (and at least some bundle size) to this polyfill for minimal benefit, so solving the problem with optimization is, IMHO, preferable.  

This PR improves worst-case perf ~1500x by:
* Skipping looping for any dates before 1847 CE, which is the first entry in the TZDB.
* Optimizing handling of dates 10 years or later than the current system time. Offset changes are only planned a few years in advance, so when provided a far-future date, we only need to check one year away to see if there's DST projected forward from the most recent rule in that TZ. If there's not, then when calling `getNextTransition` we know there's no transitions (and can return `null`) and when calling `getPreviousTransition` we can skip all the way back to current time + 10 years because we know that no transitions will be in the skipped period.

These optimizations reduce a worst-case loop of 273K years to 175 years, or about 1500x faster.  That translates to a worst-case call time of ~80ms on my older MacBook Pro, which is still not great but is probably good enough for now given this is a corner case of an unusual API.

Fixes #60.