### PR TITLE
Temporarily work around Test262 tests broken by V8 bug #1416538

### DIFF
--- a/runtest262.mjs
+++ b/runtest262.mjs
@@ -29,6 +29,8 @@ yargs(hideBin(process.argv))
       const nodeVersion = parseInt(process.versions.node.split('.')[0]);
       if (nodeVersion < 18) expectedFailureFiles.push('test/expected-failures-before-node18.txt');
       if (nodeVersion < 16) expectedFailureFiles.push('test/expected-failures-before-node16.txt');
+      // Eventually this should be fixed and this condition should be updated.
+      if (nodeVersion >= 18) expectedFailureFiles.push('test/expected-failures-cldr42.txt');
 
       // As we migrate commits from proposal-temporal, remove expected failures from here.
       expectedFailureFiles.push('test/expected-failures-todo-migrated-code.txt');

--- a/test/expected-failures-cldr42.txt
+++ b/test/expected-failures-cldr42.txt
@@ -1,0 +1,13 @@
+# Failures in this file are expected to fail for all Test262 tests. To record
+# expected test failures for the transpiled or optimized builds of the polyfill,
+# see expected-failures-es5.txt and expected-failures-opt.txt respectively.
+
+# # A regression in V8 (https://bugs.chromium.org/p/chromium/issues/detail?id=1416538)
+# caused these tests to fail. We don't know when a fix is expected, but when it's fixed then
+# these tests should start passing again.
+staging/Intl402/Temporal/old/date-time-format.js
+staging/Intl402/Temporal/old/datetime-toLocaleString.js
+staging/Intl402/Temporal/old/instant-toLocaleString.js
+staging/Intl402/Temporal/old/time-toLocaleString.js
+staging/Intl402/Temporal/old/zoneddatetime-toLocaleString.js
+intl402/DateTimeFormat/prototype/format/temporal-objects-resolved-time-zone.js

--- a/test/expected-failures.txt
+++ b/test/expected-failures.txt
@@ -2,4 +2,3 @@
 # expected test failures for the transpiled or optimized builds of the polyfill,
 # see expected-failures-es5.txt and expected-failures-opt.txt respectively.
 
-# https://github.com/tc39/test262/pull/3548


### PR DESCRIPTION
V8 broke Test262 by releasing a regression that caused the output of `Intl.DateTimeFormat.p.format` to differ from `Intl.DateTimeFormat.p.format`. See https://bugs.chromium.org/p/chromium/issues/detail?id=1416538.

Until V8 fixes itself and those fixes get into CI, we'll skip the now-broken tests. 