### PR TITLE
Fix sourcemap warnings in VSCode debugger

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "index.d.cts",
     "dist",
     "lib",
+    "tsc-out",
     "CHANGELOG.md"
   ],
   "dependencies": {


### PR DESCRIPTION
Fixes #192. by adding the `tsc-out` folder to the package, which will solve the sourcemap warnings you'll see in VSCode in the debugger console. 

It's possible that there may be some other way to fix sourcemaps without making the package larger, but at least in the meantime we can fix the debugger console warnings while we look for a better solution if one exists. 