### PR TITLE
Support Deno.customInspect for better debugging in Deno

### DIFF
--- a/lib/intrinsicclass.ts
+++ b/lib/intrinsicclass.ts
@@ -88,12 +88,14 @@ export function MakeIntrinsicClass(
     configurable: true
   });
   if (DEBUG) {
-    Object.defineProperty(Class.prototype, Symbol.for('nodejs.util.inspect.custom'), {
-      value: customUtilInspectFormatters[name] || defaultUtilInspectFormatter,
-      writable: false,
-      enumerable: false,
-      configurable: true
-    });
+    for (const symbolName of ['nodejs.util.inspect.custom', 'Deno.customInspect']) {
+      Object.defineProperty(Class.prototype, Symbol.for(symbolName), {
+        value: customUtilInspectFormatters[name] || defaultUtilInspectFormatter,
+        writable: false,
+        enumerable: false,
+        configurable: true
+      });
+    }
   }
   for (const prop of Object.getOwnPropertyNames(Class)) {
     // we know that `prop` is present, so the descriptor is never undefined


### PR DESCRIPTION
`Deno.customInspect` is not currently supported, which causes logging of `Temporal` objects in Deno to be pretty unhelpful. Before:

```ts
console.log(Temporal.Now.instant())
// Temporal.Instant {}
```

This PR adds support for this in the same way as `nodejs.util.inspect.custom` is supported for Node. After:

```ts
console.log(Temporal.Now.instant())
// Temporal.Instant <2023-02-28T12:00:20.232618577Z>
```