### PR TITLE
Editorial: Simplify operations (#2248)

### DIFF
--- a/lib/calendar.ts
+++ b/lib/calendar.ts
@@ -237,12 +237,8 @@ export class Calendar implements Temporal.Calendar {
     const one = ES.ToTemporalDate(oneParam);
     const two = ES.ToTemporalDate(twoParam);
     const options = ES.GetOptionsObject(optionsParam);
-    const largestUnit = ES.ToLargestTemporalUnit(
-      options,
-      'auto',
-      ['hour', 'minute', 'second', 'millisecond', 'microsecond', 'nanosecond'] as const,
-      'day'
-    );
+    let largestUnit = ES.GetTemporalUnit(options, 'largestUnit', 'date', 'auto');
+    if (largestUnit === 'auto') largestUnit = 'day';
     const { years, months, weeks, days } = impl[GetSlot(this, CALENDAR_ID)].dateUntil(one, two, largestUnit);
     const Duration = GetIntrinsic('%Temporal.Duration%');
     return new Duration(years, months, weeks, days, 0, 0, 0, 0, 0, 0);

--- a/lib/ecmascript.ts
+++ b/lib/ecmascript.ts
@@ -5938,14 +5938,15 @@ export function CreateOnePropObject<K extends string, V>(propName: K, propValue:
   return o;
 }
 
-function GetOption<P extends string, O extends Partial<Record<P, unknown>>>(
+type StringlyTypedKeys<T> = Exclude<keyof T, symbol | number>;
+function GetOption<P extends StringlyTypedKeys<O>, O extends Partial<Record<P, unknown>>>(
   options: O,
   property: P,
   allowedValues: ReadonlyArray<O[P]>,
   fallback: undefined
 ): O[P];
 function GetOption<
-  P extends string,
+  P extends StringlyTypedKeys<O>,
   O extends Partial<Record<P, unknown>>,
   Fallback extends Required<O>[P] | undefined
 >(
@@ -5955,7 +5956,7 @@ function GetOption<
   fallback: Fallback
 ): Fallback extends undefined ? O[P] | undefined : Required<O>[P];
 function GetOption<
-  P extends string,
+  P extends StringlyTypedKeys<O>,
   O extends Partial<Record<P, unknown>>,
   Fallback extends Required<O>[P] | undefined
 >(
@@ -5975,7 +5976,7 @@ function GetOption<
   return fallback;
 }
 
-function GetNumberOption<P extends string, T extends Partial<Record<P, unknown>>>(
+function GetNumberOption<P extends StringlyTypedKeys<T>, T extends Partial<Record<P, unknown>>>(
   options: T,
   property: P,
   minimum: number,
@@ -5986,7 +5987,7 @@ function GetNumberOption<P extends string, T extends Partial<Record<P, unknown>>
   if (valueRaw === undefined) return fallback;
   const value = ToNumber(valueRaw);
   if (NumberIsNaN(value) || value < minimum || value > maximum) {
-    throw new RangeError(`${property} must be between ${minimum} and ${maximum}, not ${value}`);
+    throw new RangeError(`${String(property)} must be between ${minimum} and ${maximum}, not ${value}`);
   }
   return MathFloor(value);
 }

--- a/lib/instant.ts
+++ b/lib/instant.ts
@@ -76,9 +76,7 @@ export class Instant implements Temporal.Instant {
       typeof optionsParam === 'string'
         ? (ES.CreateOnePropObject('smallestUnit', optionsParam) as Exclude<typeof optionsParam, string>)
         : ES.GetOptionsObject(optionsParam);
-    const DISALLOWED_UNITS = ['year', 'month', 'week', 'day'] as const;
-    const smallestUnit = ES.ToSmallestTemporalUnit(options, undefined, DISALLOWED_UNITS);
-    if (smallestUnit === undefined) throw new RangeError('smallestUnit is required');
+    const smallestUnit = ES.GetTemporalUnit(options, 'smallestUnit', 'time', ES.REQUIRED);
     const roundingMode = ES.ToTemporalRoundingMode(options, 'halfExpand');
     const maximumIncrements = {
       hour: 24,

--- a/lib/plaindatetime.ts
+++ b/lib/plaindatetime.ts
@@ -295,8 +295,7 @@ export class PlainDateTime implements Temporal.PlainDateTime {
       typeof optionsParam === 'string'
         ? (ES.CreateOnePropObject('smallestUnit', optionsParam) as Exclude<typeof optionsParam, string>)
         : ES.GetOptionsObject(optionsParam);
-    const smallestUnit = ES.ToSmallestTemporalUnit(options, undefined, ['year', 'month', 'week']);
-    if (smallestUnit === undefined) throw new RangeError('smallestUnit is required');
+    const smallestUnit = ES.GetTemporalUnit(options, 'smallestUnit', 'time', ES.REQUIRED, ['day']);
     const roundingMode = ES.ToTemporalRoundingMode(options, 'halfExpand');
     const maximumIncrements = {
       day: 1,

--- a/lib/plaintime.ts
+++ b/lib/plaintime.ts
@@ -186,9 +186,7 @@ export class PlainTime implements Temporal.PlainTime {
       typeof optionsParam === 'string'
         ? (ES.CreateOnePropObject('smallestUnit', optionsParam) as Exclude<typeof optionsParam, string>)
         : ES.GetOptionsObject(optionsParam);
-    const DISALLOWED_UNITS = ['year', 'month', 'week', 'day'] as const;
-    const smallestUnit = ES.ToSmallestTemporalUnit(options, undefined, DISALLOWED_UNITS);
-    if (smallestUnit === undefined) throw new RangeError('smallestUnit is required');
+    const smallestUnit = ES.GetTemporalUnit(options, 'smallestUnit', 'time', ES.REQUIRED);
     const roundingMode = ES.ToTemporalRoundingMode(options, 'halfExpand');
     const MAX_INCREMENTS = {
       hour: 24,

--- a/lib/zoneddatetime.ts
+++ b/lib/zoneddatetime.ts
@@ -357,8 +357,7 @@ export class ZonedDateTime implements Temporal.ZonedDateTime {
       typeof optionsParam === 'string'
         ? (ES.CreateOnePropObject('smallestUnit', optionsParam) as Exclude<typeof optionsParam, string>)
         : ES.GetOptionsObject(optionsParam);
-    const smallestUnit = ES.ToSmallestTemporalUnit(options, undefined, ['year', 'month', 'week']);
-    if (smallestUnit === undefined) throw new RangeError('smallestUnit is required');
+    const smallestUnit = ES.GetTemporalUnit(options, 'smallestUnit', 'time', ES.REQUIRED, ['day']);
     const roundingMode = ES.ToTemporalRoundingMode(options, 'halfExpand');
     const maximumIncrements = {
       day: 1,


### PR DESCRIPTION
Similar to other rebases, I intend for this to be merged as-is without squashing.

The typing for GetTemporalUnit is interesting - ideally, I'd like to find a way to avoid all the casts within the function itself and avoid needing overloads, but I can't seem to get TS to recognize that when the default empty array (typed as `never[]`) is used as the `extraValues` property that it expands to `never` in the return type (which is the union identity).