### PR TITLE
Bail out early in non-ISO Calendars when calculating the duration

### DIFF
--- a/lib/calendar.ts
+++ b/lib/calendar.ts
@@ -1131,6 +1131,9 @@ abstract class HelperBase {
         const diffMonths = calendarTwo.month - calendarOne.month;
         const diffDays = calendarTwo.day - calendarOne.day;
         const sign = this.compareCalendarDates(calendarTwo, calendarOne);
+        if (!sign) {
+          return { years: 0, months: 0, weeks: 0, days: 0 };
+        }
         if (largestUnit === 'year' && diffYears) {
           const isOneFurtherInYear = diffMonths * sign < 0 || (diffMonths === 0 && diffDays * sign < 0);
           years = isOneFurtherInYear ? diffYears - sign : diffYears;

--- a/test/calendar.mjs
+++ b/test/calendar.mjs
@@ -404,6 +404,10 @@ describe('Built-in calendars (not standardized yet)', () => {
       const date = Temporal.PlainDate.from({ era: 'bce', eraYear: 2, month: 12, day: 31, calendar: 'gregory' });
       equal(`${date}`, '-000001-12-31[u-ca=gregory]');
     });
+    it('does not infinite loop', () => {
+      const nowZoned = Temporal.Now.zonedDateTime('gregory');
+      equal(Temporal.Duration.from('PT0S').total({ unit: 'years', relativeTo: nowZoned }), 0);
+    });
   });
 });
 


### PR DESCRIPTION
between two identical dates.

Fixes #180.