### PR TITLE
export ./lib folder from npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
         "default": "./dist/index.cjs"
       },
       "./dist/index.cjs"
-    ]
+    ],
+    "./lib/": "./lib/"
   },
   "types": "./index.d.ts",
   "scripts": {


### PR DESCRIPTION
Hello 👋 ,
the `lib` folder is part of the npm package as configured in the package.json field `files`. However it is not accessible unless listed in the `exports` field. Currently I have to override my bundlers dependency resolution to access the folder's contents.