### PR TITLE
Fixed a possible type error if higher TS version is used in the future.

### DIFF
--- a/lib/intl.ts
+++ b/lib/intl.ts
@@ -172,7 +172,7 @@ DateTimeFormatImpl.supportedLocalesOf = function (
   return IntlDateTimeFormat.supportedLocalesOf(locales, options as globalThis.Intl.DateTimeFormatOptions);
 };
 
-const propertyDescriptors: Partial<Record<keyof Intl.DateTimeFormat, PropertyDescriptor>>  = {
+const propertyDescriptors: Partial<Record<keyof Intl.DateTimeFormat, PropertyDescriptor>> = {
   resolvedOptions: descriptor(resolvedOptions),
   format: descriptor(format),
   formatRange: descriptor(formatRange)


### PR DESCRIPTION
Just found a possible small type error. In the current TS version, its type is considered as `Partial<any>` so it's not an error for now, but the type may be not correct actually and I guess it may become a type error in the future.