### PR TITLE
Set package sideEffects to `false`

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
       "./dist/index.cjs"
     ]
   },
+  "sideEffects": false,
   "types": "./index.d.ts",
   "scripts": {
     "test": "npm run build && node --no-warnings --experimental-modules --experimental-specifier-resolution=node --icu-data-dir node_modules/full-icu --loader ./test/resolve.source.mjs ./test/all.mjs",


### PR DESCRIPTION
Allows bundlers to tree-shake out the temporal polyfill when it is imported but not used.

If (or when) in the future the polyfill patches the global object `"sideEffects"` may be changed to an array to declare the side effects of a specific entry (e.g. `@js-temporal/polyfill/global` has side effects while other entry points do not).