### PR TITLE
Update as of November 2023

### DIFF
--- a/lib/ecmascript.ts
+++ b/lib/ecmascript.ts
@@ -5722,7 +5722,10 @@ function AddDuration(
     const TemporalInstant = GetIntrinsic('%Temporal.Instant%');
     const calendar = GetSlot(zonedRelativeTo, CALENDAR);
     const startInstant = GetSlot(zonedRelativeTo, INSTANT);
-    const startDateTime = precalculatedPlainDateTime ?? GetPlainDateTimeFor(timeZoneRec, startInstant, calendar);
+    let startDateTime = precalculatedPlainDateTime;
+    if (largestUnit === 'year' || largestUnit === 'month' || largestUnit === 'week' || largestUnit === 'day') {
+      startDateTime ??= GetPlainDateTimeFor(timeZoneRec, startInstant, calendar);
+    }
     const intermediateNs = AddZonedDateTime(
       startInstant,
       timeZoneRec,

--- a/lib/instant.ts
+++ b/lib/instant.ts
@@ -8,6 +8,7 @@ import type { InstantParams as Params, InstantReturn as Return } from './interna
 
 import JSBI from 'jsbi';
 import { BILLION, MILLION, THOUSAND } from './ecmascript';
+import { TimeZoneMethodRecord } from './methodrecord';
 
 export class Instant implements Temporal.Instant {
   constructor(epochNanoseconds: bigint | JSBI) {
@@ -23,7 +24,8 @@ export class Instant implements Temporal.Instant {
     SetSlot(this, EPOCHNANOSECONDS, ns);
 
     if (DEBUG) {
-      const dateTime = ES.GetPlainDateTimeFor('ignored', this, 'iso8601', 0);
+      const ignored = new TimeZoneMethodRecord('UTC', []);
+      const dateTime = ES.GetPlainDateTimeFor(ignored, this, 'iso8601', 0);
       const repr = ES.TemporalDateTimeToString(dateTime, 'auto', 'never') + 'Z';
       Object.defineProperty(this, '_repr_', {
         value: `${this[Symbol.toStringTag]} <${repr}>`,

--- a/lib/internaltypes.d.ts
+++ b/lib/internaltypes.d.ts
@@ -198,8 +198,8 @@ export interface TimeZoneReturn extends MethodReturn<typeof Temporal.TimeZone> {
 export interface ZonedDateTimeReturn extends MethodReturn<typeof Temporal.ZonedDateTime> {}
 
 export interface CalendarProtocolParams extends InterfaceParams<Temporal.CalendarProtocol> {}
-export interface TimeZoneProtocolParams extends InterfaceParams<Temporal.TimeZoneProtocol> {}
 // UNUSED, BUT MAY USE LATER
+// export interface TimeZoneProtocolParams extends InterfaceParams<Temporal.TimeZoneProtocol> {}
 // export interface TimeZoneProtocolReturn extends InterfaceReturn<Temporal.TimeZoneProtocol> {}
 // export interface CalendarProtocolReturn extends InterfaceReturn<Temporal.CalendarProtocol> {}
 

--- a/lib/intl.ts
+++ b/lib/intl.ts
@@ -1,4 +1,5 @@
 import * as ES from './ecmascript';
+import { TimeZoneMethodRecord } from './methodrecord';
 import {
   GetSlot,
   ISO_YEAR,
@@ -480,8 +481,9 @@ function extractOverrides(temporalObj: Params['format'][0], main: DateTimeFormat
       nanosecond,
       'iso8601'
     );
+    const timeZoneRec = new TimeZoneMethodRecord(main[TZ_CANONICAL], ['getPossibleInstantsFor']);
     return {
-      instant: ES.GetInstantFor(main[TZ_CANONICAL], datetime, 'compatible'),
+      instant: ES.GetInstantFor(timeZoneRec, datetime, 'compatible'),
       formatter: getPropLazy(main, TIME)
     };
   }
@@ -497,8 +499,9 @@ function extractOverrides(temporalObj: Params['format'][0], main: DateTimeFormat
       );
     }
     const datetime = ES.CreateTemporalDateTime(isoYear, isoMonth, referenceISODay, 12, 0, 0, 0, 0, 0, calendar);
+    const timeZoneRec = new TimeZoneMethodRecord(main[TZ_CANONICAL], ['getPossibleInstantsFor']);
     return {
-      instant: ES.GetInstantFor(main[TZ_CANONICAL], datetime, 'compatible'),
+      instant: ES.GetInstantFor(timeZoneRec, datetime, 'compatible'),
       formatter: getPropLazy(main, YM)
     };
   }
@@ -514,8 +517,9 @@ function extractOverrides(temporalObj: Params['format'][0], main: DateTimeFormat
       );
     }
     const datetime = ES.CreateTemporalDateTime(referenceISOYear, isoMonth, isoDay, 12, 0, 0, 0, 0, 0, calendar);
+    const timeZoneRec = new TimeZoneMethodRecord(main[TZ_CANONICAL], ['getPossibleInstantsFor']);
     return {
-      instant: ES.GetInstantFor(main[TZ_CANONICAL], datetime, 'compatible'),
+      instant: ES.GetInstantFor(timeZoneRec, datetime, 'compatible'),
       formatter: getPropLazy(main, MD)
     };
   }
@@ -529,8 +533,9 @@ function extractOverrides(temporalObj: Params['format'][0], main: DateTimeFormat
       throw new RangeError(`cannot format PlainDate with calendar ${calendar} in locale with calendar ${main[CAL_ID]}`);
     }
     const datetime = ES.CreateTemporalDateTime(isoYear, isoMonth, isoDay, 12, 0, 0, 0, 0, 0, main[CAL_ID]);
+    const timeZoneRec = new TimeZoneMethodRecord(main[TZ_CANONICAL], ['getPossibleInstantsFor']);
     return {
-      instant: ES.GetInstantFor(main[TZ_CANONICAL], datetime, 'compatible'),
+      instant: ES.GetInstantFor(timeZoneRec, datetime, 'compatible'),
       formatter: getPropLazy(main, DATE)
     };
   }
@@ -542,8 +547,9 @@ function extractOverrides(temporalObj: Params['format'][0], main: DateTimeFormat
         `cannot format PlainDateTime with calendar ${calendar} in locale with calendar ${main[CAL_ID]}`
       );
     }
+    const timeZoneRec = new TimeZoneMethodRecord(main[TZ_CANONICAL], ['getPossibleInstantsFor']);
     return {
-      instant: ES.GetInstantFor(main[TZ_CANONICAL], temporalObj, 'compatible'),
+      instant: ES.GetInstantFor(timeZoneRec, temporalObj, 'compatible'),
       formatter: getPropLazy(main, DATETIME)
     };
   }

--- a/lib/intrinsicclass.ts
+++ b/lib/intrinsicclass.ts
@@ -43,7 +43,7 @@ type TemporalCalendarIntrinsicRegisteredKeys = {
   [key in keyof TemporalCalendarIntrinsicRegistrations as `%${key}%`]: TemporalCalendarIntrinsicRegistrations[key];
 };
 
-type TimeZonePrototypeKeys = 'getOffsetNanosecondsFor' | 'getPossibleInstantsFor';
+export type TimeZonePrototypeKeys = 'getOffsetNanosecondsFor' | 'getPossibleInstantsFor';
 type TemporalTimeZoneIntrinsicRegistrations = {
   [key in TimeZonePrototypeKeys as `Temporal.TimeZone.prototype.${key}`]: Temporal.TimeZone[key];
 } & {

--- a/lib/methodrecord.ts
+++ b/lib/methodrecord.ts
@@ -1,0 +1,92 @@
+import { GetIntrinsic } from './intrinsicclass';
+import type { Temporal } from '..';
+import type { TimeZonePrototypeKeys } from './intrinsicclass';
+
+type TimeZoneRecordInfo = {
+  Name: 'TimeZone';
+  Protocol: Temporal.TimeZoneProtocol;
+  MethodName: TimeZonePrototypeKeys;
+};
+
+// We switch off type checking when accessing the cached methods on this object.
+// It could be expressed properly in the type system, but we're just going to
+// remove this object later down the line in the rebase, so I'm not going to
+// spend a lot of effort on it.
+class MethodRecord<T extends TimeZoneRecordInfo> {
+  recordType: T['Name'];
+  receiver: string | T['Protocol'];
+
+  constructor(recordType: T['Name'], receiver: string | T['Protocol'], methodNames: T['MethodName'][]) {
+    this.recordType = recordType;
+    this.receiver = receiver;
+
+    const nMethods = methodNames.length;
+    for (let ix = 0; ix < nMethods; ix++) {
+      this.lookup(methodNames[ix]);
+    }
+  }
+
+  isBuiltIn() {
+    return typeof this.receiver === 'string';
+  }
+
+  hasLookedUp(methodName: T['MethodName']) {
+    // @ts-expect-error
+    return !!this[`_${methodName}`];
+  }
+
+  lookup(methodName: T['MethodName']) {
+    if (this.hasLookedUp(methodName)) {
+      throw new Error(`assertion failure: ${methodName} already looked up`);
+    }
+    if (typeof this.receiver === 'string') {
+      // @ts-expect-error
+      this[`_${methodName}`] = GetIntrinsic(`%Temporal.${this.recordType}.prototype.${methodName}%`);
+    } else {
+      // This is not expressed correctly in TypeScript; we should be able to
+      // express in the type system that T['MethodName'] can be used to index
+      // T['Protocol'], and use one of the GetMethod overloads. But as above,
+      // we're just going to remove this object later down the line in the
+      // rebase, so it's not worth spending the time.
+      // @ts-expect-error
+      const method = this.receiver[methodName];
+      if (!method) {
+        throw new TypeError(`${methodName} should be present on ${this.recordType}`);
+      }
+      if (typeof method !== 'function') {
+        throw new TypeError(`${methodName} must be a function`);
+      }
+      // @ts-expect-error
+      this[`_${methodName}`] = method;
+    }
+  }
+
+  call(methodName: T['MethodName'], args: any[]) {
+    if (!this.hasLookedUp(methodName)) {
+      throw new Error(`assertion failure: ${methodName} should have been looked up`);
+    }
+    let receiver = this.receiver;
+    if (typeof receiver === 'string') {
+      const cls = GetIntrinsic(`%Temporal.${this.recordType}%`);
+      const realObject = new cls(receiver);
+      // @ts-expect-error
+      return this[`_${methodName}`].apply(realObject, args);
+    }
+    // @ts-expect-error
+    return this[`_${methodName}`].apply(receiver, args);
+  }
+}
+
+export class TimeZoneMethodRecord extends MethodRecord<TimeZoneRecordInfo> {
+  constructor(timeZone: string | Temporal.TimeZoneProtocol, methodNames: TimeZonePrototypeKeys[] = []) {
+    super('TimeZone', timeZone, methodNames);
+  }
+
+  getOffsetNanosecondsFor(instant: Temporal.Instant) {
+    return this.call('getOffsetNanosecondsFor', [instant]);
+  }
+
+  getPossibleInstantsFor(dateTime: Temporal.PlainDateTime) {
+    return this.call('getPossibleInstantsFor', [dateTime]);
+  }
+}

--- a/lib/methodrecord.ts
+++ b/lib/methodrecord.ts
@@ -1,6 +1,24 @@
 import { GetIntrinsic } from './intrinsicclass';
 import type { Temporal } from '..';
+import type { CalendarParams } from './internaltypes';
 import type { TimeZonePrototypeKeys } from './intrinsicclass';
+
+// Not all calendar protocol methods need to be able to be cached
+type CalendarRecordMethodNames =
+  | 'dateAdd'
+  | 'dateFromFields'
+  | 'dateUntil'
+  | 'day'
+  | 'fields'
+  | 'mergeFields'
+  | 'monthDayFromFields'
+  | 'yearMonthFromFields';
+
+type CalendarRecordInfo = {
+  Name: 'Calendar';
+  Protocol: Temporal.CalendarProtocol;
+  MethodName: CalendarRecordMethodNames;
+};
 
 type TimeZoneRecordInfo = {
   Name: 'TimeZone';
@@ -12,7 +30,7 @@ type TimeZoneRecordInfo = {
 // It could be expressed properly in the type system, but we're just going to
 // remove this object later down the line in the rebase, so I'm not going to
 // spend a lot of effort on it.
-class MethodRecord<T extends TimeZoneRecordInfo> {
+class MethodRecord<T extends TimeZoneRecordInfo | CalendarRecordInfo> {
   recordType: T['Name'];
   receiver: string | T['Protocol'];
 
@@ -88,5 +106,50 @@ export class TimeZoneMethodRecord extends MethodRecord<TimeZoneRecordInfo> {
 
   getPossibleInstantsFor(dateTime: Temporal.PlainDateTime) {
     return this.call('getPossibleInstantsFor', [dateTime]);
+  }
+}
+
+export class CalendarMethodRecord extends MethodRecord<CalendarRecordInfo> {
+  constructor(calendar: string | Temporal.CalendarProtocol, methodNames: CalendarRecordMethodNames[] = []) {
+    super('Calendar', calendar, methodNames);
+  }
+
+  dateAdd(date: Temporal.PlainDate, duration: Temporal.Duration, options: Temporal.ArithmeticOptions | undefined) {
+    return this.call('dateAdd', [date, duration, options]);
+  }
+
+  dateFromFields(fields: CalendarParams['dateFromFields'][0], options: Temporal.AssignmentOptions | undefined) {
+    return this.call('dateFromFields', [fields, options]);
+  }
+
+  dateUntil(
+    one: Temporal.PlainDate,
+    two: Temporal.PlainDate,
+    options: Temporal.DifferenceOptions<'year' | 'month' | 'week' | 'day'> | undefined
+  ) {
+    return this.call('dateUntil', [one, two, options]);
+  }
+
+  day(date: Temporal.PlainDate | Temporal.PlainDateTime | Temporal.PlainMonthDay) {
+    return this.call('day', [date]);
+  }
+
+  fields(fieldNames: Iterable<string>) {
+    return this.call('fields', [fieldNames]);
+  }
+
+  mergeFields(fields: Record<string, any>, additionalFields: Record<string, any>) {
+    return this.call('mergeFields', [fields, additionalFields]);
+  }
+
+  monthDayFromFields(fields: CalendarParams['monthDayFromFields'][0], options: Temporal.AssignmentOptions | undefined) {
+    return this.call('monthDayFromFields', [fields, options]);
+  }
+
+  yearMonthFromFields(
+    fields: CalendarParams['yearMonthFromFields'][0],
+    options: Temporal.AssignmentOptions | undefined
+  ) {
+    return this.call('yearMonthFromFields', [fields, options]);
   }
 }

--- a/lib/now.ts
+++ b/lib/now.ts
@@ -1,5 +1,6 @@
 import * as ES from './ecmascript';
 import { GetIntrinsic } from './intrinsicclass';
+import { TimeZoneMethodRecord } from './methodrecord';
 import type { Temporal } from '..';
 
 const instant: (typeof Temporal.Now)['instant'] = () => {
@@ -13,12 +14,14 @@ const plainDateTime: (typeof Temporal.Now)['plainDateTime'] = (
   const tZ = ES.ToTemporalTimeZoneSlotValue(temporalTimeZoneLike);
   const calendar = ES.ToTemporalCalendarSlotValue(calendarLike);
   const inst = instant();
-  return ES.GetPlainDateTimeFor(tZ, inst, calendar);
+  const timeZoneRec = new TimeZoneMethodRecord(tZ, ['getOffsetNanosecondsFor']);
+  return ES.GetPlainDateTimeFor(timeZoneRec, inst, calendar);
 };
 const plainDateTimeISO: (typeof Temporal.Now)['plainDateTimeISO'] = (temporalTimeZoneLike = ES.DefaultTimeZone()) => {
   const tZ = ES.ToTemporalTimeZoneSlotValue(temporalTimeZoneLike);
   const inst = instant();
-  return ES.GetPlainDateTimeFor(tZ, inst, 'iso8601');
+  const timeZoneRec = new TimeZoneMethodRecord(tZ, ['getOffsetNanosecondsFor']);
+  return ES.GetPlainDateTimeFor(timeZoneRec, inst, 'iso8601');
 };
 const zonedDateTime: (typeof Temporal.Now)['zonedDateTime'] = (
   calendarLike,

--- a/lib/plaindate.ts
+++ b/lib/plaindate.ts
@@ -1,5 +1,6 @@
 import * as ES from './ecmascript';
 import { MakeIntrinsicClass } from './intrinsicclass';
+import { TimeZoneMethodRecord } from './methodrecord';
 import {
   ISO_YEAR,
   ISO_MONTH,
@@ -269,7 +270,8 @@ export class PlainDate implements Temporal.PlainDate {
       nanosecond,
       calendar
     );
-    const instant = ES.GetInstantFor(timeZone, dt, 'compatible');
+    const timeZoneRec = new TimeZoneMethodRecord(timeZone, ['getPossibleInstantsFor']);
+    const instant = ES.GetInstantFor(timeZoneRec, dt, 'compatible');
     return ES.CreateTemporalZonedDateTime(GetSlot(instant, EPOCHNANOSECONDS), timeZone, calendar);
   }
   toPlainYearMonth(): Return['toPlainYearMonth'] {

--- a/lib/plaindatetime.ts
+++ b/lib/plaindatetime.ts
@@ -1,6 +1,6 @@
 import * as ES from './ecmascript';
 import { MakeIntrinsicClass } from './intrinsicclass';
-import { TimeZoneMethodRecord } from './methodrecord';
+import { CalendarMethodRecord, TimeZoneMethodRecord } from './methodrecord';
 
 import {
   ISO_YEAR,
@@ -78,7 +78,8 @@ export class PlainDateTime implements Temporal.PlainDateTime {
   }
   get day(): Return['day'] {
     if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
-    return ES.CalendarDay(GetSlot(this, CALENDAR), this);
+    const calendarRec = new CalendarMethodRecord(GetSlot(this, CALENDAR), ['day']);
+    return ES.CalendarDay(calendarRec, this);
   }
   get hour(): Return['hour'] {
     if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
@@ -156,8 +157,8 @@ export class PlainDateTime implements Temporal.PlainDateTime {
     ES.RejectTemporalLikeObject(temporalDateTimeLike);
 
     const resolvedOptions = ES.SnapshotOwnProperties(ES.GetOptionsObject(options), null);
-    const calendar = GetSlot(this, CALENDAR);
-    const fieldNames = ES.CalendarFields(calendar, ['day', 'month', 'monthCode', 'year']);
+    const calendarRec = new CalendarMethodRecord(GetSlot(this, CALENDAR), ['dateFromFields', 'fields', 'mergeFields']);
+    const fieldNames = ES.CalendarFields(calendarRec, ['day', 'month', 'monthCode', 'year']);
     let fields = ES.PrepareTemporalFields(this, fieldNames, []);
     fields.hour = GetSlot(this, ISO_HOUR);
     fields.minute = GetSlot(this, ISO_MINUTE);
@@ -167,10 +168,10 @@ export class PlainDateTime implements Temporal.PlainDateTime {
     fields.nanosecond = GetSlot(this, ISO_NANOSECOND);
     ES.Call(ArrayPrototypePush, fieldNames, ['hour', 'microsecond', 'millisecond', 'minute', 'nanosecond', 'second']);
     const partialDateTime = ES.PrepareTemporalFields(temporalDateTimeLike, fieldNames, 'partial');
-    fields = ES.CalendarMergeFields(calendar, fields, partialDateTime);
+    fields = ES.CalendarMergeFields(calendarRec, fields, partialDateTime);
     fields = ES.PrepareTemporalFields(fields, fieldNames, []);
     const { year, month, day, hour, minute, second, millisecond, microsecond, nanosecond } =
-      ES.InterpretTemporalDateTimeFields(calendar, fields, resolvedOptions);
+      ES.InterpretTemporalDateTimeFields(calendarRec, fields, resolvedOptions);
 
     return ES.CreateTemporalDateTime(
       year,
@@ -182,7 +183,7 @@ export class PlainDateTime implements Temporal.PlainDateTime {
       millisecond,
       microsecond,
       nanosecond,
-      calendar
+      calendarRec.receiver
     );
   }
   withPlainTime(temporalTimeParam: Params['withPlainTime'][0] = undefined): Return['withPlainTime'] {
@@ -427,17 +428,17 @@ export class PlainDateTime implements Temporal.PlainDateTime {
   }
   toPlainYearMonth(): Return['toPlainYearMonth'] {
     if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
-    const calendar = GetSlot(this, CALENDAR);
-    const fieldNames = ES.CalendarFields(calendar, ['monthCode', 'year']);
+    const calendarRec = new CalendarMethodRecord(GetSlot(this, CALENDAR), ['fields', 'yearMonthFromFields']);
+    const fieldNames = ES.CalendarFields(calendarRec, ['monthCode', 'year']);
     const fields = ES.PrepareTemporalFields(this, fieldNames, []);
-    return ES.CalendarYearMonthFromFields(calendar, fields);
+    return ES.CalendarYearMonthFromFields(calendarRec, fields);
   }
   toPlainMonthDay(): Return['toPlainMonthDay'] {
     if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
-    const calendar = GetSlot(this, CALENDAR);
-    const fieldNames = ES.CalendarFields(calendar, ['day', 'monthCode']);
+    const calendarRec = new CalendarMethodRecord(GetSlot(this, CALENDAR), ['fields', 'monthDayFromFields']);
+    const fieldNames = ES.CalendarFields(calendarRec, ['day', 'monthCode']);
     const fields = ES.PrepareTemporalFields(this, fieldNames, []);
-    return ES.CalendarMonthDayFromFields(calendar, fields);
+    return ES.CalendarMonthDayFromFields(calendarRec, fields);
   }
   toPlainTime(): Return['toPlainTime'] {
     if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');

--- a/lib/plaindatetime.ts
+++ b/lib/plaindatetime.ts
@@ -1,5 +1,6 @@
 import * as ES from './ecmascript';
 import { MakeIntrinsicClass } from './intrinsicclass';
+import { TimeZoneMethodRecord } from './methodrecord';
 
 import {
   ISO_YEAR,
@@ -416,7 +417,8 @@ export class PlainDateTime implements Temporal.PlainDateTime {
     const timeZone = ES.ToTemporalTimeZoneSlotValue(temporalTimeZoneLike);
     const options = ES.GetOptionsObject(optionsParam);
     const disambiguation = ES.ToTemporalDisambiguation(options);
-    const instant = ES.GetInstantFor(timeZone, this, disambiguation);
+    const timeZoneRec = new TimeZoneMethodRecord(timeZone, ['getPossibleInstantsFor']);
+    const instant = ES.GetInstantFor(timeZoneRec, this, disambiguation);
     return ES.CreateTemporalZonedDateTime(GetSlot(instant, EPOCHNANOSECONDS), timeZone, GetSlot(this, CALENDAR));
   }
   toPlainDate(): Return['toPlainDate'] {

--- a/lib/plainmonthday.ts
+++ b/lib/plainmonthday.ts
@@ -1,5 +1,6 @@
 import * as ES from './ecmascript';
 import { MakeIntrinsicClass } from './intrinsicclass';
+import { CalendarMethodRecord } from './methodrecord';
 import { ISO_MONTH, ISO_DAY, ISO_YEAR, CALENDAR, GetSlot } from './slots';
 import type { Temporal } from '..';
 import { DateTimeFormat } from './intl';
@@ -29,7 +30,8 @@ export class PlainMonthDay implements Temporal.PlainMonthDay {
   }
   get day(): Return['day'] {
     if (!ES.IsTemporalMonthDay(this)) throw new TypeError('invalid receiver');
-    return ES.CalendarDay(GetSlot(this, CALENDAR), this);
+    const calendarRec = new CalendarMethodRecord(GetSlot(this, CALENDAR), ['day']);
+    return ES.CalendarDay(calendarRec, this);
   }
   get calendarId(): Return['calendarId'] {
     if (!ES.IsTemporalMonthDay(this)) throw new TypeError('invalid receiver');
@@ -44,14 +46,18 @@ export class PlainMonthDay implements Temporal.PlainMonthDay {
     ES.RejectTemporalLikeObject(temporalMonthDayLike);
     const resolvedOptions = ES.SnapshotOwnProperties(ES.GetOptionsObject(options), null);
 
-    const calendar = GetSlot(this, CALENDAR);
-    const fieldNames = ES.CalendarFields(calendar, ['day', 'month', 'monthCode', 'year']);
+    const calendarRec = new CalendarMethodRecord(GetSlot(this, CALENDAR), [
+      'fields',
+      'mergeFields',
+      'monthDayFromFields'
+    ]);
+    const fieldNames = ES.CalendarFields(calendarRec, ['day', 'month', 'monthCode', 'year']);
     let fields = ES.PrepareTemporalFields(this, fieldNames, []);
     const partialMonthDay = ES.PrepareTemporalFields(temporalMonthDayLike, fieldNames, 'partial');
-    fields = ES.CalendarMergeFields(calendar, fields, partialMonthDay);
+    fields = ES.CalendarMergeFields(calendarRec, fields, partialMonthDay);
     fields = ES.PrepareTemporalFields(fields, fieldNames, []);
 
-    return ES.CalendarMonthDayFromFields(calendar, fields, resolvedOptions);
+    return ES.CalendarMonthDayFromFields(calendarRec, fields, resolvedOptions);
   }
   equals(otherParam: Params['equals'][0]): Return['equals'] {
     if (!ES.IsTemporalMonthDay(this)) throw new TypeError('invalid receiver');
@@ -84,19 +90,19 @@ export class PlainMonthDay implements Temporal.PlainMonthDay {
   toPlainDate(item: Params['toPlainDate'][0]): Return['toPlainDate'] {
     if (!ES.IsTemporalMonthDay(this)) throw new TypeError('invalid receiver');
     if (!ES.IsObject(item)) throw new TypeError('argument should be an object');
-    const calendar = GetSlot(this, CALENDAR);
+    const calendarRec = new CalendarMethodRecord(GetSlot(this, CALENDAR), ['dateFromFields', 'fields', 'mergeFields']);
 
-    const receiverFieldNames = ES.CalendarFields(calendar, ['day', 'monthCode']);
+    const receiverFieldNames = ES.CalendarFields(calendarRec, ['day', 'monthCode']);
     const fields = ES.PrepareTemporalFields(this, receiverFieldNames, []);
 
-    const inputFieldNames = ES.CalendarFields(calendar, ['year']);
+    const inputFieldNames = ES.CalendarFields(calendarRec, ['year']);
     const inputFields = ES.PrepareTemporalFields(item, inputFieldNames, []);
-    let mergedFields = ES.CalendarMergeFields(calendar, fields, inputFields);
+    let mergedFields = ES.CalendarMergeFields(calendarRec, fields, inputFields);
     const concatenatedFieldNames: FieldKey[] = ES.Call(ArrayPrototypeConcat, receiverFieldNames, inputFieldNames);
     mergedFields = ES.PrepareTemporalFields(mergedFields, concatenatedFieldNames, [], [], 'ignore');
     const options = ObjectCreate(null);
     options.overflow = 'reject';
-    return ES.CalendarDateFromFields(calendar, mergedFields, options);
+    return ES.CalendarDateFromFields(calendarRec, mergedFields, options);
   }
   getISOFields(): Return['getISOFields'] {
     if (!ES.IsTemporalMonthDay(this)) throw new TypeError('invalid receiver');

--- a/lib/plaintime.ts
+++ b/lib/plaintime.ts
@@ -1,6 +1,7 @@
 import { DEBUG } from './debug';
 import * as ES from './ecmascript';
 import { MakeIntrinsicClass } from './intrinsicclass';
+import { TimeZoneMethodRecord } from './methodrecord';
 
 import {
   ISO_YEAR,
@@ -308,7 +309,8 @@ export class PlainTime implements Temporal.PlainTime {
       nanosecond,
       calendar
     );
-    const instant = ES.GetInstantFor(timeZone, dt, 'compatible');
+    const timeZoneRec = new TimeZoneMethodRecord(timeZone, ['getPossibleInstantsFor']);
+    const instant = ES.GetInstantFor(timeZoneRec, dt, 'compatible');
     return ES.CreateTemporalZonedDateTime(GetSlot(instant, EPOCHNANOSECONDS), timeZone, calendar);
   }
   getISOFields(): Return['getISOFields'] {

--- a/lib/timezone.ts
+++ b/lib/timezone.ts
@@ -1,6 +1,7 @@
 import { DEBUG } from './debug';
 import * as ES from './ecmascript';
 import { DefineIntrinsic, GetIntrinsic, MakeIntrinsicClass } from './intrinsicclass';
+import { TimeZoneMethodRecord } from './methodrecord';
 import {
   TIMEZONE_ID,
   EPOCHNANOSECONDS,
@@ -66,7 +67,8 @@ export class TimeZone implements Temporal.TimeZone {
   getOffsetStringFor(instantParam: Params['getOffsetStringFor'][0]): Return['getOffsetStringFor'] {
     if (!ES.IsTemporalTimeZone(this)) throw new TypeError('invalid receiver');
     const instant = ES.ToTemporalInstant(instantParam);
-    return ES.GetOffsetStringFor(this, instant);
+    const timeZoneRec = new TimeZoneMethodRecord(this, ['getOffsetNanosecondsFor']);
+    return ES.GetOffsetStringFor(timeZoneRec, instant);
   }
   getPlainDateTimeFor(
     instantParam: Params['getPlainDateTimeFor'][0],
@@ -75,7 +77,8 @@ export class TimeZone implements Temporal.TimeZone {
     if (!ES.IsTemporalTimeZone(this)) throw new TypeError('invalid receiver');
     const instant = ES.ToTemporalInstant(instantParam);
     const calendar = ES.ToTemporalCalendarSlotValue(calendarParam);
-    return ES.GetPlainDateTimeFor(this, instant, calendar);
+    const timeZoneRec = new TimeZoneMethodRecord(this, ['getOffsetNanosecondsFor']);
+    return ES.GetPlainDateTimeFor(timeZoneRec, instant, calendar);
   }
   getInstantFor(
     dateTimeParam: Params['getInstantFor'][0],
@@ -85,7 +88,8 @@ export class TimeZone implements Temporal.TimeZone {
     const dateTime = ES.ToTemporalDateTime(dateTimeParam);
     const options = ES.GetOptionsObject(optionsParam);
     const disambiguation = ES.ToTemporalDisambiguation(options);
-    return ES.GetInstantFor(this, dateTime, disambiguation);
+    const timeZoneRec = new TimeZoneMethodRecord(this, ['getPossibleInstantsFor']);
+    return ES.GetInstantFor(timeZoneRec, dateTime, disambiguation);
   }
   getPossibleInstantsFor(dateTimeParam: Params['getPossibleInstantsFor'][0]): Return['getPossibleInstantsFor'] {
     if (!ES.IsTemporalTimeZone(this)) throw new TypeError('invalid receiver');


### PR DESCRIPTION
This one is very few commits but a lot of changed lines. It corresponds pretty much to https://github.com/tc39/proposal-temporal/pull/2519

I'll be the first to admit that the Typescript annotations in `methodrecord.ts` are not very good, and there's a lot of `@ts-expect-error` needed to get it to compile. However, note that method records were removed from the proposal in June 2024. So I didn't want to spend a lot of time getting the types just right, since it'll be deleted in a forthcoming PR anyway.

If there are any easy-to-implement suggestions to improve `methodrecord.ts` I'm happy to incorporate them, but if it's complicated I'd prefer to just leave it. The sloppy code will be gone soon enough!