### PR TITLE
Add types to exports/./import to support Typescript Node16

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,10 @@
   "exports": {
     ".": [
       {
-        "import": "./dist/index.esm.js",
+        "import": {
+          "types": "./index.d.ts",
+          "default": "./dist/index.esm.js"
+        },
         "default": "./dist/index.cjs"
       },
       "./dist/index.cjs"


### PR DESCRIPTION
Before this Typescript would fail to resolve the types for the package when configured to use module: "Node16" (new in Typescript 4.7).

`main.ts:1:26 - error TS7016: Could not find a declaration file for module '@js-temporal/polyfill'.`

Repro available at https://github.com/jonasb/typescript-error-repro/tree/typescript-4.7-esm-node16-js-temporal