### PR TITLE
Rebase through end of June 2024

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -463,8 +463,7 @@ export namespace Temporal {
       };
 
   /**
-   * Options to control behavior of `Duration.compare()`, `Duration.add()`, and
-   * `Duration.subtract()`
+   * Options to control behavior of `Duration.compare()`
    */
   export interface DurationArithmeticOptions {
     /**
@@ -544,8 +543,8 @@ export namespace Temporal {
     negated(): Temporal.Duration;
     abs(): Temporal.Duration;
     with(durationLike: DurationLike): Temporal.Duration;
-    add(other: Temporal.Duration | DurationLike | string, options?: DurationArithmeticOptions): Temporal.Duration;
-    subtract(other: Temporal.Duration | DurationLike | string, options?: DurationArithmeticOptions): Temporal.Duration;
+    add(other: Temporal.Duration | DurationLike | string): Temporal.Duration;
+    subtract(other: Temporal.Duration | DurationLike | string): Temporal.Duration;
     round(roundTo: DurationRoundTo): Temporal.Duration;
     total(totalOf: DurationTotalOf): number;
     toLocaleString(locales?: string | string[], options?: Intl.DateTimeFormatOptions): string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -569,16 +569,12 @@ export namespace Temporal {
    * See https://tc39.es/proposal-temporal/docs/instant.html for more details.
    */
   export class Instant {
-    static fromEpochSeconds(epochSeconds: number): Temporal.Instant;
     static fromEpochMilliseconds(epochMilliseconds: number): Temporal.Instant;
-    static fromEpochMicroseconds(epochMicroseconds: bigint): Temporal.Instant;
     static fromEpochNanoseconds(epochNanoseconds: bigint): Temporal.Instant;
     static from(item: Temporal.Instant | string): Temporal.Instant;
     static compare(one: Temporal.Instant | string, two: Temporal.Instant | string): ComparisonResult;
     constructor(epochNanoseconds: bigint);
-    readonly epochSeconds: number;
     readonly epochMilliseconds: number;
-    readonly epochMicroseconds: bigint;
     readonly epochNanoseconds: bigint;
     equals(other: Temporal.Instant | string): boolean;
     add(
@@ -1279,9 +1275,7 @@ export namespace Temporal {
     readonly inLeapYear: boolean;
     readonly offsetNanoseconds: number;
     readonly offset: string;
-    readonly epochSeconds: number;
     readonly epochMilliseconds: number;
-    readonly epochMicroseconds: bigint;
     readonly epochNanoseconds: bigint;
     equals(other: Temporal.ZonedDateTime | ZonedDateTimeLike | string): boolean;
     with(zonedDateTimeLike: ZonedDateTimeLike, options?: ZonedDateTimeAssignmentOptions): Temporal.ZonedDateTime;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1081,11 +1081,6 @@ export namespace Temporal {
     round(
       roundTo: RoundTo<'hour' | 'minute' | 'second' | 'millisecond' | 'microsecond' | 'nanosecond'>
     ): Temporal.PlainTime;
-    toPlainDateTime(temporalDate: Temporal.PlainDate | PlainDateLike | string): Temporal.PlainDateTime;
-    toZonedDateTime(timeZoneAndDate: {
-      timeZone: TimeZoneLike;
-      plainDate: Temporal.PlainDate | PlainDateLike | string;
-    }): Temporal.ZonedDateTime;
     getISOFields(): PlainTimeISOFields;
     toLocaleString(locales?: string | string[], options?: Intl.DateTimeFormatOptions): string;
     toJSON(): string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -941,7 +941,6 @@ export namespace Temporal {
     equals(other: Temporal.PlainDateTime | PlainDateTimeLike | string): boolean;
     with(dateTimeLike: PlainDateTimeLike, options?: AssignmentOptions): Temporal.PlainDateTime;
     withPlainTime(timeLike?: Temporal.PlainTime | PlainTimeLike | string): Temporal.PlainDateTime;
-    withPlainDate(dateLike: Temporal.PlainDate | PlainDateLike | string): Temporal.PlainDateTime;
     withCalendar(calendar: CalendarLike): Temporal.PlainDateTime;
     add(durationLike: Temporal.Duration | DurationLike | string, options?: ArithmeticOptions): Temporal.PlainDateTime;
     subtract(
@@ -1292,7 +1291,6 @@ export namespace Temporal {
     equals(other: Temporal.ZonedDateTime | ZonedDateTimeLike | string): boolean;
     with(zonedDateTimeLike: ZonedDateTimeLike, options?: ZonedDateTimeAssignmentOptions): Temporal.ZonedDateTime;
     withPlainTime(timeLike?: Temporal.PlainTime | PlainTimeLike | string): Temporal.ZonedDateTime;
-    withPlainDate(dateLike: Temporal.PlainDate | PlainDateLike | string): Temporal.ZonedDateTime;
     withCalendar(calendar: CalendarLike): Temporal.ZonedDateTime;
     withTimeZone(timeZone: TimeZoneLike): Temporal.ZonedDateTime;
     add(durationLike: Temporal.Duration | DurationLike | string, options?: ArithmeticOptions): Temporal.ZonedDateTime;

--- a/index.d.ts
+++ b/index.d.ts
@@ -594,7 +594,6 @@ export namespace Temporal {
     round(
       roundTo: RoundTo<'hour' | 'minute' | 'second' | 'millisecond' | 'microsecond' | 'nanosecond'>
     ): Temporal.Instant;
-    toZonedDateTime(calendarAndTimeZone: { timeZone: TimeZoneLike; calendar: CalendarLike }): Temporal.ZonedDateTime;
     toZonedDateTimeISO(tzLike: TimeZoneLike): Temporal.ZonedDateTime;
     toLocaleString(locales?: string | string[], options?: Intl.DateTimeFormatOptions): string;
     toJSON(): string;
@@ -1335,26 +1334,6 @@ export namespace Temporal {
     instant: () => Temporal.Instant;
 
     /**
-     * Get the current calendar date and clock time in a specific calendar and
-     * time zone.
-     *
-     * The `calendar` parameter is required. When using the ISO 8601 calendar or
-     * if you don't understand the need for or implications of a calendar, then
-     * a more ergonomic alternative to this method is
-     * `Temporal.Now.zonedDateTimeISO()`.
-     *
-     * @param {CalendarLike} [calendar] - calendar identifier, or
-     * a `Temporal.Calendar` instance, or an object implementing the calendar
-     * protocol.
-     * @param {TimeZoneLike} [tzLike] -
-     * {@link https://en.wikipedia.org/wiki/List_of_tz_database_time_zones|IANA time zone identifier}
-     * string (e.g. `'Europe/London'`), `Temporal.TimeZone` instance, or an
-     * object implementing the time zone protocol. If omitted, the environment's
-     * current time zone will be used.
-     */
-    zonedDateTime: (calendar: CalendarLike, tzLike?: TimeZoneLike) => Temporal.ZonedDateTime;
-
-    /**
      * Get the current calendar date and clock time in a specific time zone,
      * using the ISO 8601 calendar.
      *
@@ -1365,31 +1344,6 @@ export namespace Temporal {
      * current time zone will be used.
      */
     zonedDateTimeISO: (tzLike?: TimeZoneLike) => Temporal.ZonedDateTime;
-
-    /**
-     * Get the current calendar date and clock time in a specific calendar and
-     * time zone.
-     *
-     * The calendar is required. When using the ISO 8601 calendar or if you
-     * don't understand the need for or implications of a calendar, then a more
-     * ergonomic alternative to this method is `Temporal.Now.plainDateTimeISO`.
-     *
-     * Note that the `Temporal.PlainDateTime` type does not persist the time zone,
-     * but retaining the time zone is required for most time-zone-related use
-     * cases. Therefore, it's usually recommended to use
-     * `Temporal.Now.zonedDateTimeISO` or `Temporal.Now.zonedDateTime` instead
-     * of this function.
-     *
-     * @param {CalendarLike} [calendar] - calendar identifier, or
-     * a `Temporal.Calendar` instance, or an object implementing the calendar
-     * protocol.
-     * @param {TimeZoneLike} [tzLike] -
-     * {@link https://en.wikipedia.org/wiki/List_of_tz_database_time_zones|IANA time zone identifier}
-     * string (e.g. `'Europe/London'`), `Temporal.TimeZone` instance, or an
-     * object implementing the time zone protocol. If omitted,
-     * the environment's current time zone will be used.
-     */
-    plainDateTime: (calendar: CalendarLike, tzLike?: TimeZoneLike) => Temporal.PlainDateTime;
 
     /**
      * Get the current date and clock time in a specific time zone, using the
@@ -1407,24 +1361,6 @@ export namespace Temporal {
      * current time zone will be used.
      */
     plainDateTimeISO: (tzLike?: TimeZoneLike) => Temporal.PlainDateTime;
-
-    /**
-     * Get the current calendar date in a specific calendar and time zone.
-     *
-     * The calendar is required. When using the ISO 8601 calendar or if you
-     * don't understand the need for or implications of a calendar, then a more
-     * ergonomic alternative to this method is `Temporal.Now.plainDateISO`.
-     *
-     * @param {CalendarLike} [calendar] - calendar identifier, or
-     * a `Temporal.Calendar` instance, or an object implementing the calendar
-     * protocol.
-     * @param {TimeZoneLike} [tzLike] -
-     * {@link https://en.wikipedia.org/wiki/List_of_tz_database_time_zones|IANA time zone identifier}
-     * string (e.g. `'Europe/London'`), `Temporal.TimeZone` instance, or an
-     * object implementing the time zone protocol. If omitted,
-     * the environment's current time zone will be used.
-     */
-    plainDate: (calendar: CalendarLike, tzLike?: TimeZoneLike) => Temporal.PlainDate;
 
     /**
      * Get the current date in a specific time zone, using the ISO 8601

--- a/index.d.ts
+++ b/index.d.ts
@@ -960,8 +960,6 @@ export namespace Temporal {
     ): Temporal.PlainDateTime;
     toZonedDateTime(tzLike: TimeZoneLike, options?: ToInstantOptions): Temporal.ZonedDateTime;
     toPlainDate(): Temporal.PlainDate;
-    toPlainYearMonth(): Temporal.PlainYearMonth;
-    toPlainMonthDay(): Temporal.PlainMonthDay;
     toPlainTime(): Temporal.PlainTime;
     getISOFields(): PlainDateTimeISOFields;
     toLocaleString(locales?: string | string[], options?: Intl.DateTimeFormatOptions): string;
@@ -1306,8 +1304,6 @@ export namespace Temporal {
     toInstant(): Temporal.Instant;
     toPlainDateTime(): Temporal.PlainDateTime;
     toPlainDate(): Temporal.PlainDate;
-    toPlainYearMonth(): Temporal.PlainYearMonth;
-    toPlainMonthDay(): Temporal.PlainMonthDay;
     toPlainTime(): Temporal.PlainTime;
     getISOFields(): ZonedDateTimeISOFields;
     toLocaleString(locales?: string | string[], options?: Intl.DateTimeFormatOptions): string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -140,7 +140,7 @@ export namespace Temporal {
   /**
    * When the name of a unit is provided to a Temporal API as a string, it is
    * usually singular, e.g. 'day' or 'hour'. But plural unit names like 'days'
-   * or 'hours' are aso accepted too.
+   * or 'hours' are also accepted.
    * */
   export type PluralUnit<T extends DateTimeUnit> = {
     year: 'years';

--- a/lib/calendar.ts
+++ b/lib/calendar.ts
@@ -1572,9 +1572,9 @@ abstract class IslamicBaseHelper extends HelperBase {
   override reviseIntlEra<T extends Partial<EraAndEraYear>>(calendarDate: T /*, isoDate: IsoYMD */): T {
     let { era, eraYear } = calendarDate;
     // Chrome for Android as of v 142.0.6367.179 mishandled the era option in Intl.DateTimeFormat
-    // and returned 'bc' instead of 'ah'. This code corrects that.
+    // and returned 'bc' instead of 'ah'. This code corrects that and any possible future errors.
     // see https://issues.chromium.org/issues/40856332
-    if (era === 'before-christ' || era === 'bc' || era === 'b') era = 'ah';
+    era = 'ah';
     return { era, eraYear } as T;
   }
   estimateIsoDate(calendarDate: CalendarYMD) {

--- a/lib/calendar.ts
+++ b/lib/calendar.ts
@@ -1569,6 +1569,14 @@ abstract class IslamicBaseHelper extends HelperBase {
   DAYS_PER_ISLAMIC_YEAR = 354 + 11 / 30;
   DAYS_PER_ISO_YEAR = 365.2425;
   override constantEra = 'ah';
+  override reviseIntlEra<T extends Partial<EraAndEraYear>>(calendarDate: T /*, isoDate: IsoYMD */): T {
+    let { era, eraYear } = calendarDate;
+    // Chrome for Android as of v 142.0.6367.179 mishandled the era option in Intl.DateTimeFormat
+    // and returned 'bc' instead of 'ah'. This code corrects that.
+    // see https://issues.chromium.org/issues/40856332
+    if (era === 'before-christ' || era === 'bc' || era === 'b') era = 'ah';
+    return { era, eraYear } as T;
+  }
   estimateIsoDate(calendarDate: CalendarYMD) {
     const { year } = this.adjustCalendarDate(calendarDate);
     return { year: MathFloor((year * this.DAYS_PER_ISLAMIC_YEAR) / this.DAYS_PER_ISO_YEAR) + 622, month: 1, day: 1 };

--- a/lib/calendar.ts
+++ b/lib/calendar.ts
@@ -1570,12 +1570,10 @@ abstract class IslamicBaseHelper extends HelperBase {
   DAYS_PER_ISO_YEAR = 365.2425;
   override constantEra = 'ah';
   override reviseIntlEra<T extends Partial<EraAndEraYear>>(calendarDate: T /*, isoDate: IsoYMD */): T {
-    let { era, eraYear } = calendarDate;
     // Chrome for Android as of v 142.0.6367.179 mishandled the era option in Intl.DateTimeFormat
     // and returned 'bc' instead of 'ah'. This code corrects that and any possible future errors.
     // see https://issues.chromium.org/issues/40856332
-    era = 'ah';
-    return { era, eraYear } as T;
+    return { ...calendarDate, era: 'ah' };
   }
   estimateIsoDate(calendarDate: CalendarYMD) {
     const { year } = this.adjustCalendarDate(calendarDate);

--- a/lib/duration.ts
+++ b/lib/duration.ts
@@ -401,7 +401,7 @@ export class Duration implements Temporal.Duration {
         throw new RangeError(`a starting point is required for ${largestUnit}s balancing`);
       }
       if (ES.IsCalendarUnit(smallestUnit)) {
-        throw new RangeError(`a starting point is required for ${smallestUnit}s rounding`);
+        throw new Error('assertion failed: smallestUnit was larger than largestUnit');
       }
       ({ days, norm } = ES.RoundTimeDuration(days, norm, roundingIncrement, smallestUnit, roundingMode));
       ({ days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds } = ES.BalanceTimeDuration(

--- a/lib/duration.ts
+++ b/lib/duration.ts
@@ -368,7 +368,9 @@ export class Duration implements Temporal.Duration {
 
       ({ years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds } =
         ES.DifferencePlainDateTimeWithRounding(
-          plainRelativeTo,
+          GetSlot(plainRelativeTo, ISO_YEAR),
+          GetSlot(plainRelativeTo, ISO_MONTH),
+          GetSlot(plainRelativeTo, ISO_DAY),
           0,
           0,
           0,
@@ -493,7 +495,9 @@ export class Duration implements Temporal.Duration {
       const targetDate = ES.AddDate(calendarRec, plainRelativeTo, dateDuration);
 
       const { total } = ES.DifferencePlainDateTimeWithRounding(
-        plainRelativeTo,
+        GetSlot(plainRelativeTo, ISO_YEAR),
+        GetSlot(plainRelativeTo, ISO_MONTH),
+        GetSlot(plainRelativeTo, ISO_DAY),
         0,
         0,
         0,

--- a/lib/duration.ts
+++ b/lib/duration.ts
@@ -212,13 +212,13 @@ export class Duration implements Temporal.Duration {
       Math.abs(GetSlot(this, NANOSECONDS))
     );
   }
-  add(other: Params['add'][0], options: Params['add'][1] = undefined): Return['add'] {
+  add(other: Params['add'][0]): Return['add'] {
     if (!ES.IsTemporalDuration(this)) throw new TypeError('invalid receiver');
-    return ES.AddDurations('add', this, other, options);
+    return ES.AddDurations('add', this, other);
   }
-  subtract(other: Params['subtract'][0], options: Params['subtract'][1] = undefined): Return['subtract'] {
+  subtract(other: Params['subtract'][0]): Return['subtract'] {
     if (!ES.IsTemporalDuration(this)) throw new TypeError('invalid receiver');
-    return ES.AddDurations('subtract', this, other, options);
+    return ES.AddDurations('subtract', this, other);
   }
   round(roundToParam: Params['round'][0]): Return['round'] {
     if (!ES.IsTemporalDuration(this)) throw new TypeError('invalid receiver');

--- a/lib/duration.ts
+++ b/lib/duration.ts
@@ -214,11 +214,11 @@ export class Duration implements Temporal.Duration {
   }
   add(other: Params['add'][0], options: Params['add'][1] = undefined): Return['add'] {
     if (!ES.IsTemporalDuration(this)) throw new TypeError('invalid receiver');
-    return ES.AddDurationToOrSubtractDurationFromDuration('add', this, other, options);
+    return ES.AddDurations('add', this, other, options);
   }
   subtract(other: Params['subtract'][0], options: Params['subtract'][1] = undefined): Return['subtract'] {
     if (!ES.IsTemporalDuration(this)) throw new TypeError('invalid receiver');
-    return ES.AddDurationToOrSubtractDurationFromDuration('subtract', this, other, options);
+    return ES.AddDurations('subtract', this, other, options);
   }
   round(roundToParam: Params['round'][0]): Return['round'] {
     if (!ES.IsTemporalDuration(this)) throw new TypeError('invalid receiver');
@@ -243,8 +243,7 @@ export class Duration implements Temporal.Duration {
       minutes,
       seconds,
       milliseconds,
-      microseconds,
-      nanoseconds
+      microseconds
     );
     const roundTo =
       typeof roundToParam === 'string'
@@ -568,8 +567,7 @@ export class Duration implements Temporal.Duration {
         minutes,
         seconds,
         milliseconds,
-        microseconds,
-        nanoseconds
+        microseconds
       );
       ({ norm } = ES.RoundTimeDuration(0, norm, increment, unit, roundingMode));
       let deltaDays;

--- a/lib/ecmascript.ts
+++ b/lib/ecmascript.ts
@@ -2739,19 +2739,6 @@ function ThrowIfCalendarsNotEqual(one: CalendarSlot, two: CalendarSlot, errorMes
   }
 }
 
-export function ConsolidateCalendars(one: CalendarSlot, two: CalendarSlot) {
-  if (one === two) return two;
-  const sOne = ToTemporalCalendarIdentifier(one);
-  const sTwo = ToTemporalCalendarIdentifier(two);
-  if (sOne === sTwo || sOne === 'iso8601') {
-    return two;
-  } else if (sTwo === 'iso8601') {
-    return one;
-  } else {
-    throw new RangeError('irreconcilable calendars');
-  }
-}
-
 export function CalendarDateFromFields(
   calendarRec: CalendarMethodRecord,
   fields: CalendarProtocolParams['dateFromFields'][0],

--- a/lib/ecmascript.ts
+++ b/lib/ecmascript.ts
@@ -4277,9 +4277,9 @@ function DifferenceISODateTime(
   ms1: number,
   µs1: number,
   ns1: number,
-  y2: number,
-  mon2: number,
-  d2: number,
+  y2Param: number,
+  mon2Param: number,
+  d2Param: number,
   h2: number,
   min2: number,
   s2: number,
@@ -4295,13 +4295,18 @@ function DifferenceISODateTime(
   let y1 = y1Param;
   let mon1 = mon1Param;
   let d1 = d1Param;
+  let y2 = y2Param;
+  let mon2 = mon2Param;
+  let d2 = d2Param;
 
   let timeDuration = DifferenceTime(h1, min1, s1, ms1, µs1, ns1, h2, min2, s2, ms2, µs2, ns2);
 
   const timeSign = timeDuration.sign();
   const dateSign = CompareISODate(y2, mon2, d2, y1, mon1, d1);
+
+  // back-off a day from date2 so that the signs of the date a time diff match
   if (dateSign === -timeSign) {
-    ({ year: y1, month: mon1, day: d1 } = BalanceISODate(y1, mon1, d1 - timeSign));
+    ({ year: y2, month: mon2, day: d2 } = BalanceISODate(y2, mon2, d2 + timeSign));
     timeDuration = timeDuration.add24HourDays(-timeSign);
   }
 

--- a/lib/ecmascript.ts
+++ b/lib/ecmascript.ts
@@ -5941,18 +5941,10 @@ type AddSubtractOperation = 'add' | 'subtract';
 export function AddDurations(
   operation: AddSubtractOperation,
   duration: Temporal.Duration,
-  otherParam: DurationParams['add'][0],
-  optionsParam: DurationParams['add'][1]
+  otherParam: DurationParams['add'][0]
 ): Temporal.Duration {
   const sign = operation === 'subtract' ? -1 : 1;
   const other = ToTemporalDurationRecord(otherParam);
-  const options = GetOptionsObject(optionsParam);
-  const { plainRelativeTo, zonedRelativeTo, timeZoneRec } = GetTemporalRelativeToOption(options);
-
-  const calendarRec = CalendarMethodRecord.CreateFromRelativeTo(plainRelativeTo, zonedRelativeTo, [
-    'dateAdd',
-    'dateUntil'
-  ]);
 
   const y1 = GetSlot(duration, YEARS);
   const mon1 = GetSlot(duration, MONTHS);
@@ -5983,92 +5975,14 @@ export function AddDurations(
   const norm2 = TimeDuration.normalize(h2, min2, s2, ms2, µs2, ns2);
   const Duration = GetIntrinsic('%Temporal.Duration%');
 
-  if (!zonedRelativeTo && !plainRelativeTo) {
-    if (IsCalendarUnit(largestUnit)) {
-      throw new RangeError('relativeTo is required for years, months, or weeks arithmetic');
-    }
-    const { days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds } = BalanceTimeDuration(
-      norm1.add(norm2).add24HourDays(d1 + d2),
-      largestUnit
-    );
-    return new Duration(0, 0, 0, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds);
+  if (IsCalendarUnit(largestUnit)) {
+    throw new RangeError('For years, months, or weeks arithmetic, use date arithmetic relative to a starting point');
   }
-
-  if (plainRelativeTo) {
-    assertExists(calendarRec);
-    const dateDuration1 = new Duration(y1, mon1, w1, d1, 0, 0, 0, 0, 0, 0);
-    const dateDuration2 = new Duration(y2, mon2, w2, d2, 0, 0, 0, 0, 0, 0);
-    const intermediate = AddDate(calendarRec, plainRelativeTo, dateDuration1);
-    const end = AddDate(calendarRec, intermediate, dateDuration2);
-
-    const dateLargestUnit = LargerOfTwoTemporalUnits('day', largestUnit);
-    const differenceOptions = ObjectCreate(null);
-    differenceOptions.largestUnit = dateLargestUnit;
-    const untilResult = DifferenceDate(calendarRec, plainRelativeTo, end, differenceOptions);
-    const years = GetSlot(untilResult, YEARS);
-    const months = GetSlot(untilResult, MONTHS);
-    const weeks = GetSlot(untilResult, WEEKS);
-    let days = GetSlot(untilResult, DAYS);
-    // Signs of date part and time part may not agree; balance them together
-    let hours, minutes, seconds, milliseconds, microseconds, nanoseconds;
-    ({ days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds } = BalanceTimeDuration(
-      norm1.add(norm2).add24HourDays(days),
-      largestUnit
-    ));
-    return new Duration(years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds);
-  }
-
-  // zonedRelativeTo is defined
-  assertExists(zonedRelativeTo);
-  assertExists(calendarRec);
-  assertExists(timeZoneRec);
-  const TemporalInstant = GetIntrinsic('%Temporal.Instant%');
-  const calendar = GetSlot(zonedRelativeTo, CALENDAR);
-  const startInstant = GetSlot(zonedRelativeTo, INSTANT);
-  let startDateTime;
-  if (IsCalendarUnit(largestUnit) || largestUnit === 'day') {
-    startDateTime = GetPlainDateTimeFor(timeZoneRec, startInstant, calendar);
-  }
-  const intermediateNs = AddZonedDateTime(
-    startInstant,
-    timeZoneRec,
-    calendarRec,
-    y1,
-    mon1,
-    w1,
-    d1,
-    norm1,
-    startDateTime
+  const { days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds } = BalanceTimeDuration(
+    norm1.add(norm2).add24HourDays(d1 + d2),
+    largestUnit
   );
-  const endNs = AddZonedDateTime(
-    new TemporalInstant(intermediateNs),
-    timeZoneRec,
-    calendarRec,
-    y2,
-    mon2,
-    w2,
-    d2,
-    norm2
-  );
-  if (largestUnit !== 'year' && largestUnit !== 'month' && largestUnit !== 'week' && largestUnit !== 'day') {
-    // The user is only asking for a time difference, so return difference of instants.
-    const norm = TimeDuration.fromEpochNsDiff(endNs, GetSlot(zonedRelativeTo, EPOCHNANOSECONDS));
-    const { hours, minutes, seconds, milliseconds, microseconds, nanoseconds } = BalanceTimeDuration(norm, largestUnit);
-    return new Duration(0, 0, 0, 0, hours, minutes, seconds, milliseconds, microseconds, nanoseconds);
-  }
-
-  assertExists(startDateTime);
-  const { years, months, weeks, days, norm } = DifferenceZonedDateTime(
-    GetSlot(zonedRelativeTo, EPOCHNANOSECONDS),
-    endNs,
-    timeZoneRec,
-    calendarRec,
-    largestUnit,
-    ObjectCreate(null),
-    startDateTime
-  );
-  const { hours, minutes, seconds, milliseconds, microseconds, nanoseconds } = BalanceTimeDuration(norm, 'hour');
-  return new Duration(years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds);
+  return new Duration(0, 0, 0, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds);
 }
 
 export function AddDurationToOrSubtractDurationFromInstant(

--- a/lib/ecmascript.ts
+++ b/lib/ecmascript.ts
@@ -1337,8 +1337,7 @@ export function DefaultTemporalLargestUnit(
   minutes: number,
   seconds: number,
   milliseconds: number,
-  microseconds: number,
-  nanoseconds: number
+  microseconds: number
 ): Temporal.DateTimeUnit {
   const entries = [
     ['years', years],
@@ -1349,8 +1348,7 @@ export function DefaultTemporalLargestUnit(
     ['minutes', minutes],
     ['seconds', seconds],
     ['milliseconds', milliseconds],
-    ['microseconds', microseconds],
-    ['nanoseconds', nanoseconds]
+    ['microseconds', microseconds]
   ] as const;
   for (let index = 0; index < entries.length; index++) {
     const entry = entries[index];
@@ -5751,132 +5749,6 @@ export function AddTime(
   return BalanceTime(hour, minute, second, millisecond, microsecond, nanosecond);
 }
 
-function AddDuration(
-  y1: number,
-  mon1: number,
-  w1: number,
-  d1: number,
-  h1: number,
-  min1: number,
-  s1: number,
-  ms1: number,
-  µs1: number,
-  ns1: number,
-  y2: number,
-  mon2: number,
-  w2: number,
-  d2: number,
-  h2: number,
-  min2: number,
-  s2: number,
-  ms2: number,
-  µs2: number,
-  ns2: number,
-  plainRelativeTo: Temporal.PlainDate | undefined,
-  zonedRelativeTo: Temporal.ZonedDateTime | undefined,
-  calendarRec: CalendarMethodRecord | undefined,
-  timeZoneRec: TimeZoneMethodRecord | undefined,
-  precalculatedPlainDateTime?: Temporal.PlainDateTime | undefined
-) {
-  // dateAdd must be looked up if zonedRelativeTo or plainRelativeTo not
-  // undefined, and years...weeks != 0 in either duration
-  // dateUntil must additionally be looked up if duration 2 not zero
-  const largestUnit1 = DefaultTemporalLargestUnit(y1, mon1, w1, d1, h1, min1, s1, ms1, µs1, ns1);
-  const largestUnit2 = DefaultTemporalLargestUnit(y2, mon2, w2, d2, h2, min2, s2, ms2, µs2, ns2);
-  const largestUnit = LargerOfTwoTemporalUnits(largestUnit1, largestUnit2);
-
-  let years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds;
-  const norm1 = TimeDuration.normalize(h1, min1, s1, ms1, µs1, ns1);
-  const norm2 = TimeDuration.normalize(h2, min2, s2, ms2, µs2, ns2);
-  if (!zonedRelativeTo && !plainRelativeTo) {
-    if (IsCalendarUnit(largestUnit)) {
-      throw new RangeError('relativeTo is required for years, months, or weeks arithmetic');
-    }
-    years = months = weeks = 0;
-    ({ days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds } = BalanceTimeDuration(
-      norm1.add(norm2).add24HourDays(d1 + d2),
-      largestUnit
-    ));
-  } else if (plainRelativeTo) {
-    assertExists(calendarRec);
-    const TemporalDuration = GetIntrinsic('%Temporal.Duration%');
-
-    const dateDuration1 = new TemporalDuration(y1, mon1, w1, d1, 0, 0, 0, 0, 0, 0);
-    const dateDuration2 = new TemporalDuration(y2, mon2, w2, d2, 0, 0, 0, 0, 0, 0);
-    const intermediate = AddDate(calendarRec, plainRelativeTo, dateDuration1);
-    const end = AddDate(calendarRec, intermediate, dateDuration2);
-
-    const dateLargestUnit = LargerOfTwoTemporalUnits('day', largestUnit) as Temporal.DateUnit;
-    const differenceOptions = ObjectCreate(null) as Temporal.DifferenceOptions<Temporal.DateUnit>;
-    differenceOptions.largestUnit = dateLargestUnit;
-    const untilResult = DifferenceDate(calendarRec, plainRelativeTo, end, differenceOptions);
-    years = GetSlot(untilResult, YEARS);
-    months = GetSlot(untilResult, MONTHS);
-    weeks = GetSlot(untilResult, WEEKS);
-    days = GetSlot(untilResult, DAYS);
-    // Signs of date part and time part may not agree; balance them together
-    ({ days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds } = BalanceTimeDuration(
-      norm1.add(norm2).add24HourDays(days),
-      largestUnit
-    ));
-  } else {
-    assertExists(zonedRelativeTo);
-    assertExists(timeZoneRec);
-    assertExists(calendarRec);
-    const TemporalInstant = GetIntrinsic('%Temporal.Instant%');
-    const calendar = GetSlot(zonedRelativeTo, CALENDAR);
-    const startInstant = GetSlot(zonedRelativeTo, INSTANT);
-    let startDateTime = precalculatedPlainDateTime;
-    if (IsCalendarUnit(largestUnit) || largestUnit === 'day') {
-      startDateTime ??= GetPlainDateTimeFor(timeZoneRec, startInstant, calendar);
-    }
-    const intermediateNs = AddZonedDateTime(
-      startInstant,
-      timeZoneRec,
-      calendarRec,
-      y1,
-      mon1,
-      w1,
-      d1,
-      norm1,
-      startDateTime
-    );
-    const endNs = AddZonedDateTime(
-      new TemporalInstant(intermediateNs),
-      timeZoneRec,
-      calendarRec,
-      y2,
-      mon2,
-      w2,
-      d2,
-      norm2
-    );
-    if (largestUnit !== 'year' && largestUnit !== 'month' && largestUnit !== 'week' && largestUnit !== 'day') {
-      // The user is only asking for a time difference, so return difference of instants.
-      years = 0;
-      months = 0;
-      weeks = 0;
-      days = 0;
-      const norm = TimeDuration.fromEpochNsDiff(endNs, GetSlot(zonedRelativeTo, EPOCHNANOSECONDS));
-      ({ hours, minutes, seconds, milliseconds, microseconds, nanoseconds } = BalanceTimeDuration(norm, largestUnit));
-    } else {
-      let norm;
-      ({ years, months, weeks, days, norm } = DifferenceZonedDateTime(
-        GetSlot(zonedRelativeTo, EPOCHNANOSECONDS),
-        endNs,
-        timeZoneRec,
-        calendarRec,
-        largestUnit,
-        ObjectCreate(null) as Temporal.DifferenceOptions<Temporal.DateTimeUnit>,
-        castExists(startDateTime)
-      ));
-      ({ hours, minutes, seconds, milliseconds, microseconds, nanoseconds } = BalanceTimeDuration(norm, 'hour'));
-    }
-  }
-
-  return { years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds };
-}
-
 function AddInstant(epochNanoseconds: JSBI, norm: TimeDuration) {
   const result = norm.addToEpochNs(epochNanoseconds);
   ValidateEpochNanoseconds(result);
@@ -6061,15 +5933,14 @@ function AddDaysToZonedDateTime(
 
 type AddSubtractOperation = 'add' | 'subtract';
 
-export function AddDurationToOrSubtractDurationFromDuration(
+export function AddDurations(
   operation: AddSubtractOperation,
   duration: Temporal.Duration,
-  other: DurationParams['add'][0],
+  otherParam: DurationParams['add'][0],
   optionsParam: DurationParams['add'][1]
 ): Temporal.Duration {
   const sign = operation === 'subtract' ? -1 : 1;
-  let { years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds } =
-    ToTemporalDurationRecord(other);
+  const other = ToTemporalDurationRecord(otherParam);
   const options = GetOptionsObject(optionsParam);
   const { plainRelativeTo, zonedRelativeTo, timeZoneRec } = GetTemporalRelativeToOption(options);
 
@@ -6078,33 +5949,120 @@ export function AddDurationToOrSubtractDurationFromDuration(
     'dateUntil'
   ]);
 
-  ({ years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds } = AddDuration(
-    GetSlot(duration, YEARS),
-    GetSlot(duration, MONTHS),
-    GetSlot(duration, WEEKS),
-    GetSlot(duration, DAYS),
-    GetSlot(duration, HOURS),
-    GetSlot(duration, MINUTES),
-    GetSlot(duration, SECONDS),
-    GetSlot(duration, MILLISECONDS),
-    GetSlot(duration, MICROSECONDS),
-    GetSlot(duration, NANOSECONDS),
-    sign * years,
-    sign * months,
-    sign * weeks,
-    sign * days,
-    sign * hours,
-    sign * minutes,
-    sign * seconds,
-    sign * milliseconds,
-    sign * microseconds,
-    sign * nanoseconds,
-    plainRelativeTo,
-    zonedRelativeTo,
-    calendarRec,
-    timeZoneRec
-  ));
+  const y1 = GetSlot(duration, YEARS);
+  const mon1 = GetSlot(duration, MONTHS);
+  const w1 = GetSlot(duration, WEEKS);
+  const d1 = GetSlot(duration, DAYS);
+  const h1 = GetSlot(duration, HOURS);
+  const min1 = GetSlot(duration, MINUTES);
+  const s1 = GetSlot(duration, SECONDS);
+  const ms1 = GetSlot(duration, MILLISECONDS);
+  const µs1 = GetSlot(duration, MICROSECONDS);
+  const ns1 = GetSlot(duration, NANOSECONDS);
+  const y2 = sign * other.years;
+  const mon2 = sign * other.months;
+  const w2 = sign * other.weeks;
+  const d2 = sign * other.days;
+  const h2 = sign * other.hours;
+  const min2 = sign * other.minutes;
+  const s2 = sign * other.seconds;
+  const ms2 = sign * other.milliseconds;
+  const µs2 = sign * other.microseconds;
+  const ns2 = sign * other.nanoseconds;
+
+  const largestUnit1 = DefaultTemporalLargestUnit(y1, mon1, w1, d1, h1, min1, s1, ms1, µs1);
+  const largestUnit2 = DefaultTemporalLargestUnit(y2, mon2, w2, d2, h2, min2, s2, ms2, µs2);
+  const largestUnit = LargerOfTwoTemporalUnits(largestUnit1, largestUnit2);
+
+  const norm1 = TimeDuration.normalize(h1, min1, s1, ms1, µs1, ns1);
+  const norm2 = TimeDuration.normalize(h2, min2, s2, ms2, µs2, ns2);
   const Duration = GetIntrinsic('%Temporal.Duration%');
+
+  if (!zonedRelativeTo && !plainRelativeTo) {
+    if (IsCalendarUnit(largestUnit)) {
+      throw new RangeError('relativeTo is required for years, months, or weeks arithmetic');
+    }
+    const { days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds } = BalanceTimeDuration(
+      norm1.add(norm2).add24HourDays(d1 + d2),
+      largestUnit
+    );
+    return new Duration(0, 0, 0, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds);
+  }
+
+  if (plainRelativeTo) {
+    assertExists(calendarRec);
+    const dateDuration1 = new Duration(y1, mon1, w1, d1, 0, 0, 0, 0, 0, 0);
+    const dateDuration2 = new Duration(y2, mon2, w2, d2, 0, 0, 0, 0, 0, 0);
+    const intermediate = AddDate(calendarRec, plainRelativeTo, dateDuration1);
+    const end = AddDate(calendarRec, intermediate, dateDuration2);
+
+    const dateLargestUnit = LargerOfTwoTemporalUnits('day', largestUnit);
+    const differenceOptions = ObjectCreate(null);
+    differenceOptions.largestUnit = dateLargestUnit;
+    const untilResult = DifferenceDate(calendarRec, plainRelativeTo, end, differenceOptions);
+    const years = GetSlot(untilResult, YEARS);
+    const months = GetSlot(untilResult, MONTHS);
+    const weeks = GetSlot(untilResult, WEEKS);
+    let days = GetSlot(untilResult, DAYS);
+    // Signs of date part and time part may not agree; balance them together
+    let hours, minutes, seconds, milliseconds, microseconds, nanoseconds;
+    ({ days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds } = BalanceTimeDuration(
+      norm1.add(norm2).add24HourDays(days),
+      largestUnit
+    ));
+    return new Duration(years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds);
+  }
+
+  // zonedRelativeTo is defined
+  assertExists(zonedRelativeTo);
+  assertExists(calendarRec);
+  assertExists(timeZoneRec);
+  const TemporalInstant = GetIntrinsic('%Temporal.Instant%');
+  const calendar = GetSlot(zonedRelativeTo, CALENDAR);
+  const startInstant = GetSlot(zonedRelativeTo, INSTANT);
+  let startDateTime;
+  if (IsCalendarUnit(largestUnit) || largestUnit === 'day') {
+    startDateTime = GetPlainDateTimeFor(timeZoneRec, startInstant, calendar);
+  }
+  const intermediateNs = AddZonedDateTime(
+    startInstant,
+    timeZoneRec,
+    calendarRec,
+    y1,
+    mon1,
+    w1,
+    d1,
+    norm1,
+    startDateTime
+  );
+  const endNs = AddZonedDateTime(
+    new TemporalInstant(intermediateNs),
+    timeZoneRec,
+    calendarRec,
+    y2,
+    mon2,
+    w2,
+    d2,
+    norm2
+  );
+  if (largestUnit !== 'year' && largestUnit !== 'month' && largestUnit !== 'week' && largestUnit !== 'day') {
+    // The user is only asking for a time difference, so return difference of instants.
+    const norm = TimeDuration.fromEpochNsDiff(endNs, GetSlot(zonedRelativeTo, EPOCHNANOSECONDS));
+    const { hours, minutes, seconds, milliseconds, microseconds, nanoseconds } = BalanceTimeDuration(norm, largestUnit);
+    return new Duration(0, 0, 0, 0, hours, minutes, seconds, milliseconds, microseconds, nanoseconds);
+  }
+
+  assertExists(startDateTime);
+  const { years, months, weeks, days, norm } = DifferenceZonedDateTime(
+    GetSlot(zonedRelativeTo, EPOCHNANOSECONDS),
+    endNs,
+    timeZoneRec,
+    calendarRec,
+    largestUnit,
+    ObjectCreate(null),
+    startDateTime
+  );
+  const { hours, minutes, seconds, milliseconds, microseconds, nanoseconds } = BalanceTimeDuration(norm, 'hour');
   return new Duration(years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds);
 }
 

--- a/lib/ecmascript.ts
+++ b/lib/ecmascript.ts
@@ -5020,7 +5020,9 @@ function RoundRelativeDuration(
 }
 
 export function DifferencePlainDateTimeWithRounding(
-  plainDate1: Temporal.PlainDate,
+  y1: number,
+  mon1: number,
+  d1: number,
   h1: number,
   min1: number,
   s1: number,
@@ -5043,9 +5045,6 @@ export function DifferencePlainDateTimeWithRounding(
   roundingMode: Temporal.RoundingMode,
   resolvedOptions: Temporal.DifferenceOptions<Temporal.DateTimeUnit> = ObjectCreate(null)
 ) {
-  const y1 = GetSlot(plainDate1, ISO_YEAR);
-  const mon1 = GetSlot(plainDate1, ISO_MONTH);
-  const d1 = GetSlot(plainDate1, ISO_DAY);
   if (CompareISODateTime(y1, mon1, d1, h1, min1, s1, ms1, µs1, ns1, y2, mon2, d2, h2, min2, s2, ms2, µs2, ns2) == 0) {
     return {
       years: 0,
@@ -5401,11 +5400,12 @@ export function DifferenceTemporalPlainDateTime(
     return new Duration();
   }
 
-  const plainDate1 = TemporalDateTimeToDate(plainDateTime);
   const calendarRec = new CalendarMethodRecord(calendar, ['dateAdd', 'dateUntil']);
   const { years, months, weeks, days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds } =
     DifferencePlainDateTimeWithRounding(
-      plainDate1,
+      GetSlot(plainDateTime, ISO_YEAR),
+      GetSlot(plainDateTime, ISO_MONTH),
+      GetSlot(plainDateTime, ISO_DAY),
       GetSlot(plainDateTime, ISO_HOUR),
       GetSlot(plainDateTime, ISO_MINUTE),
       GetSlot(plainDateTime, ISO_SECOND),

--- a/lib/instant.ts
+++ b/lib/instant.ts
@@ -7,7 +7,7 @@ import { DateTimeFormat } from './intl';
 import type { InstantParams as Params, InstantReturn as Return } from './internaltypes';
 
 import JSBI from 'jsbi';
-import { BigIntFloorDiv, BILLION, MILLION, THOUSAND } from './bigintmath';
+import { BigIntFloorDiv, MILLION } from './bigintmath';
 import { TimeZoneMethodRecord } from './methodrecord';
 
 export class Instant implements Temporal.Instant {
@@ -36,20 +36,10 @@ export class Instant implements Temporal.Instant {
     }
   }
 
-  get epochSeconds(): Return['epochSeconds'] {
-    if (!ES.IsTemporalInstant(this)) throw new TypeError('invalid receiver');
-    const value = GetSlot(this, EPOCHNANOSECONDS);
-    return JSBI.toNumber(BigIntFloorDiv(value, BILLION));
-  }
   get epochMilliseconds(): Return['epochMilliseconds'] {
     if (!ES.IsTemporalInstant(this)) throw new TypeError('invalid receiver');
     const value = GetSlot(this, EPOCHNANOSECONDS);
     return JSBI.toNumber(BigIntFloorDiv(value, MILLION));
-  }
-  get epochMicroseconds(): Return['epochMicroseconds'] {
-    if (!ES.IsTemporalInstant(this)) throw new TypeError('invalid receiver');
-    const value = JSBI.BigInt(GetSlot(this, EPOCHNANOSECONDS));
-    return ES.ToBigIntExternal(BigIntFloorDiv(value, THOUSAND));
   }
   get epochNanoseconds(): Return['epochNanoseconds'] {
     if (!ES.IsTemporalInstant(this)) throw new TypeError('invalid receiver');
@@ -154,25 +144,11 @@ export class Instant implements Temporal.Instant {
     return ES.CreateTemporalZonedDateTime(GetSlot(this, EPOCHNANOSECONDS), timeZone, 'iso8601');
   }
 
-  static fromEpochSeconds(epochSecondsParam: Params['fromEpochSeconds'][0]): Return['fromEpochSeconds'] {
-    const epochSeconds = ES.ToNumber(epochSecondsParam);
-    const epochNanoseconds = JSBI.multiply(JSBI.BigInt(epochSeconds), BILLION);
-    ES.ValidateEpochNanoseconds(epochNanoseconds);
-    return new Instant(epochNanoseconds);
-  }
   static fromEpochMilliseconds(
     epochMillisecondsParam: Params['fromEpochMilliseconds'][0]
   ): Return['fromEpochMilliseconds'] {
     const epochMilliseconds = ES.ToNumber(epochMillisecondsParam);
     const epochNanoseconds = JSBI.multiply(JSBI.BigInt(epochMilliseconds), MILLION);
-    ES.ValidateEpochNanoseconds(epochNanoseconds);
-    return new Instant(epochNanoseconds);
-  }
-  static fromEpochMicroseconds(
-    epochMicrosecondsParam: Params['fromEpochMicroseconds'][0]
-  ): Return['fromEpochMicroseconds'] {
-    const epochMicroseconds = ES.ToBigInt(epochMicrosecondsParam);
-    const epochNanoseconds = JSBI.multiply(epochMicroseconds, THOUSAND);
     ES.ValidateEpochNanoseconds(epochNanoseconds);
     return new Instant(epochNanoseconds);
   }

--- a/lib/instant.ts
+++ b/lib/instant.ts
@@ -121,23 +121,6 @@ export class Instant implements Temporal.Instant {
   valueOf(): never {
     ES.ValueOfThrows('Instant');
   }
-  toZonedDateTime(item: Params['toZonedDateTime'][0]): Return['toZonedDateTime'] {
-    if (!ES.IsTemporalInstant(this)) throw new TypeError('invalid receiver');
-    if (!ES.IsObject(item)) {
-      throw new TypeError('invalid argument in toZonedDateTime');
-    }
-    const calendarLike = item.calendar;
-    if (calendarLike === undefined) {
-      throw new TypeError('missing calendar property in toZonedDateTime');
-    }
-    const calendar = ES.ToTemporalCalendarSlotValue(calendarLike);
-    const temporalTimeZoneLike = item.timeZone;
-    if (temporalTimeZoneLike === undefined) {
-      throw new TypeError('missing timeZone property in toZonedDateTime');
-    }
-    const timeZone = ES.ToTemporalTimeZoneSlotValue(temporalTimeZoneLike);
-    return ES.CreateTemporalZonedDateTime(GetSlot(this, EPOCHNANOSECONDS), timeZone, calendar);
-  }
   toZonedDateTimeISO(timeZoneParam: Params['toZonedDateTimeISO'][0]): Return['toZonedDateTimeISO'] {
     if (!ES.IsTemporalInstant(this)) throw new TypeError('invalid receiver');
     const timeZone = ES.ToTemporalTimeZoneSlotValue(timeZoneParam);

--- a/lib/now.ts
+++ b/lib/now.ts
@@ -7,35 +7,15 @@ const instant: (typeof Temporal.Now)['instant'] = () => {
   const Instant = GetIntrinsic('%Temporal.Instant%');
   return new Instant(ES.SystemUTCEpochNanoSeconds());
 };
-const plainDateTime: (typeof Temporal.Now)['plainDateTime'] = (
-  calendarLike,
-  temporalTimeZoneLike = ES.DefaultTimeZone()
-) => {
-  const tZ = ES.ToTemporalTimeZoneSlotValue(temporalTimeZoneLike);
-  const calendar = ES.ToTemporalCalendarSlotValue(calendarLike);
-  const inst = instant();
-  const timeZoneRec = new TimeZoneMethodRecord(tZ, ['getOffsetNanosecondsFor']);
-  return ES.GetPlainDateTimeFor(timeZoneRec, inst, calendar);
-};
 const plainDateTimeISO: (typeof Temporal.Now)['plainDateTimeISO'] = (temporalTimeZoneLike = ES.DefaultTimeZone()) => {
-  const tZ = ES.ToTemporalTimeZoneSlotValue(temporalTimeZoneLike);
+  const timeZone = ES.ToTemporalTimeZoneSlotValue(temporalTimeZoneLike);
   const inst = instant();
-  const timeZoneRec = new TimeZoneMethodRecord(tZ, ['getOffsetNanosecondsFor']);
+  const timeZoneRec = new TimeZoneMethodRecord(timeZone, ['getOffsetNanosecondsFor']);
   return ES.GetPlainDateTimeFor(timeZoneRec, inst, 'iso8601');
 };
-const zonedDateTime: (typeof Temporal.Now)['zonedDateTime'] = (
-  calendarLike,
-  temporalTimeZoneLike = ES.DefaultTimeZone()
-) => {
-  const tZ = ES.ToTemporalTimeZoneSlotValue(temporalTimeZoneLike);
-  const calendar = ES.ToTemporalCalendarSlotValue(calendarLike);
-  return ES.CreateTemporalZonedDateTime(ES.SystemUTCEpochNanoSeconds(), tZ, calendar);
-};
 const zonedDateTimeISO: (typeof Temporal.Now)['zonedDateTimeISO'] = (temporalTimeZoneLike = ES.DefaultTimeZone()) => {
-  return zonedDateTime('iso8601', temporalTimeZoneLike);
-};
-const plainDate: (typeof Temporal.Now)['plainDate'] = (calendarLike, temporalTimeZoneLike = ES.DefaultTimeZone()) => {
-  return ES.TemporalDateTimeToDate(plainDateTime(calendarLike, temporalTimeZoneLike));
+  const timeZone = ES.ToTemporalTimeZoneSlotValue(temporalTimeZoneLike);
+  return ES.CreateTemporalZonedDateTime(ES.SystemUTCEpochNanoSeconds(), timeZone, 'iso8601');
 };
 const plainDateISO: (typeof Temporal.Now)['plainDateISO'] = (temporalTimeZoneLike = ES.DefaultTimeZone()) => {
   return ES.TemporalDateTimeToDate(plainDateTimeISO(temporalTimeZoneLike));
@@ -49,13 +29,10 @@ const timeZoneId: (typeof Temporal.Now)['timeZoneId'] = () => {
 
 export const Now: typeof Temporal.Now = {
   instant,
-  plainDateTime,
   plainDateTimeISO,
-  plainDate,
   plainDateISO,
   plainTimeISO,
   timeZoneId,
-  zonedDateTime,
   zonedDateTimeISO,
   [Symbol.toStringTag]: 'Temporal.Now'
 };

--- a/lib/plaindatetime.ts
+++ b/lib/plaindatetime.ts
@@ -206,36 +206,6 @@ export class PlainDateTime implements Temporal.PlainDateTime {
       GetSlot(this, CALENDAR)
     );
   }
-  withPlainDate(temporalDateParam: Params['withPlainDate'][0]): Return['withPlainDate'] {
-    if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
-
-    const temporalDate = ES.ToTemporalDate(temporalDateParam);
-    const year = GetSlot(temporalDate, ISO_YEAR);
-    const month = GetSlot(temporalDate, ISO_MONTH);
-    const day = GetSlot(temporalDate, ISO_DAY);
-    let calendar = GetSlot(temporalDate, CALENDAR);
-
-    const hour = GetSlot(this, ISO_HOUR);
-    const minute = GetSlot(this, ISO_MINUTE);
-    const second = GetSlot(this, ISO_SECOND);
-    const millisecond = GetSlot(this, ISO_MILLISECOND);
-    const microsecond = GetSlot(this, ISO_MICROSECOND);
-    const nanosecond = GetSlot(this, ISO_NANOSECOND);
-
-    calendar = ES.ConsolidateCalendars(GetSlot(this, CALENDAR), calendar);
-    return ES.CreateTemporalDateTime(
-      year,
-      month,
-      day,
-      hour,
-      minute,
-      second,
-      millisecond,
-      microsecond,
-      nanosecond,
-      calendar
-    );
-  }
   withCalendar(calendarParam: Params['withCalendar'][0]): Return['withCalendar'] {
     if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
     const calendar = ES.ToTemporalCalendarSlotValue(calendarParam);

--- a/lib/plaindatetime.ts
+++ b/lib/plaindatetime.ts
@@ -386,18 +386,6 @@ export class PlainDateTime implements Temporal.PlainDateTime {
     if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
     return ES.TemporalDateTimeToDate(this);
   }
-  toPlainYearMonth(): Return['toPlainYearMonth'] {
-    if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
-    const calendarRec = new CalendarMethodRecord(GetSlot(this, CALENDAR), ['fields', 'yearMonthFromFields']);
-    const fields = ES.PrepareCalendarFields(calendarRec, this, ['monthCode', 'year'], [], []);
-    return ES.CalendarYearMonthFromFields(calendarRec, fields);
-  }
-  toPlainMonthDay(): Return['toPlainMonthDay'] {
-    if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
-    const calendarRec = new CalendarMethodRecord(GetSlot(this, CALENDAR), ['fields', 'monthDayFromFields']);
-    const fields = ES.PrepareCalendarFields(calendarRec, this, ['day', 'monthCode'], [], []);
-    return ES.CalendarMonthDayFromFields(calendarRec, fields);
-  }
   toPlainTime(): Return['toPlainTime'] {
     if (!ES.IsTemporalDateTime(this)) throw new TypeError('invalid receiver');
     return ES.TemporalDateTimeToTime(this);

--- a/lib/plaintime.ts
+++ b/lib/plaintime.ts
@@ -1,20 +1,14 @@
 import { DEBUG } from './debug';
 import * as ES from './ecmascript';
 import { MakeIntrinsicClass } from './intrinsicclass';
-import { TimeZoneMethodRecord } from './methodrecord';
 
 import {
-  ISO_YEAR,
-  ISO_MONTH,
-  ISO_DAY,
   ISO_HOUR,
   ISO_MINUTE,
   ISO_SECOND,
   ISO_MILLISECOND,
   ISO_MICROSECOND,
   ISO_NANOSECOND,
-  CALENDAR,
-  EPOCHNANOSECONDS,
   CreateSlots,
   GetSlot,
   SetSlot
@@ -238,81 +232,6 @@ export class PlainTime implements Temporal.PlainTime {
     ES.ValueOfThrows('PlainTime');
   }
 
-  toPlainDateTime(temporalDateParam: Params['toPlainDateTime'][0]): Return['toPlainDateTime'] {
-    if (!ES.IsTemporalTime(this)) throw new TypeError('invalid receiver');
-
-    const temporalDate = ES.ToTemporalDate(temporalDateParam);
-    const year = GetSlot(temporalDate, ISO_YEAR);
-    const month = GetSlot(temporalDate, ISO_MONTH);
-    const day = GetSlot(temporalDate, ISO_DAY);
-    const calendar = GetSlot(temporalDate, CALENDAR);
-
-    const hour = GetSlot(this, ISO_HOUR);
-    const minute = GetSlot(this, ISO_MINUTE);
-    const second = GetSlot(this, ISO_SECOND);
-    const millisecond = GetSlot(this, ISO_MILLISECOND);
-    const microsecond = GetSlot(this, ISO_MICROSECOND);
-    const nanosecond = GetSlot(this, ISO_NANOSECOND);
-
-    return ES.CreateTemporalDateTime(
-      year,
-      month,
-      day,
-      hour,
-      minute,
-      second,
-      millisecond,
-      microsecond,
-      nanosecond,
-      calendar
-    );
-  }
-  toZonedDateTime(item: Params['toZonedDateTime'][0]): Return['toZonedDateTime'] {
-    if (!ES.IsTemporalTime(this)) throw new TypeError('invalid receiver');
-
-    if (!ES.IsObject(item)) {
-      throw new TypeError('invalid argument');
-    }
-
-    const dateLike = item.plainDate;
-    if (dateLike === undefined) {
-      throw new TypeError('missing date property');
-    }
-    const temporalDate = ES.ToTemporalDate(dateLike);
-
-    const timeZoneLike = item.timeZone;
-    if (timeZoneLike === undefined) {
-      throw new TypeError('missing timeZone property');
-    }
-    const timeZone = ES.ToTemporalTimeZoneSlotValue(timeZoneLike);
-
-    const year = GetSlot(temporalDate, ISO_YEAR);
-    const month = GetSlot(temporalDate, ISO_MONTH);
-    const day = GetSlot(temporalDate, ISO_DAY);
-    const calendar = GetSlot(temporalDate, CALENDAR);
-    const hour = GetSlot(this, ISO_HOUR);
-    const minute = GetSlot(this, ISO_MINUTE);
-    const second = GetSlot(this, ISO_SECOND);
-    const millisecond = GetSlot(this, ISO_MILLISECOND);
-    const microsecond = GetSlot(this, ISO_MICROSECOND);
-    const nanosecond = GetSlot(this, ISO_NANOSECOND);
-
-    const dt = ES.CreateTemporalDateTime(
-      year,
-      month,
-      day,
-      hour,
-      minute,
-      second,
-      millisecond,
-      microsecond,
-      nanosecond,
-      calendar
-    );
-    const timeZoneRec = new TimeZoneMethodRecord(timeZone, ['getOffsetNanosecondsFor', 'getPossibleInstantsFor']);
-    const instant = ES.GetInstantFor(timeZoneRec, dt, 'compatible');
-    return ES.CreateTemporalZonedDateTime(GetSlot(instant, EPOCHNANOSECONDS), timeZone, calendar);
-  }
   getISOFields(): Return['getISOFields'] {
     if (!ES.IsTemporalTime(this)) throw new TypeError('invalid receiver');
     return {

--- a/lib/zoneddatetime.ts
+++ b/lib/zoneddatetime.ts
@@ -264,43 +264,6 @@ export class ZonedDateTime implements Temporal.ZonedDateTime {
 
     return ES.CreateTemporalZonedDateTime(epochNanoseconds, timeZoneRec.receiver, calendarRec.receiver);
   }
-  withPlainDate(temporalDateParam: Params['withPlainDate'][0]): Return['withPlainDate'] {
-    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
-
-    const temporalDate = ES.ToTemporalDate(temporalDateParam);
-
-    const year = GetSlot(temporalDate, ISO_YEAR);
-    const month = GetSlot(temporalDate, ISO_MONTH);
-    const day = GetSlot(temporalDate, ISO_DAY);
-    let calendar = GetSlot(temporalDate, CALENDAR);
-    const timeZoneRec = new TimeZoneMethodRecord(GetSlot(this, TIME_ZONE), [
-      'getOffsetNanosecondsFor',
-      'getPossibleInstantsFor'
-    ]);
-    const thisDt = ES.GetPlainDateTimeFor(timeZoneRec, GetSlot(this, INSTANT), GetSlot(this, CALENDAR));
-    const hour = GetSlot(thisDt, ISO_HOUR);
-    const minute = GetSlot(thisDt, ISO_MINUTE);
-    const second = GetSlot(thisDt, ISO_SECOND);
-    const millisecond = GetSlot(thisDt, ISO_MILLISECOND);
-    const microsecond = GetSlot(thisDt, ISO_MICROSECOND);
-    const nanosecond = GetSlot(thisDt, ISO_NANOSECOND);
-
-    calendar = ES.ConsolidateCalendars(GetSlot(this, CALENDAR), calendar);
-    const dt = ES.CreateTemporalDateTime(
-      year,
-      month,
-      day,
-      hour,
-      minute,
-      second,
-      millisecond,
-      microsecond,
-      nanosecond,
-      calendar
-    );
-    const instant = ES.GetInstantFor(timeZoneRec, dt, 'compatible');
-    return ES.CreateTemporalZonedDateTime(GetSlot(instant, EPOCHNANOSECONDS), timeZoneRec.receiver, calendar);
-  }
   withPlainTime(temporalTimeParam: Params['withPlainTime'][0] = undefined): Return['withPlainTime'] {
     if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
 

--- a/lib/zoneddatetime.ts
+++ b/lib/zoneddatetime.ts
@@ -23,7 +23,7 @@ import { DateTimeFormat } from './intl';
 import type { ZonedDateTimeParams as Params, ZonedDateTimeReturn as Return } from './internaltypes';
 
 import JSBI from 'jsbi';
-import { BILLION, MILLION, THOUSAND, HOUR_NANOS, BigIntFloorDiv } from './bigintmath';
+import { MILLION, HOUR_NANOS, BigIntFloorDiv } from './bigintmath';
 
 const ArrayPrototypePush = Array.prototype.push;
 const customResolvedOptions = DateTimeFormat.prototype.resolvedOptions as Intl.DateTimeFormat['resolvedOptions'];
@@ -103,20 +103,10 @@ export class ZonedDateTime implements Temporal.ZonedDateTime {
     if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
     return ES.CalendarEraYear(GetSlot(this, CALENDAR), dateTime(this));
   }
-  get epochSeconds(): Return['epochSeconds'] {
-    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
-    const value = GetSlot(this, EPOCHNANOSECONDS);
-    return JSBI.toNumber(BigIntFloorDiv(value, BILLION));
-  }
   get epochMilliseconds(): Return['epochMilliseconds'] {
     if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
     const value = GetSlot(this, EPOCHNANOSECONDS);
     return JSBI.toNumber(BigIntFloorDiv(value, MILLION));
-  }
-  get epochMicroseconds(): Return['epochMicroseconds'] {
-    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
-    const value = GetSlot(this, EPOCHNANOSECONDS);
-    return ES.ToBigIntExternal(BigIntFloorDiv(value, THOUSAND));
   }
   get epochNanoseconds(): Return['epochNanoseconds'] {
     if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');

--- a/lib/zoneddatetime.ts
+++ b/lib/zoneddatetime.ts
@@ -566,20 +566,6 @@ export class ZonedDateTime implements Temporal.ZonedDateTime {
     if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
     return dateTime(this);
   }
-  toPlainYearMonth(): Return['toPlainYearMonth'] {
-    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
-    const calendarRec = new CalendarMethodRecord(GetSlot(this, CALENDAR), ['fields', 'yearMonthFromFields']);
-    const dt = dateTime(this);
-    const fields = ES.PrepareCalendarFields(calendarRec, dt, ['monthCode', 'year'], [], []);
-    return ES.CalendarYearMonthFromFields(calendarRec, fields);
-  }
-  toPlainMonthDay(): Return['toPlainMonthDay'] {
-    if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
-    const calendarRec = new CalendarMethodRecord(GetSlot(this, CALENDAR), ['fields', 'monthDayFromFields']);
-    const dt = dateTime(this);
-    const fields = ES.PrepareCalendarFields(calendarRec, dt, ['day', 'monthCode'], [], []);
-    return ES.CalendarMonthDayFromFields(calendarRec, fields);
-  }
   getISOFields(): Return['getISOFields'] {
     if (!ES.IsTemporalZonedDateTime(this)) throw new TypeError('invalid receiver');
     const timeZoneRec = new TimeZoneMethodRecord(GetSlot(this, TIME_ZONE), ['getOffsetNanosecondsFor']);

--- a/test/validStrings.mjs
+++ b/test/validStrings.mjs
@@ -263,7 +263,7 @@ const utcOffsetSubMinutePrecision = withCode(
   choice(utcOffsetMinutePrecision, utcOffsetWithSubMinuteComponents(true), utcOffsetWithSubMinuteComponents(false)),
   saveOffset
 );
-const dateTimeUTCOffset = choice(utcDesignator, utcOffsetSubMinutePrecision);
+const dateTimeUTCOffset = (z) => (z ? choice(utcDesignator, utcOffsetSubMinutePrecision) : utcOffsetSubMinutePrecision);
 const timeZoneUTCOffsetName = utcOffsetMinutePrecision;
 const timeZoneIANAName = choice(...timezoneNames);
 const timeZoneIdentifier = withCode(
@@ -306,11 +306,11 @@ const dateSpec = (extended) =>
     validateDayOfMonth
   );
 const date = choice(dateSpec(true), dateSpec(false));
-const dateTime = seq(date, [dateTimeSeparator, time, [dateTimeUTCOffset]]);
+const dateTime = (z) => seq(date, [dateTimeSeparator, time, [dateTimeUTCOffset(z)]]);
 const annotatedTime = choice(
-  seq(timeDesignator, time, [dateTimeUTCOffset], [timeZoneAnnotation], [annotations]),
+  seq(timeDesignator, time, [dateTimeUTCOffset(false)], [timeZoneAnnotation], [annotations]),
   seq(
-    withSyntaxConstraints(seq(time, [dateTimeUTCOffset]), (result) => {
+    withSyntaxConstraints(seq(time, [dateTimeUTCOffset(false)]), (result) => {
       if (/^(?:(?!02-?30)(?:0[1-9]|1[012])-?(?:0[1-9]|[12][0-9]|30)|(?:0[13578]|10|12)-?31)$/.test(result)) {
         throw new SyntaxError('valid PlainMonthDay');
       }
@@ -322,12 +322,13 @@ const annotatedTime = choice(
     [annotations]
   )
 );
-const annotatedDateTime = seq(dateTime, [timeZoneAnnotation], [annotations]);
+const annotatedDateTime = (zoned) =>
+  seq(dateTime(zoned), zoned ? timeZoneAnnotation : [timeZoneAnnotation], [annotations]);
 const annotatedDateTimeTimeRequired = seq(
   date,
   dateTimeSeparator,
   time,
-  [dateTimeUTCOffset],
+  [dateTimeUTCOffset(false)],
   [timeZoneAnnotation],
   [annotations]
 );
@@ -441,19 +442,19 @@ const duration = withSyntaxConstraints(
   }
 );
 
-const instant = seq(date, dateTimeSeparator, time, dateTimeUTCOffset, [timeZoneAnnotation], [annotations]);
-const zonedDateTime = seq(dateTime, timeZoneAnnotation, [annotations]);
+const instant = seq(date, dateTimeSeparator, time, dateTimeUTCOffset(true), [timeZoneAnnotation], [annotations]);
+const zonedDateTime = annotatedDateTime(true);
 
 // goal elements
 const goals = {
   Instant: instant,
-  Date: annotatedDateTime,
-  DateTime: annotatedDateTime,
+  Date: annotatedDateTime(false),
+  DateTime: annotatedDateTime(false),
   Duration: duration,
-  MonthDay: choice(annotatedMonthDay, annotatedDateTime),
+  MonthDay: choice(annotatedMonthDay, annotatedDateTime(false)),
   Time: choice(annotatedTime, annotatedDateTimeTimeRequired),
   TimeZone: choice(timeZoneIdentifier, zonedDateTime, instant),
-  YearMonth: choice(annotatedYearMonth, annotatedDateTime),
+  YearMonth: choice(annotatedYearMonth, annotatedDateTime(false)),
   ZonedDateTime: zonedDateTime
 };
 
@@ -481,16 +482,12 @@ const comparisonItems = {
   YearMonth: ['year', 'month', 'calendar'],
   ZonedDateTime: [...dateItems, ...timeItems, 'offset', 'z', 'tzAnnotation', 'calendar']
 };
-const plainModes = ['Date', 'DateTime', 'MonthDay', 'Time', 'YearMonth'];
 
 function fuzzMode(mode) {
   console.log('// starting to fuzz ' + mode);
   for (let count = 0; count < 1000; count++) {
-    let generatedData, fuzzed;
-    do {
-      generatedData = {};
-      fuzzed = goals[mode].generate(generatedData);
-    } while (plainModes.includes(mode) && /[0-9][zZ]/.test(fuzzed));
+    const generatedData = {};
+    const fuzzed = goals[mode].generate(generatedData);
     try {
       const parsingMethod = ES[`ParseTemporal${mode}StringRaw`] ?? ES[`ParseTemporal${mode}String`];
       const parsed = parsingMethod(fuzzed);

--- a/test/validStrings.mjs
+++ b/test/validStrings.mjs
@@ -228,26 +228,11 @@ const dateYear = withCode(
 const dateMonth = withCode(zeroPaddedInclusive(1, 12, 2), (data, result) => (data.month = +result));
 const dateDay = withCode(zeroPaddedInclusive(1, 31, 2), (data, result) => (data.day = +result));
 
-function saveHour(data, result) {
-  data.hour = +result;
-}
-function saveMinute(data, result) {
-  data.minute = +result;
-}
 function saveSecond(data, result) {
   data.second = +result;
   if (data.second === 60) data.second = 59;
 }
-const timeHour = withCode(hour, saveHour);
-const timeMinute = withCode(minuteSecond, saveMinute);
 const timeSecond = withCode(choice(minuteSecond, '60'), saveSecond);
-const timeFraction = withCode(temporalDecimalFraction, (data, result) => {
-  result = result.slice(1);
-  const fraction = result.padEnd(9, '0');
-  data.millisecond = +fraction.slice(0, 3);
-  data.microsecond = +fraction.slice(3, 6);
-  data.nanosecond = +fraction.slice(6, 9);
-});
 
 function saveOffset(data, result) {
   data.offset = ES.ParseDateTimeUTCOffset(result);
@@ -269,10 +254,9 @@ const utcOffset = (subMinutePrecision) =>
   ]);
 const dateTimeUTCOffset = (z) =>
   z ? choice(utcDesignator, withCode(utcOffset(true), saveOffset)) : withCode(utcOffset(true), saveOffset);
-const timeZoneUTCOffsetName = utcOffset(false);
 const timeZoneIANAName = choice(...timezoneNames);
 const timeZoneIdentifier = withCode(
-  choice(timeZoneUTCOffsetName, timeZoneIANAName),
+  choice(utcOffset(false), timeZoneIANAName),
   (data, result) => (data.tzAnnotation = result)
 );
 const timeZoneAnnotation = seq('[', [annotationCriticalFlag], timeZoneIdentifier, ']');
@@ -294,7 +278,26 @@ const annotations = withSyntaxConstraints(oneOrMore(choice(calendarAnnotation, a
   }
 });
 const timeSpec = (extended) =>
-  seq(timeHour, [timeSeparator(extended), timeMinute, [timeSeparator(extended), timeSecond, [timeFraction]]]);
+  seq(
+    withCode(hour, (data, result) => (data.hour = +result)),
+    [
+      timeSeparator(extended),
+      withCode(minuteSecond, (data, result) => (data.minute = +result)),
+      [
+        timeSeparator(extended),
+        timeSecond,
+        [
+          withCode(temporalDecimalFraction, (data, result) => {
+            result = result.slice(1);
+            const fraction = result.padEnd(9, '0');
+            data.millisecond = +fraction.slice(0, 3);
+            data.microsecond = +fraction.slice(3, 6);
+            data.nanosecond = +fraction.slice(6, 9);
+          })
+        ]
+      ]
+    ]
+  );
 const time = choice(timeSpec(true), timeSpec(false));
 
 function validateDayOfMonth(result, { year, month, day }) {
@@ -352,31 +355,6 @@ const annotatedMonthDay = withSyntaxConstraints(
   }
 );
 
-const durationSecondsFraction = withCode(temporalDecimalFraction, (data, result) => {
-  result = result.slice(1);
-  const fraction = result.padEnd(9, '0');
-  data.milliseconds = +fraction.slice(0, 3) * data.factor;
-  data.microseconds = +fraction.slice(3, 6) * data.factor;
-  data.nanoseconds = +fraction.slice(6, 9) * data.factor;
-});
-const durationMinutesFraction = withCode(temporalDecimalFraction, (data, result) => {
-  result = result.slice(1);
-  const ns = +result.padEnd(9, '0') * 60;
-  data.seconds = Math.trunc(ns / 1e9) * data.factor;
-  data.milliseconds = Math.trunc((ns % 1e9) / 1e6) * data.factor;
-  data.microseconds = Math.trunc((ns % 1e6) / 1e3) * data.factor;
-  data.nanoseconds = Math.trunc(ns % 1e3) * data.factor;
-});
-const durationHoursFraction = withCode(temporalDecimalFraction, (data, result) => {
-  result = result.slice(1);
-  const ns = +result.padEnd(9, '0') * 3600;
-  data.minutes = Math.trunc(ns / 6e10) * data.factor;
-  data.seconds = Math.trunc((ns % 6e10) / 1e9) * data.factor;
-  data.milliseconds = Math.trunc((ns % 1e9) / 1e6) * data.factor;
-  data.microseconds = Math.trunc((ns % 1e6) / 1e3) * data.factor;
-  data.nanoseconds = Math.trunc(ns % 1e3) * data.factor;
-});
-
 const uint32Digits = withSyntaxConstraints(between(1, 10, digit()), (result) => {
   if (+result >= 2 ** 32) throw new SyntaxError('try again for an uint32');
 });
@@ -384,40 +362,77 @@ const timeDurationDigits = (factor) =>
   withSyntaxConstraints(between(1, 16, digit()), (result) => {
     if (!Number.isSafeInteger(+result * factor)) throw new SyntaxError('try again on unsafe integer');
   });
-const durationSeconds = seq(
+const durationSecondsPart = seq(
   withCode(timeDurationDigits(1), (data, result) => (data.seconds = +result * data.factor)),
-  [durationSecondsFraction],
+  [
+    withCode(temporalDecimalFraction, (data, result) => {
+      result = result.slice(1);
+      const fraction = result.padEnd(9, '0');
+      data.milliseconds = +fraction.slice(0, 3) * data.factor;
+      data.microseconds = +fraction.slice(3, 6) * data.factor;
+      data.nanoseconds = +fraction.slice(6, 9) * data.factor;
+    })
+  ],
   secondsDesignator
 );
-const durationMinutes = seq(
+const durationMinutesPart = seq(
   withCode(timeDurationDigits(60), (data, result) => (data.minutes = +result * data.factor)),
-  choice(seq(minutesDesignator, [durationSeconds]), seq(durationMinutesFraction, minutesDesignator))
+  choice(
+    seq(minutesDesignator, [durationSecondsPart]),
+    seq(
+      withCode(temporalDecimalFraction, (data, result) => {
+        result = result.slice(1);
+        const ns = +result.padEnd(9, '0') * 60;
+        data.seconds = Math.trunc(ns / 1e9) * data.factor;
+        data.milliseconds = Math.trunc((ns % 1e9) / 1e6) * data.factor;
+        data.microseconds = Math.trunc((ns % 1e6) / 1e3) * data.factor;
+        data.nanoseconds = Math.trunc(ns % 1e3) * data.factor;
+      }),
+      minutesDesignator
+    )
+  )
 );
-const durationHours = seq(
+const durationHoursPart = seq(
   withCode(timeDurationDigits(3600), (data, result) => (data.hours = +result * data.factor)),
-  choice(seq(hoursDesignator, [choice(durationMinutes, durationSeconds)]), seq(durationHoursFraction, hoursDesignator))
+  choice(
+    seq(hoursDesignator, [choice(durationMinutesPart, durationSecondsPart)]),
+    seq(
+      withCode(temporalDecimalFraction, (data, result) => {
+        result = result.slice(1);
+        const ns = +result.padEnd(9, '0') * 3600;
+        data.minutes = Math.trunc(ns / 6e10) * data.factor;
+        data.seconds = Math.trunc((ns % 6e10) / 1e9) * data.factor;
+        data.milliseconds = Math.trunc((ns % 1e9) / 1e6) * data.factor;
+        data.microseconds = Math.trunc((ns % 1e6) / 1e3) * data.factor;
+        data.nanoseconds = Math.trunc(ns % 1e3) * data.factor;
+      }),
+      hoursDesignator
+    )
+  )
 );
-const durationTime = seq(timeDesignator, choice(durationHours, durationMinutes, durationSeconds));
-const durationDays = seq(
+const durationTime = seq(timeDesignator, choice(durationHoursPart, durationMinutesPart, durationSecondsPart));
+const durationDaysPart = seq(
   withCode(timeDurationDigits(86400), (data, result) => (data.days = +result * data.factor)),
   daysDesignator
 );
-const durationWeeks = seq(
+const durationWeeksPart = seq(
   withCode(uint32Digits, (data, result) => (data.weeks = +result * data.factor)),
   weeksDesignator,
-  [durationDays]
+  [durationDaysPart]
 );
-const durationMonths = seq(
+const durationMonthsPart = seq(
   withCode(uint32Digits, (data, result) => (data.months = +result * data.factor)),
   monthsDesignator,
-  [choice(durationWeeks, durationDays)]
+  [choice(durationWeeksPart, durationDaysPart)]
 );
-const durationYears = seq(
+const durationYearsPart = seq(
   withCode(uint32Digits, (data, result) => (data.years = +result * data.factor)),
   yearsDesignator,
-  [choice(durationMonths, durationWeeks, durationDays)]
+  [choice(durationMonthsPart, durationWeeksPart, durationDaysPart)]
 );
-const durationDate = seq(choice(durationYears, durationMonths, durationWeeks, durationDays), [durationTime]);
+const durationDate = seq(choice(durationYearsPart, durationMonthsPart, durationWeeksPart, durationDaysPart), [
+  durationTime
+]);
 const duration = withSyntaxConstraints(
   seq(
     withCode([temporalSign], (data, result) => (data.factor = result === '-' || result === '\u2212' ? -1 : 1)),

--- a/test/validStrings.mjs
+++ b/test/validStrings.mjs
@@ -288,14 +288,6 @@ const timeSpec = seq(
   timeHour,
   choice([':', timeMinute, [':', timeSecond, [timeFraction]]], seq(timeMinute, [timeSecond, [timeFraction]]))
 );
-const timeSpecWithOptionalOffsetNotAmbiguous = withSyntaxConstraints(seq(timeSpec, [dateTimeUTCOffset]), (result) => {
-  if (/^(?:(?!02-?30)(?:0[1-9]|1[012])-?(?:0[1-9]|[12][0-9]|30)|(?:0[13578]|10|12)-?31)$/.test(result)) {
-    throw new SyntaxError('valid PlainMonthDay');
-  }
-  if (/^(?![−-]000000)(?:[0-9]{4}|[+−-][0-9]{6})-?(?:0[1-9]|1[012])$/.test(result)) {
-    throw new SyntaxError('valid PlainYearMonth');
-  }
-});
 
 function validateDayOfMonth(result, { year, month, day }) {
   if (day > ES.ISODaysInMonth(year, month)) throw SyntaxError('retry if bad day of month');
@@ -309,7 +301,18 @@ const date = withSyntaxConstraints(
 const dateTime = seq(date, [dateTimeSeparator, timeSpec, [dateTimeUTCOffset]]);
 const annotatedTime = choice(
   seq(timeDesignator, timeSpec, [dateTimeUTCOffset], [timeZoneAnnotation], [annotations]),
-  seq(timeSpecWithOptionalOffsetNotAmbiguous, [timeZoneAnnotation], [annotations])
+  seq(
+    withSyntaxConstraints(seq(timeSpec, [dateTimeUTCOffset]), (result) => {
+      if (/^(?:(?!02-?30)(?:0[1-9]|1[012])-?(?:0[1-9]|[12][0-9]|30)|(?:0[13578]|10|12)-?31)$/.test(result)) {
+        throw new SyntaxError('valid PlainMonthDay');
+      }
+      if (/^(?![−-]000000)(?:[0-9]{4}|[+−-][0-9]{6})-?(?:0[1-9]|1[012])$/.test(result)) {
+        throw new SyntaxError('valid PlainYearMonth');
+      }
+    }),
+    [timeZoneAnnotation],
+    [annotations]
+  )
 );
 const annotatedDateTime = seq(dateTime, [timeZoneAnnotation], [annotations]);
 const annotatedDateTimeTimeRequired = seq(

--- a/test/validStrings.mjs
+++ b/test/validStrings.mjs
@@ -193,6 +193,7 @@ function seq(...productions) {
 
 // characters
 const temporalSign = character('+-−');
+const dateSeparator = (extended) => (extended ? character('-') : empty);
 const timeSeparator = (extended) => (extended ? character(':') : empty);
 const hour = zeroPaddedInclusive(0, 23, 2);
 const minuteSecond = zeroPaddedInclusive(0, 59, 2);
@@ -294,12 +295,17 @@ const time = choice(timeSpec(true), timeSpec(false));
 function validateDayOfMonth(result, { year, month, day }) {
   if (day > ES.ISODaysInMonth(year, month)) throw SyntaxError('retry if bad day of month');
 }
-const dateSpecMonthDay = withSyntaxConstraints(seq(['--'], dateMonth, ['-'], dateDay), validateDayOfMonth);
-const dateSpecYearMonth = seq(dateYear, ['-'], dateMonth);
-const date = withSyntaxConstraints(
-  choice(seq(dateYear, '-', dateMonth, '-', dateDay), seq(dateYear, dateMonth, dateDay)),
+const dateSpecMonthDay = withSyntaxConstraints(
+  seq(['--'], dateMonth, choice(dateSeparator(true), dateSeparator(false)), dateDay),
   validateDayOfMonth
 );
+const dateSpecYearMonth = seq(dateYear, choice(dateSeparator(true), dateSeparator(false)), dateMonth);
+const dateSpec = (extended) =>
+  withSyntaxConstraints(
+    seq(dateYear, dateSeparator(extended), dateMonth, dateSeparator(extended), dateDay),
+    validateDayOfMonth
+  );
+const date = choice(dateSpec(true), dateSpec(false));
 const dateTime = seq(date, [dateTimeSeparator, time, [dateTimeUTCOffset]]);
 const annotatedTime = choice(
   seq(timeDesignator, time, [dateTimeUTCOffset], [timeZoneAnnotation], [annotations]),

--- a/test/validStrings.mjs
+++ b/test/validStrings.mjs
@@ -248,23 +248,28 @@ const timeFraction = withCode(temporalDecimalFraction, (data, result) => {
   data.microsecond = +fraction.slice(3, 6);
   data.nanosecond = +fraction.slice(6, 9);
 });
+
 function saveOffset(data, result) {
   data.offset = ES.ParseDateTimeUTCOffset(result);
 }
-
-const utcOffsetWithSubMinuteComponents = (extended) =>
-  seq(temporalSign, hour, timeSeparator(extended), minuteSecond, timeSeparator(extended), minuteSecond, [
-    temporalDecimalFraction
+const utcOffset = (subMinutePrecision) =>
+  seq(temporalSign, hour, [
+    choice(
+      seq(
+        timeSeparator(true),
+        minuteSecond,
+        subMinutePrecision ? [timeSeparator(true), minuteSecond, [temporalDecimalFraction]] : empty
+      ),
+      seq(
+        timeSeparator(false),
+        minuteSecond,
+        subMinutePrecision ? [timeSeparator(false), minuteSecond, [temporalDecimalFraction]] : empty
+      )
+    )
   ]);
-const utcOffsetMinutePrecision = seq(temporalSign, hour, [
-  choice(seq(timeSeparator(true), minuteSecond), seq(timeSeparator(false), minuteSecond))
-]);
-const utcOffsetSubMinutePrecision = withCode(
-  choice(utcOffsetMinutePrecision, utcOffsetWithSubMinuteComponents(true), utcOffsetWithSubMinuteComponents(false)),
-  saveOffset
-);
-const dateTimeUTCOffset = (z) => (z ? choice(utcDesignator, utcOffsetSubMinutePrecision) : utcOffsetSubMinutePrecision);
-const timeZoneUTCOffsetName = utcOffsetMinutePrecision;
+const dateTimeUTCOffset = (z) =>
+  z ? choice(utcDesignator, withCode(utcOffset(true), saveOffset)) : withCode(utcOffset(true), saveOffset);
+const timeZoneUTCOffsetName = utcOffset(false);
 const timeZoneIANAName = choice(...timezoneNames);
 const timeZoneIdentifier = withCode(
   choice(timeZoneUTCOffsetName, timeZoneIANAName),

--- a/test/validStrings.mjs
+++ b/test/validStrings.mjs
@@ -306,7 +306,13 @@ const dateSpec = (extended) =>
     validateDayOfMonth
   );
 const date = choice(dateSpec(true), dateSpec(false));
-const dateTime = (z) => seq(date, [dateTimeSeparator, time, [dateTimeUTCOffset(z)]]);
+const dateTime = (z, timeRequired) =>
+  seq(
+    date,
+    timeRequired
+      ? seq(dateTimeSeparator, time, [dateTimeUTCOffset(z)])
+      : [dateTimeSeparator, time, [dateTimeUTCOffset(z)]]
+  );
 const annotatedTime = choice(
   seq(timeDesignator, time, [dateTimeUTCOffset(false)], [timeZoneAnnotation], [annotations]),
   seq(
@@ -322,16 +328,8 @@ const annotatedTime = choice(
     [annotations]
   )
 );
-const annotatedDateTime = (zoned) =>
-  seq(dateTime(zoned), zoned ? timeZoneAnnotation : [timeZoneAnnotation], [annotations]);
-const annotatedDateTimeTimeRequired = seq(
-  date,
-  dateTimeSeparator,
-  time,
-  [dateTimeUTCOffset(false)],
-  [timeZoneAnnotation],
-  [annotations]
-);
+const annotatedDateTime = (zoned, timeRequired) =>
+  seq(dateTime(zoned, timeRequired), zoned ? timeZoneAnnotation : [timeZoneAnnotation], [annotations]);
 const annotatedYearMonth = withSyntaxConstraints(
   seq(dateSpecYearMonth, [timeZoneAnnotation], [annotations]),
   (result, data) => {
@@ -443,18 +441,18 @@ const duration = withSyntaxConstraints(
 );
 
 const instant = seq(date, dateTimeSeparator, time, dateTimeUTCOffset(true), [timeZoneAnnotation], [annotations]);
-const zonedDateTime = annotatedDateTime(true);
+const zonedDateTime = annotatedDateTime(true, false);
 
 // goal elements
 const goals = {
   Instant: instant,
-  Date: annotatedDateTime(false),
-  DateTime: annotatedDateTime(false),
+  Date: annotatedDateTime(false, false),
+  DateTime: annotatedDateTime(false, false),
   Duration: duration,
-  MonthDay: choice(annotatedMonthDay, annotatedDateTime(false)),
-  Time: choice(annotatedTime, annotatedDateTimeTimeRequired),
+  MonthDay: choice(annotatedMonthDay, annotatedDateTime(false, false)),
+  Time: choice(annotatedTime, annotatedDateTime(false, true)),
   TimeZone: choice(timeZoneIdentifier, zonedDateTime, instant),
-  YearMonth: choice(annotatedYearMonth, annotatedDateTime(false)),
+  YearMonth: choice(annotatedYearMonth, annotatedDateTime(false, false)),
   ZonedDateTime: zonedDateTime
 };
 

--- a/test/validStrings.mjs
+++ b/test/validStrings.mjs
@@ -79,6 +79,7 @@ class Literal {
     return this.str;
   }
 }
+const empty = new Literal('');
 
 class Optional {
   constructor(productionLike) {
@@ -192,6 +193,7 @@ function seq(...productions) {
 
 // characters
 const temporalSign = character('+-−');
+const timeSeparator = (extended) => (extended ? character(':') : empty);
 const hour = zeroPaddedInclusive(0, 23, 2);
 const minuteSecond = zeroPaddedInclusive(0, 59, 2);
 const temporalDecimalSeparator = character('.,');
@@ -248,19 +250,20 @@ const timeFraction = withCode(temporalDecimalFraction, (data, result) => {
 function saveOffset(data, result) {
   data.offset = ES.ParseDateTimeUTCOffset(result);
 }
+
+const utcOffsetWithSubMinuteComponents = (extended) =>
+  seq(temporalSign, hour, timeSeparator(extended), minuteSecond, timeSeparator(extended), minuteSecond, [
+    temporalDecimalFraction
+  ]);
+const utcOffsetMinutePrecision = seq(temporalSign, hour, [
+  choice(seq(timeSeparator(true), minuteSecond), seq(timeSeparator(false), minuteSecond))
+]);
 const utcOffsetSubMinutePrecision = withCode(
-  seq(
-    temporalSign,
-    hour,
-    choice(
-      [minuteSecond, [minuteSecond, [temporalDecimalFraction]]],
-      seq(':', minuteSecond, [':', minuteSecond, [temporalDecimalFraction]])
-    )
-  ),
+  choice(utcOffsetMinutePrecision, utcOffsetWithSubMinuteComponents(true), utcOffsetWithSubMinuteComponents(false)),
   saveOffset
 );
 const dateTimeUTCOffset = choice(utcDesignator, utcOffsetSubMinutePrecision);
-const timeZoneUTCOffsetName = seq(temporalSign, hour, choice([minuteSecond], seq(':', minuteSecond)));
+const timeZoneUTCOffsetName = utcOffsetMinutePrecision;
 const timeZoneIANAName = choice(...timezoneNames);
 const timeZoneIdentifier = withCode(
   choice(timeZoneUTCOffsetName, timeZoneIANAName),
@@ -284,10 +287,9 @@ const annotations = withSyntaxConstraints(oneOrMore(choice(calendarAnnotation, a
     throw new SyntaxError('more than one calendar annotation and at least one critical');
   }
 });
-const timeSpec = seq(
-  timeHour,
-  choice([':', timeMinute, [':', timeSecond, [timeFraction]]], seq(timeMinute, [timeSecond, [timeFraction]]))
-);
+const timeSpec = (extended) =>
+  seq(timeHour, [timeSeparator(extended), timeMinute, [timeSeparator(extended), timeSecond, [timeFraction]]]);
+const time = choice(timeSpec(true), timeSpec(false));
 
 function validateDayOfMonth(result, { year, month, day }) {
   if (day > ES.ISODaysInMonth(year, month)) throw SyntaxError('retry if bad day of month');
@@ -298,11 +300,11 @@ const date = withSyntaxConstraints(
   choice(seq(dateYear, '-', dateMonth, '-', dateDay), seq(dateYear, dateMonth, dateDay)),
   validateDayOfMonth
 );
-const dateTime = seq(date, [dateTimeSeparator, timeSpec, [dateTimeUTCOffset]]);
+const dateTime = seq(date, [dateTimeSeparator, time, [dateTimeUTCOffset]]);
 const annotatedTime = choice(
-  seq(timeDesignator, timeSpec, [dateTimeUTCOffset], [timeZoneAnnotation], [annotations]),
+  seq(timeDesignator, time, [dateTimeUTCOffset], [timeZoneAnnotation], [annotations]),
   seq(
-    withSyntaxConstraints(seq(timeSpec, [dateTimeUTCOffset]), (result) => {
+    withSyntaxConstraints(seq(time, [dateTimeUTCOffset]), (result) => {
       if (/^(?:(?!02-?30)(?:0[1-9]|1[012])-?(?:0[1-9]|[12][0-9]|30)|(?:0[13578]|10|12)-?31)$/.test(result)) {
         throw new SyntaxError('valid PlainMonthDay');
       }
@@ -318,7 +320,7 @@ const annotatedDateTime = seq(dateTime, [timeZoneAnnotation], [annotations]);
 const annotatedDateTimeTimeRequired = seq(
   date,
   dateTimeSeparator,
-  timeSpec,
+  time,
   [dateTimeUTCOffset],
   [timeZoneAnnotation],
   [annotations]
@@ -433,7 +435,7 @@ const duration = withSyntaxConstraints(
   }
 );
 
-const instant = seq(date, dateTimeSeparator, timeSpec, dateTimeUTCOffset, [timeZoneAnnotation], [annotations]);
+const instant = seq(date, dateTimeSeparator, time, dateTimeUTCOffset, [timeZoneAnnotation], [annotations]);
 const zonedDateTime = seq(dateTime, timeZoneAnnotation, [annotations]);
 
 // goal elements


### PR DESCRIPTION
Another stack of 25 commits. Most of them are either the more straightforward removals from the June 2024 changes, or improvements to the ISO 8601 grammar which were reflected in test/validStrings.mjs. (We have not yet gotten to the removal of calendars and time zones.)