### PR TITLE
Add BigInt bundle

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@js-temporal/polyfill",
-  "version": "0.3.0",
+  "version": "0.4.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@js-temporal/polyfill",
-      "version": "0.3.0",
+      "version": "0.4.1",
       "license": "ISC",
       "dependencies": {
         "jsbi": "^4.1.0",
@@ -25,6 +25,7 @@
         "@rollup/plugin-typescript": "^8.3.0",
         "@typescript-eslint/eslint-plugin": "^5.7.0",
         "@typescript-eslint/parser": "^5.7.0",
+        "babel-plugin-transform-jsbi-to-bigint": "^1.4.0",
         "eslint": "^8.4.1",
         "eslint-config-prettier": "^8.3.0",
         "eslint-plugin-prettier": "^4.0.0",
@@ -2268,6 +2269,15 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/babel-plugin-transform-jsbi-to-bigint": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-jsbi-to-bigint/-/babel-plugin-transform-jsbi-to-bigint-1.4.0.tgz",
+      "integrity": "sha512-59f6ClwQBY/SKMVwKV/xoAqH/gnyZ6C5gSSPsEUCLPvvZULCDSE5Y3T62wjNTbpBcFzh0ReYz2mIe3u44mW9UQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/backo2": {
@@ -7066,6 +7076,12 @@
       "requires": {
         "@babel/helper-define-polyfill-provider": "^0.3.0"
       }
+    },
+    "babel-plugin-transform-jsbi-to-bigint": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-jsbi-to-bigint/-/babel-plugin-transform-jsbi-to-bigint-1.4.0.tgz",
+      "integrity": "sha512-59f6ClwQBY/SKMVwKV/xoAqH/gnyZ6C5gSSPsEUCLPvvZULCDSE5Y3T62wjNTbpBcFzh0ReYz2mIe3u44mW9UQ==",
+      "dev": true
     },
     "backo2": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
         "default": "./dist/index.cjs"
       },
       "./dist/index.cjs"
-    ]
+    ],
+    "./bigint": "./dist/bigint/index.esm.js"
   },
   "types": "./index.d.ts",
   "scripts": {
@@ -90,6 +91,7 @@
     "@rollup/plugin-typescript": "^8.3.0",
     "@typescript-eslint/eslint-plugin": "^5.7.0",
     "@typescript-eslint/parser": "^5.7.0",
+    "babel-plugin-transform-jsbi-to-bigint": "^1.4.0",
     "eslint": "^8.4.1",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-prettier": "^4.0.0",


### PR DESCRIPTION
Related: #155

For the environments that have native bigint support, This PR will add an subpath export with a separate native bigint build. As far as I believe this shouldn't change/affect existing exports/builds. You can import the bigint build as follows:

```
import { Temporal } from '@js-temporal/polyfill/bigint'
```