### PR TITLE
Support Node 20 and work around Node 20 / ICU 73.1 bug

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,10 +5,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: use node.js v19.x
+      - name: use node.js v20.x
         uses: actions/setup-node@v1
         with:
-          node-version: 19.x
+          node-version: 20.x
       - run: node --version
       - run: npm ci --no-optional
       - run: npx tsc --version
@@ -17,9 +17,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: use node.js v19.x
+      - name: use node.js v20.x
         uses: actions/setup-node@v1
         with:
-          node-version: 19.x
+          node-version: 20.x
       - run: npm ci --no-optional
       - run: npm run prune

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [19.x, 18.x, 16.x, 14.x]
+        version: [20.x, 18.x, 16.x, 14.x]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [19.x, 18.x, 16.x, 14.x]
+        version: [20.x, 18.x, 16.x, 14.x]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -41,7 +41,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [19.x, 18.x, 16.x, 14.x]
+        version: [20.x, 18.x, 16.x, 14.x]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -59,7 +59,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [19.x, 18.x, 16.x, 14.x]
+        version: [20.x, 18.x, 16.x, 14.x]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -78,10 +78,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: use node.js v19.x
+      - name: use node.js v20.x
         uses: actions/setup-node@v1
         with:
-          node-version: 19.x
+          node-version: 20.x
       - run: npm ci
       - run: |
           npm ci


### PR DESCRIPTION
Work around an ICU 73.1 bug (https://bugs.chromium.org/p/chromium/issues/detail?id=1173158) that was causing Test262 tests to fail. The workaround simply avoids using Intl.DateTimeFormat for Gregorian-based calendars, which enables these calendars to work properly for dates before the 1582-10-15 Gregorian switchover while also using less RAM and CPU.

This PR is stacked on top of #258, so you only need to review the top commit in this PR.

We'll wait to merge this until the corresponding Test262 PR (https://github.com/tc39/test262/pull/3848) is merged and this PR can be rebased on top of that one. 