### PR TITLE
Port recent changes from tc39/proposal-temporal.

### DIFF
--- a/lib/calendar.ts
+++ b/lib/calendar.ts
@@ -141,6 +141,7 @@ export class Calendar implements Temporal.Calendar {
     }
   }
   get id(): Return['id'] {
+    if (!ES.IsTemporalCalendar(this)) throw new TypeError('invalid receiver');
     return ES.ToString(this);
   }
   dateFromFields(
@@ -334,6 +335,7 @@ export class Calendar implements Temporal.Calendar {
     return GetSlot(this, CALENDAR_ID);
   }
   toJSON(): Return['toJSON'] {
+    if (!ES.IsTemporalCalendar(this)) throw new TypeError('invalid receiver');
     return ES.ToString(this);
   }
   static from(item: Params['from'][0]): Return['from'] {

--- a/lib/ecmascript.ts
+++ b/lib/ecmascript.ts
@@ -324,6 +324,7 @@ function ParseISODateTime(isoString: string) {
   if (!match) throw new RangeError(`invalid ISO 8601 string: ${isoString}`);
   let yearString = match[1];
   if (yearString[0] === '\u2212') yearString = `-${yearString.slice(1)}`;
+  if (yearString === '-000000') throw new RangeError(`invalid ISO 8601 string: ${isoString}`);
   const year = ToInteger(yearString);
   const month = ToInteger(match[2] || match[4]);
   const day = ToInteger(match[3] || match[5]);
@@ -451,6 +452,7 @@ function ParseTemporalYearMonthString(isoString: string) {
   if (match) {
     let yearString = match[1];
     if (yearString[0] === '\u2212') yearString = `-${yearString.slice(1)}`;
+    if (yearString === '-000000') throw new RangeError(`invalid ISO 8601 string: ${isoString}`);
     year = ToInteger(yearString);
     month = ToInteger(match[2]);
     calendar = match[3];

--- a/lib/timezone.ts
+++ b/lib/timezone.ts
@@ -43,6 +43,7 @@ export class TimeZone implements Temporal.TimeZone {
     }
   }
   get id(): Return['id'] {
+    if (!ES.IsTemporalTimeZone(this)) throw new TypeError('invalid receiver');
     return ES.ToString(this);
   }
   getOffsetNanosecondsFor(instantParam: Params['getOffsetNanosecondsFor'][0]): Return['getOffsetNanosecondsFor'] {
@@ -150,6 +151,7 @@ export class TimeZone implements Temporal.TimeZone {
     return ES.ToString(GetSlot(this, TIMEZONE_ID));
   }
   toJSON(): Return['toJSON'] {
+    if (!ES.IsTemporalTimeZone(this)) throw new TypeError('invalid receiver');
     return ES.ToString(this);
   }
   static from(item: Params['from'][0]): Return['from'] {


### PR DESCRIPTION
Add missing branding checks for Timezone and Calendar toString and toJSON.
Port of https://github.com/tc39/proposal-temporal/pull/1995.

Reject '-000000' as an extended year value.
Port of https://github.com/tc39/proposal-temporal/pull/1992

Bump test262.

