### PR TITLE
Improvements to rebase tool.

### DIFF
--- a/tools/rebase-upstream-commits.ts
+++ b/tools/rebase-upstream-commits.ts
@@ -612,9 +612,9 @@ Prefer using this tool's commands to finish the rebase (either via "continue",
 up.
 
 This tool runs any git commands that might have interactivity directly, and so
-lots of the output printed when running tool commands will actually be from git
-, not from this tool. To make it easy to distinguish the two, any output this
-tool prints is prefixed with [Temporal Rebase Tool].
+lots of the output printed when running tool commands will actually be from
+git, not from this tool. To make it easy to distinguish the two, any output
+this tool prints is prefixed with [Temporal Rebase Tool].
 `);
     }
   )

--- a/tools/rebase-upstream-commits.ts
+++ b/tools/rebase-upstream-commits.ts
@@ -308,8 +308,12 @@ share history and git doesn't think they are at all similar.
 
 To resolve this conflict you will need to manually inspect and re-apply
 changes from polyfill/lib/ecmascript.mjs over to lib/ecmascript.ts. Once
-done, remove polyfill/lib/ecmascript.mjs (using git rm) and add the new
-changes to lib/ecmascript.ts (using git add).
+done, remove the mjs file from the commit using:
+  git rm polyfill/lib/ecmascript.mjs
+Then stage the TS version of that file using:
+  git add lib/ecmascript.ts 
+At that point, after any other changes are staged too, you can:
+  trt continue
 
 Tip: to see the changes the upstream commit introduced, try running
 \`<this tool> basediff -U40 polyfill/lib/ecmascript.mjs\`.


### PR DESCRIPTION
This addresses some of the points raised in #236:

- Includes an explanation of how to handle updates to polyfill/lib/ecmascript.mjs from upstream
- new abort and finish commands that help end rebasing prematurely, throwing away or keeping your current rebase progress respectively.
-  > When a commit only updates the spec (no polyfill files) the tool still stopped.
   This was a bug in the way calls to `git rebase --continue` were being handled - handling is now centralized to be consistent.
- The tool will attempt to clean up the `.temporal_rebase_tool` folder it creates when it thinks the rebase is done.
- Test262 no-op update handling might have improved - we check to see if the upstream submodule is changing before running the "handle test262 cases" logic, but I'm not 100% that will fix all the problems.
 - some more docs on what commands are useful during rebases
 - better delineation between what parts of the tool output are actually from underlying git command invocations and what parts are the tool itself. 