### PR TITLE
Simplify some redundant BigInt operations.

### DIFF
--- a/lib/legacydate.ts
+++ b/lib/legacydate.ts
@@ -1,11 +1,10 @@
 import { Instant } from './instant';
 
 import JSBI from 'jsbi';
-import * as ES from './ecmascript';
 import { MILLION } from './ecmascript';
 
 export function toTemporalInstant(this: Date) {
   // Observable access to valueOf is not correct here, but unavoidable
   const epochNanoseconds = JSBI.multiply(JSBI.BigInt(+this), MILLION);
-  return new Instant(ES.ToBigInt(epochNanoseconds));
+  return new Instant(epochNanoseconds);
 }


### PR DESCRIPTION
ToBigInt is somewhat redundant with the JSBI.BigInt function (which implements the BigInt constructor behavior).

The ToBigInt conversion in ToTemporalInstant is unnecessary as JSBI.multiply will always return a JSBI, and this is passed to the ToBigInt AO as part of the Temporal.Instant constructor ([spec ref](https://tc39.es/proposal-temporal/#sec-temporal.instant)).