### PR TITLE
Rebase: ISO Date-Time Record refactoring

### DIFF
--- a/lib/calendar.ts
+++ b/lib/calendar.ts
@@ -2342,8 +2342,10 @@ class NonIsoCalendar implements CalendarImpl {
     const added = this.helper.addCalendar(calendarDate, { years, months, weeks, days }, overflow, cache);
     const isoAdded = this.helper.calendarToIsoDate(added, 'constrain', cache);
     // The new object's cache starts with the cache of the old object
-    const newCache = new OneObjectCache(cache);
-    newCache.setObject(isoAdded);
+    if (!OneObjectCache.getCacheForObject(isoAdded)) {
+      const newCache = new OneObjectCache(cache);
+      newCache.setObject(isoAdded);
+    }
     return isoAdded;
   }
   dateUntil(one: ISODate, two: ISODate, largestUnit: Temporal.DateUnit) {

--- a/lib/duration.ts
+++ b/lib/duration.ts
@@ -250,8 +250,7 @@ export class Duration implements Temporal.Duration {
 
     if (plainRelativeTo) {
       let duration = ES.NormalizeDurationWith24HourDays(this);
-      const midnight = { hour: 0, minute: 0, second: 0, millisecond: 0, microsecond: 0, nanosecond: 0 };
-      const targetTime = ES.AddTime(midnight, duration.norm);
+      const targetTime = ES.AddTime(ES.MidnightTimeRecord(), duration.norm);
 
       // Delegate the date part addition to the calendar
       const isoRelativeToDate = ES.TemporalObjectToISODateRecord(plainRelativeTo);
@@ -259,7 +258,7 @@ export class Duration implements Temporal.Duration {
       const dateDuration = ES.AdjustDateDurationRecord(duration.date, targetTime.deltaDays);
       const targetDate = ES.CalendarDateAdd(calendar, isoRelativeToDate, dateDuration, 'constrain');
 
-      const isoDateTime = ES.CombineISODateAndTimeRecord(isoRelativeToDate, midnight);
+      const isoDateTime = ES.CombineISODateAndTimeRecord(isoRelativeToDate, ES.MidnightTimeRecord());
       const targetDateTime = ES.CombineISODateAndTimeRecord(targetDate, targetTime);
       duration = ES.DifferencePlainDateTimeWithRounding(
         isoDateTime,
@@ -307,8 +306,7 @@ export class Duration implements Temporal.Duration {
 
     if (plainRelativeTo) {
       const duration = ES.NormalizeDurationWith24HourDays(this);
-      const midnight = { hour: 0, minute: 0, second: 0, millisecond: 0, microsecond: 0, nanosecond: 0 };
-      let targetTime = ES.AddTime(midnight, duration.norm);
+      let targetTime = ES.AddTime(ES.MidnightTimeRecord(), duration.norm);
 
       // Delegate the date part addition to the calendar
       const isoRelativeToDate = ES.TemporalObjectToISODateRecord(plainRelativeTo);
@@ -316,7 +314,7 @@ export class Duration implements Temporal.Duration {
       const dateDuration = ES.AdjustDateDurationRecord(duration.date, targetTime.deltaDays);
       const targetDate = ES.CalendarDateAdd(calendar, isoRelativeToDate, dateDuration, 'constrain');
 
-      const isoDateTime = ES.CombineISODateAndTimeRecord(isoRelativeToDate, midnight);
+      const isoDateTime = ES.CombineISODateAndTimeRecord(isoRelativeToDate, ES.MidnightTimeRecord());
       const targetDateTime = ES.CombineISODateAndTimeRecord(targetDate, targetTime);
       return ES.DifferencePlainDateTimeWithTotal(isoDateTime, targetDateTime, calendar, unit);
     }

--- a/lib/duration.ts
+++ b/lib/duration.ts
@@ -250,10 +250,8 @@ export class Duration implements Temporal.Duration {
 
     if (plainRelativeTo) {
       let duration = ES.NormalizeDurationWith24HourDays(this);
-      const targetTime = ES.AddTime(
-        { hour: 0, minute: 0, second: 0, millisecond: 0, microsecond: 0, nanosecond: 0 },
-        duration.norm
-      );
+      const midnight = { hour: 0, minute: 0, second: 0, millisecond: 0, microsecond: 0, nanosecond: 0 };
+      const targetTime = ES.AddTime(midnight, duration.norm);
 
       // Delegate the date part addition to the calendar
       const isoRelativeToDate = ES.TemporalObjectToISODateRecord(plainRelativeTo);
@@ -261,25 +259,11 @@ export class Duration implements Temporal.Duration {
       const dateDuration = ES.AdjustDateDurationRecord(duration.date, targetTime.deltaDays);
       const targetDate = ES.CalendarDateAdd(calendar, isoRelativeToDate, dateDuration, 'constrain');
 
+      const isoDateTime = ES.CombineISODateAndTimeRecord(isoRelativeToDate, midnight);
+      const targetDateTime = ES.CombineISODateAndTimeRecord(targetDate, targetTime);
       duration = ES.DifferencePlainDateTimeWithRounding(
-        isoRelativeToDate.year,
-        isoRelativeToDate.month,
-        isoRelativeToDate.day,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        targetDate.year,
-        targetDate.month,
-        targetDate.day,
-        targetTime.hour,
-        targetTime.minute,
-        targetTime.second,
-        targetTime.millisecond,
-        targetTime.microsecond,
-        targetTime.nanosecond,
+        isoDateTime,
+        targetDateTime,
         calendar,
         largestUnit,
         roundingIncrement,

--- a/lib/duration.ts
+++ b/lib/duration.ts
@@ -33,6 +33,7 @@ import {
   EPOCHNANOSECONDS,
   CreateSlots,
   GetSlot,
+  ISO_DATE,
   SetSlot,
   TIME_ZONE
 } from './slots';
@@ -253,7 +254,7 @@ export class Duration implements Temporal.Duration {
       const targetTime = ES.AddTime(ES.MidnightTimeRecord(), duration.norm);
 
       // Delegate the date part addition to the calendar
-      const isoRelativeToDate = ES.TemporalObjectToISODateRecord(plainRelativeTo);
+      const isoRelativeToDate = GetSlot(plainRelativeTo, ISO_DATE);
       const calendar = GetSlot(plainRelativeTo, CALENDAR);
       const dateDuration = ES.AdjustDateDurationRecord(duration.date, targetTime.deltaDays);
       const targetDate = ES.CalendarDateAdd(calendar, isoRelativeToDate, dateDuration, 'constrain');
@@ -309,7 +310,7 @@ export class Duration implements Temporal.Duration {
       let targetTime = ES.AddTime(ES.MidnightTimeRecord(), duration.norm);
 
       // Delegate the date part addition to the calendar
-      const isoRelativeToDate = ES.TemporalObjectToISODateRecord(plainRelativeTo);
+      const isoRelativeToDate = GetSlot(plainRelativeTo, ISO_DATE);
       const calendar = GetSlot(plainRelativeTo, CALENDAR);
       const dateDuration = ES.AdjustDateDurationRecord(duration.date, targetTime.deltaDays);
       const targetDate = ES.CalendarDateAdd(calendar, isoRelativeToDate, dateDuration, 'constrain');

--- a/lib/duration.ts
+++ b/lib/duration.ts
@@ -307,10 +307,8 @@ export class Duration implements Temporal.Duration {
 
     if (plainRelativeTo) {
       const duration = ES.NormalizeDurationWith24HourDays(this);
-      let targetTime = ES.AddTime(
-        { hour: 0, minute: 0, second: 0, millisecond: 0, microsecond: 0, nanosecond: 0 },
-        duration.norm
-      );
+      const midnight = { hour: 0, minute: 0, second: 0, millisecond: 0, microsecond: 0, nanosecond: 0 };
+      let targetTime = ES.AddTime(midnight, duration.norm);
 
       // Delegate the date part addition to the calendar
       const isoRelativeToDate = ES.TemporalObjectToISODateRecord(plainRelativeTo);
@@ -318,28 +316,9 @@ export class Duration implements Temporal.Duration {
       const dateDuration = ES.AdjustDateDurationRecord(duration.date, targetTime.deltaDays);
       const targetDate = ES.CalendarDateAdd(calendar, isoRelativeToDate, dateDuration, 'constrain');
 
-      return ES.DifferencePlainDateTimeWithTotal(
-        isoRelativeToDate.year,
-        isoRelativeToDate.month,
-        isoRelativeToDate.day,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        targetDate.year,
-        targetDate.month,
-        targetDate.day,
-        targetTime.hour,
-        targetTime.minute,
-        targetTime.second,
-        targetTime.millisecond,
-        targetTime.microsecond,
-        targetTime.nanosecond,
-        calendar,
-        unit
-      );
+      const isoDateTime = ES.CombineISODateAndTimeRecord(isoRelativeToDate, midnight);
+      const targetDateTime = ES.CombineISODateAndTimeRecord(targetDate, targetTime);
+      return ES.DifferencePlainDateTimeWithTotal(isoDateTime, targetDateTime, calendar, unit);
     }
 
     // No reference date to calculate difference relative to

--- a/lib/duration.ts
+++ b/lib/duration.ts
@@ -250,7 +250,10 @@ export class Duration implements Temporal.Duration {
 
     if (plainRelativeTo) {
       let duration = ES.NormalizeDurationWith24HourDays(this);
-      const targetTime = ES.AddTime(0, 0, 0, 0, 0, 0, duration.norm);
+      const targetTime = ES.AddTime(
+        { hour: 0, minute: 0, second: 0, millisecond: 0, microsecond: 0, nanosecond: 0 },
+        duration.norm
+      );
 
       // Delegate the date part addition to the calendar
       const isoRelativeToDate = ES.TemporalObjectToISODateRecord(plainRelativeTo);
@@ -320,7 +323,10 @@ export class Duration implements Temporal.Duration {
 
     if (plainRelativeTo) {
       const duration = ES.NormalizeDurationWith24HourDays(this);
-      let targetTime = ES.AddTime(0, 0, 0, 0, 0, 0, duration.norm);
+      let targetTime = ES.AddTime(
+        { hour: 0, minute: 0, second: 0, millisecond: 0, microsecond: 0, nanosecond: 0 },
+        duration.norm
+      );
 
       // Delegate the date part addition to the calendar
       const isoRelativeToDate = ES.TemporalObjectToISODateRecord(plainRelativeTo);

--- a/lib/ecmascript.ts
+++ b/lib/ecmascript.ts
@@ -1292,27 +1292,6 @@ export function TemporalUnitCategory(unit: Temporal.DateTimeUnit) {
   return 'time';
 }
 
-export function TemporalObjectToFields(
-  temporalObject: Temporal.PlainDate | Temporal.PlainDateTime
-): ISODateToFieldsReturn<'date'>;
-export function TemporalObjectToFields(temporalObject: Temporal.PlainMonthDay): ISODateToFieldsReturn<'month-day'>;
-export function TemporalObjectToFields(temporalObject: Temporal.PlainYearMonth): ISODateToFieldsReturn<'year-month'>;
-export function TemporalObjectToFields(
-  temporalObject: Temporal.PlainDate | Temporal.PlainDateTime | Temporal.PlainYearMonth | Temporal.PlainMonthDay
-) {
-  const calendar = GetSlot(temporalObject, CALENDAR);
-  const isoDate = IsTemporalDateTime(temporalObject)
-    ? GetSlot(temporalObject, ISO_DATE_TIME).isoDate
-    : GetSlot(temporalObject, ISO_DATE);
-  let type: ISODateToFieldsType = 'date';
-  if (IsTemporalYearMonth(temporalObject)) {
-    type = 'year-month';
-  } else if (IsTemporalMonthDay(temporalObject)) {
-    type = 'month-day';
-  }
-  return ISODateToFields(calendar, isoDate, type);
-}
-
 function calendarImplForID(calendar: BuiltinCalendarId) {
   return GetIntrinsic('%calendarImpl%')(calendar);
 }
@@ -4359,10 +4338,10 @@ export function DifferenceTemporalPlainYearMonth(
     return new Duration();
   }
 
-  const thisFields: CalendarFieldsRecord = TemporalObjectToFields(yearMonth);
+  const thisFields: CalendarFieldsRecord = ISODateToFields(calendar, GetSlot(yearMonth, ISO_DATE), 'year-month');
   thisFields.day = 1;
   const thisDate = CalendarDateFromFields(calendar, thisFields, 'constrain');
-  const otherFields: CalendarFieldsRecord = TemporalObjectToFields(other);
+  const otherFields: CalendarFieldsRecord = ISODateToFields(calendar, GetSlot(other, ISO_DATE), 'year-month');
   otherFields.day = 1;
   const otherDate = CalendarDateFromFields(calendar, otherFields, 'constrain');
 
@@ -4617,7 +4596,7 @@ export function AddDurationToYearMonth(
   const sign = DurationSign(duration);
 
   const calendar = GetSlot(yearMonth, CALENDAR);
-  const fields: CalendarFieldsRecord = TemporalObjectToFields(yearMonth);
+  const fields: CalendarFieldsRecord = ISODateToFields(calendar, GetSlot(yearMonth, ISO_DATE), 'year-month');
   fields.day = 1;
   let startDate = CalendarDateFromFields(calendar, fields, 'constrain');
   if (sign < 0) {

--- a/lib/ecmascript.ts
+++ b/lib/ecmascript.ts
@@ -4355,38 +4355,14 @@ function TotalRelativeDuration(
 }
 
 export function DifferencePlainDateTimeWithRounding(
-  y1: number,
-  mon1: number,
-  d1: number,
-  h1: number,
-  min1: number,
-  s1: number,
-  ms1: number,
-  µs1: number,
-  ns1: number,
-  y2: number,
-  mon2: number,
-  d2: number,
-  h2: number,
-  min2: number,
-  s2: number,
-  ms2: number,
-  µs2: number,
-  ns2: number,
+  isoDateTime1: ISODateTime,
+  isoDateTime2: ISODateTime,
   calendar: BuiltinCalendarId,
   largestUnit: Temporal.DateTimeUnit,
   roundingIncrement: number,
   smallestUnit: Temporal.DateTimeUnit,
   roundingMode: Temporal.RoundingMode
 ) {
-  const isoDateTime1 = {
-    isoDate: { year: y1, month: mon1, day: d1 },
-    time: { hour: h1, minute: min1, second: s1, millisecond: ms1, microsecond: µs1, nanosecond: ns1 }
-  };
-  const isoDateTime2 = {
-    isoDate: { year: y2, month: mon2, day: d2 },
-    time: { hour: h2, minute: min2, second: s2, millisecond: ms2, microsecond: µs2, nanosecond: ns2 }
-  };
   if (CompareISODateTime(isoDateTime1, isoDateTime2) == 0) {
     return { date: ZeroDateDuration(), norm: TimeDuration.ZERO };
   }
@@ -4395,7 +4371,17 @@ export function DifferencePlainDateTimeWithRounding(
 
   if (smallestUnit === 'nanosecond' && roundingIncrement === 1) return duration;
 
-  const destEpochNs = GetUTCEpochNanoseconds(y2, mon2, d2, h2, min2, s2, ms2, µs2, ns2);
+  const destEpochNs = GetUTCEpochNanoseconds(
+    isoDateTime2.isoDate.year,
+    isoDateTime2.isoDate.month,
+    isoDateTime2.isoDate.day,
+    isoDateTime2.time.hour,
+    isoDateTime2.time.minute,
+    isoDateTime2.time.second,
+    isoDateTime2.time.millisecond,
+    isoDateTime2.time.microsecond,
+    isoDateTime2.time.nanosecond
+  );
   return RoundRelativeDuration(
     duration,
     destEpochNs,
@@ -4657,39 +4643,13 @@ export function DifferenceTemporalPlainDateTime(
   const settings = GetDifferenceSettings(operation, resolvedOptions, 'datetime', [], 'nanosecond', 'day');
 
   const Duration = GetIntrinsic('%Temporal.Duration%');
-  if (
-    GetSlot(plainDateTime, ISO_YEAR) === GetSlot(other, ISO_YEAR) &&
-    GetSlot(plainDateTime, ISO_MONTH) === GetSlot(other, ISO_MONTH) &&
-    GetSlot(plainDateTime, ISO_DAY) === GetSlot(other, ISO_DAY) &&
-    GetSlot(plainDateTime, ISO_HOUR) == GetSlot(other, ISO_HOUR) &&
-    GetSlot(plainDateTime, ISO_MINUTE) == GetSlot(other, ISO_MINUTE) &&
-    GetSlot(plainDateTime, ISO_SECOND) == GetSlot(other, ISO_SECOND) &&
-    GetSlot(plainDateTime, ISO_MILLISECOND) == GetSlot(other, ISO_MILLISECOND) &&
-    GetSlot(plainDateTime, ISO_MICROSECOND) == GetSlot(other, ISO_MICROSECOND) &&
-    GetSlot(plainDateTime, ISO_NANOSECOND) == GetSlot(other, ISO_NANOSECOND)
-  ) {
-    return new Duration();
-  }
+  const isoDateTime1 = PlainDateTimeToISODateTimeRecord(plainDateTime);
+  const isoDateTime2 = PlainDateTimeToISODateTimeRecord(other);
+  if (CompareISODateTime(isoDateTime1, isoDateTime2) === 0) return new Duration();
 
   const duration = DifferencePlainDateTimeWithRounding(
-    GetSlot(plainDateTime, ISO_YEAR),
-    GetSlot(plainDateTime, ISO_MONTH),
-    GetSlot(plainDateTime, ISO_DAY),
-    GetSlot(plainDateTime, ISO_HOUR),
-    GetSlot(plainDateTime, ISO_MINUTE),
-    GetSlot(plainDateTime, ISO_SECOND),
-    GetSlot(plainDateTime, ISO_MILLISECOND),
-    GetSlot(plainDateTime, ISO_MICROSECOND),
-    GetSlot(plainDateTime, ISO_NANOSECOND),
-    GetSlot(other, ISO_YEAR),
-    GetSlot(other, ISO_MONTH),
-    GetSlot(other, ISO_DAY),
-    GetSlot(other, ISO_HOUR),
-    GetSlot(other, ISO_MINUTE),
-    GetSlot(other, ISO_SECOND),
-    GetSlot(other, ISO_MILLISECOND),
-    GetSlot(other, ISO_MICROSECOND),
-    GetSlot(other, ISO_NANOSECOND),
+    isoDateTime1,
+    isoDateTime2,
     calendar,
     settings.largestUnit,
     settings.roundingIncrement,

--- a/lib/ecmascript.ts
+++ b/lib/ecmascript.ts
@@ -1687,10 +1687,9 @@ export function ToTemporalTime(item: PlainTimeParams['from'][0], options?: Plain
   return CreateTemporalTime(time);
 }
 
-export function ToTemporalTimeOrMidnight(item: string | Temporal.PlainTime | Temporal.PlainTimeLike | undefined) {
-  const TemporalPlainTime = GetIntrinsic('%Temporal.PlainTime%');
-  if (item === undefined) return new TemporalPlainTime();
-  return ToTemporalTime(item);
+export function ToTimeRecordOrMidnight(item: PlainTimeParams['from'][0] | undefined) {
+  if (item === undefined) return MidnightTimeRecord();
+  return GetSlot(ToTemporalTime(item), TIME);
 }
 
 export function ToTemporalYearMonth(

--- a/lib/ecmascript.ts
+++ b/lib/ecmascript.ts
@@ -888,14 +888,12 @@ export function RegulateTime(
       RejectTime(hour, minute, second, millisecond, microsecond, nanosecond);
       break;
     case 'constrain':
-      ({ hour, minute, second, millisecond, microsecond, nanosecond } = ConstrainTime(
-        hour,
-        minute,
-        second,
-        millisecond,
-        microsecond,
-        nanosecond
-      ));
+      hour = ConstrainToRange(hour, 0, 23);
+      minute = ConstrainToRange(minute, 0, 59);
+      second = ConstrainToRange(second, 0, 59);
+      millisecond = ConstrainToRange(millisecond, 0, 999);
+      microsecond = ConstrainToRange(microsecond, 0, 999);
+      nanosecond = ConstrainToRange(nanosecond, 0, 999);
       break;
   }
   return { hour, minute, second, millisecond, microsecond, nanosecond };
@@ -3232,23 +3230,6 @@ export function ConstrainISODate(year: number, monthParam: number, dayParam?: nu
   const month = ConstrainToRange(monthParam, 1, 12);
   const day = ConstrainToRange(dayParam, 1, ISODaysInMonth(year, month));
   return { year, month, day };
-}
-
-function ConstrainTime(
-  hourParam: number,
-  minuteParam: number,
-  secondParam: number,
-  millisecondParam: number,
-  microsecondParam: number,
-  nanosecondParam: number
-) {
-  const hour = ConstrainToRange(hourParam, 0, 23);
-  const minute = ConstrainToRange(minuteParam, 0, 59);
-  const second = ConstrainToRange(secondParam, 0, 59);
-  const millisecond = ConstrainToRange(millisecondParam, 0, 999);
-  const microsecond = ConstrainToRange(microsecondParam, 0, 999);
-  const nanosecond = ConstrainToRange(nanosecondParam, 0, 999);
-  return { hour, minute, second, millisecond, microsecond, nanosecond };
 }
 
 export function RejectToRange(value: number, min: number, max: number) {

--- a/lib/ecmascript.ts
+++ b/lib/ecmascript.ts
@@ -5338,26 +5338,13 @@ export function CompareISODate(isoDate1: ISODate, isoDate2: ISODate) {
   return 0;
 }
 
-export function CompareTemporalTime(
-  h1: number,
-  min1: number,
-  s1: number,
-  ms1: number,
-  µs1: number,
-  ns1: number,
-  h2: number,
-  min2: number,
-  s2: number,
-  ms2: number,
-  µs2: number,
-  ns2: number
-) {
-  if (h1 !== h2) return ComparisonResult(h1 - h2);
-  if (min1 !== min2) return ComparisonResult(min1 - min2);
-  if (s1 !== s2) return ComparisonResult(s1 - s2);
-  if (ms1 !== ms2) return ComparisonResult(ms1 - ms2);
-  if (µs1 !== µs2) return ComparisonResult(µs1 - µs2);
-  if (ns1 !== ns2) return ComparisonResult(ns1 - ns2);
+export function CompareTimeRecord(time1: TimeRecord, time2: TimeRecord) {
+  if (time1.hour !== time2.hour) return ComparisonResult(time1.hour - time2.hour);
+  if (time1.minute !== time2.minute) return ComparisonResult(time1.minute - time2.minute);
+  if (time1.second !== time2.second) return ComparisonResult(time1.second - time2.second);
+  if (time1.millisecond !== time2.millisecond) return ComparisonResult(time1.millisecond - time2.millisecond);
+  if (time1.microsecond !== time2.microsecond) return ComparisonResult(time1.microsecond - time2.microsecond);
+  if (time1.nanosecond !== time2.nanosecond) return ComparisonResult(time1.nanosecond - time2.nanosecond);
   return 0;
 }
 
@@ -5383,7 +5370,10 @@ export function CompareISODateTime(
 ) {
   const dateResult = CompareISODate({ year: y1, month: m1, day: d1 }, { year: y2, month: m2, day: d2 });
   if (dateResult !== 0) return dateResult;
-  return CompareTemporalTime(h1, min1, s1, ms1, µs1, ns1, h2, min2, s2, ms2, µs2, ns2);
+  return CompareTimeRecord(
+    { hour: h1, minute: min1, second: s1, millisecond: ms1, microsecond: µs1, nanosecond: ns1 },
+    { hour: h2, minute: min2, second: s2, millisecond: ms2, microsecond: µs2, nanosecond: ns2 }
+  );
 }
 
 // Defaults to native bigint, or something "native bigint-like".

--- a/lib/ecmascript.ts
+++ b/lib/ecmascript.ts
@@ -1718,17 +1718,7 @@ export function ToTemporalInstant(itemParam: InstantParams['from'][0]) {
   if (MathAbs(ISODateToEpochDays(balanced.isoDate.year, balanced.isoDate.month - 1, balanced.isoDate.day)) > 1e8) {
     throw new RangeErrorCtor('date/time value is outside the supported range');
   }
-  const epochNanoseconds = GetUTCEpochNanoseconds(
-    balanced.isoDate.year,
-    balanced.isoDate.month,
-    balanced.isoDate.day,
-    balanced.time.hour,
-    balanced.time.minute,
-    balanced.time.second,
-    balanced.time.millisecond,
-    balanced.time.microsecond,
-    balanced.time.nanosecond
-  );
+  const epochNanoseconds = GetUTCEpochNanoseconds(balanced);
   ValidateEpochNanoseconds(epochNanoseconds);
   return new TemporalInstant(epochNanoseconds);
 }
@@ -1906,17 +1896,7 @@ export function InterpretISODateTimeOffset(
     if (MathAbs(ISODateToEpochDays(balanced.isoDate.year, balanced.isoDate.month - 1, balanced.isoDate.day)) > 1e8) {
       throw new RangeErrorCtor('date/time outside of supported range');
     }
-    const epochNs = GetUTCEpochNanoseconds(
-      balanced.isoDate.year,
-      balanced.isoDate.month,
-      balanced.isoDate.day,
-      balanced.time.hour,
-      balanced.time.minute,
-      balanced.time.second,
-      balanced.time.millisecond,
-      balanced.time.microsecond,
-      balanced.time.nanosecond
-    );
+    const epochNs = GetUTCEpochNanoseconds(balanced);
     ValidateEpochNanoseconds(epochNs);
     return epochNs;
   }
@@ -1924,17 +1904,7 @@ export function InterpretISODateTimeOffset(
   if (MathAbs(ISODateToEpochDays(isoDate.year, isoDate.month - 1, isoDate.day)) > 1e8) {
     throw new RangeErrorCtor('date/time outside of supported range');
   }
-  const utcEpochNs = GetUTCEpochNanoseconds(
-    isoDate.year,
-    isoDate.month,
-    isoDate.day,
-    time.hour,
-    time.minute,
-    time.second,
-    time.millisecond,
-    time.microsecond,
-    time.nanosecond
-  );
+  const utcEpochNs = GetUTCEpochNanoseconds(dt);
 
   // "prefer" or "reject"
   const possibleEpochNs = GetPossibleEpochNanoseconds(timeZone, dt);
@@ -2476,11 +2446,7 @@ function DisambiguatePossibleEpochNanoseconds(
   }
 
   if (disambiguation === 'reject') throw new RangeErrorCtor('multiple instants found');
-  const {
-    isoDate: { year, month, day },
-    time: { hour, minute, second, millisecond, microsecond, nanosecond }
-  } = isoDateTime;
-  const utcns = GetUTCEpochNanoseconds(year, month, day, hour, minute, second, millisecond, microsecond, nanosecond);
+  const utcns = GetUTCEpochNanoseconds(isoDateTime);
 
   const dayBefore = JSBI.subtract(utcns, DAY_NANOS_JSBI);
   ValidateEpochNanoseconds(dayBefore);
@@ -2495,7 +2461,11 @@ function DisambiguatePossibleEpochNanoseconds(
     case 'earlier': {
       const norm = TimeDuration.normalize(0, 0, 0, 0, 0, -nanoseconds);
       const earlierTime = AddTime(isoDateTime.time, norm);
-      const earlierDate = BalanceISODate(year, month, day + earlierTime.deltaDays);
+      const earlierDate = BalanceISODate(
+        isoDateTime.isoDate.year,
+        isoDateTime.isoDate.month,
+        isoDateTime.isoDate.day + earlierTime.deltaDays
+      );
       const earlier = CombineISODateAndTimeRecord(earlierDate, earlierTime);
       return GetPossibleEpochNanoseconds(timeZone, earlier)[0];
     }
@@ -2504,7 +2474,11 @@ function DisambiguatePossibleEpochNanoseconds(
     case 'later': {
       const norm = TimeDuration.normalize(0, 0, 0, 0, 0, nanoseconds);
       const laterTime = AddTime(isoDateTime.time, norm);
-      const laterDate = BalanceISODate(year, month, day + laterTime.deltaDays);
+      const laterDate = BalanceISODate(
+        isoDateTime.isoDate.year,
+        isoDateTime.isoDate.month,
+        isoDateTime.isoDate.day + laterTime.deltaDays
+      );
       const later = CombineISODateAndTimeRecord(laterDate, laterTime);
       const possible = GetPossibleEpochNanoseconds(timeZone, later);
       return possible[possible.length - 1];
@@ -2533,17 +2507,7 @@ function GetPossibleEpochNanoseconds(timeZone: string, isoDateTime: ISODateTime)
     if (MathAbs(ISODateToEpochDays(balanced.isoDate.year, balanced.isoDate.month - 1, balanced.isoDate.day)) > 1e8) {
       throw new RangeErrorCtor('date/time value is outside the supported range');
     }
-    const epochNs = GetUTCEpochNanoseconds(
-      balanced.isoDate.year,
-      balanced.isoDate.month,
-      balanced.isoDate.day,
-      balanced.time.hour,
-      balanced.time.minute,
-      balanced.time.second,
-      balanced.time.millisecond,
-      balanced.time.microsecond,
-      balanced.time.nanosecond
-    );
+    const epochNs = GetUTCEpochNanoseconds(balanced);
     ValidateEpochNanoseconds(epochNs);
     return [epochNs];
   }
@@ -2576,7 +2540,7 @@ export function GetStartOfDay(timeZone: string, isoDate: ISODate) {
   // guaranteed to be before the transition
   assert(!IsOffsetTimeZoneIdentifier(timeZone), 'should only be reached with named time zone');
 
-  const utcns = GetUTCEpochNanoseconds(isoDate.year, isoDate.month, isoDate.day, 0, 0, 0, 0, 0, 0);
+  const utcns = GetUTCEpochNanoseconds(isoDateTime);
   const dayBefore = JSBI.subtract(utcns, DAY_NANOS_JSBI);
   ValidateEpochNanoseconds(dayBefore);
   return castExists(GetNamedTimeZoneNextTransition(timeZone, dayBefore));
@@ -2994,17 +2958,10 @@ function GetUTCEpochMilliseconds(
   return ms + MS_IN_400_YEAR_CYCLE * yearCycles;
 }
 
-function GetUTCEpochNanoseconds(
-  year: number,
-  month: number,
-  day: number,
-  hour: number,
-  minute: number,
-  second: number,
-  millisecond: number,
-  microsecond: number,
-  nanosecond: number
-) {
+function GetUTCEpochNanoseconds({
+  isoDate: { year, month, day },
+  time: { hour, minute, second, millisecond, microsecond, nanosecond }
+}: ISODateTime) {
   const ms = GetUTCEpochMilliseconds(year, month, day, hour, minute, second, millisecond);
   const subMs = microsecond * 1e3 + nanosecond;
   return JSBI.add(JSBI.multiply(JSBI.BigInt(ms), MILLION), JSBI.BigInt(subMs));
@@ -3206,7 +3163,10 @@ function GetNamedTimeZoneEpochNanoseconds(
 ) {
   // Get the offset of one day before and after the requested calendar date and
   // clock time, avoiding overflows if near the edge of the Instant range.
-  const ns = GetUTCEpochNanoseconds(year, month, day, hour, minute, second, millisecond, microsecond, nanosecond);
+  let ns = GetUTCEpochNanoseconds({
+    isoDate: { year, month, day },
+    time: { hour, minute, second, millisecond, microsecond, nanosecond }
+  });
   let nsEarlier = JSBI.subtract(ns, DAY_NANOS_JSBI);
   if (JSBI.lessThan(nsEarlier, NS_MIN)) nsEarlier = ns;
   let nsLater = JSBI.add(ns, DAY_NANOS_JSBI);
@@ -3541,11 +3501,8 @@ function RejectDateTime(
   RejectTime(hour, minute, second, millisecond, microsecond, nanosecond);
 }
 
-export function RejectDateTimeRange({
-  isoDate: { year, month, day },
-  time: { hour, minute, second, millisecond, microsecond, nanosecond }
-}: ISODateTime) {
-  const ns = GetUTCEpochNanoseconds(year, month, day, hour, minute, second, millisecond, microsecond, nanosecond);
+export function RejectDateTimeRange(isoDateTime: ISODateTime) {
+  const ns = GetUTCEpochNanoseconds(isoDateTime);
   if (JSBI.lessThan(ns, DATETIME_NS_MIN) || JSBI.greaterThan(ns, DATETIME_NS_MAX)) {
     // Because PlainDateTime's range is wider than Instant's range, the line
     // below will always throw. Calling `ValidateEpochNanoseconds` avoids
@@ -3967,34 +3924,14 @@ function NudgeToCalendarUnit(
 
   // Convert to epoch-nanoseconds
   let startEpochNs, endEpochNs;
+  const startDateTime = CombineISODateAndTimeRecord(start, isoDateTime.time);
+  const endDateTime = CombineISODateAndTimeRecord(end, isoDateTime.time);
   if (timeZone) {
-    const startDateTime = CombineISODateAndTimeRecord(start, isoDateTime.time);
     startEpochNs = GetEpochNanosecondsFor(timeZone, startDateTime, 'compatible');
-    const endDateTime = CombineISODateAndTimeRecord(end, isoDateTime.time);
     endEpochNs = GetEpochNanosecondsFor(timeZone, endDateTime, 'compatible');
   } else {
-    startEpochNs = GetUTCEpochNanoseconds(
-      start.year,
-      start.month,
-      start.day,
-      isoDateTime.time.hour,
-      isoDateTime.time.minute,
-      isoDateTime.time.second,
-      isoDateTime.time.millisecond,
-      isoDateTime.time.microsecond,
-      isoDateTime.time.nanosecond
-    );
-    endEpochNs = GetUTCEpochNanoseconds(
-      end.year,
-      end.month,
-      end.day,
-      isoDateTime.time.hour,
-      isoDateTime.time.minute,
-      isoDateTime.time.second,
-      isoDateTime.time.millisecond,
-      isoDateTime.time.microsecond,
-      isoDateTime.time.nanosecond
-    );
+    startEpochNs = GetUTCEpochNanoseconds(startDateTime);
+    endEpochNs = GetUTCEpochNanoseconds(endDateTime);
   }
 
   // Round the smallestUnit within the epoch-nanosecond span
@@ -4208,22 +4145,12 @@ function BubbleRelativeDuration(
 
     // Compute end-of-unit in epoch-nanoseconds
     const end = CalendarDateAdd(calendar, isoDateTime.isoDate, endDuration, 'constrain');
+    const endDateTime = CombineISODateAndTimeRecord(end, isoDateTime.time);
     let endEpochNs;
     if (timeZone) {
-      const endDateTime = CombineISODateAndTimeRecord(end, isoDateTime.time);
       endEpochNs = GetEpochNanosecondsFor(timeZone, endDateTime, 'compatible');
     } else {
-      endEpochNs = GetUTCEpochNanoseconds(
-        end.year,
-        end.month,
-        end.day,
-        isoDateTime.time.hour,
-        isoDateTime.time.minute,
-        isoDateTime.time.second,
-        isoDateTime.time.millisecond,
-        isoDateTime.time.microsecond,
-        isoDateTime.time.nanosecond
-      );
+      endEpochNs = GetUTCEpochNanoseconds(endDateTime);
     }
 
     const didExpandToEnd = compare(nudgedEpochNs, endEpochNs) !== -sign;
@@ -4364,17 +4291,7 @@ export function DifferencePlainDateTimeWithRounding(
 
   if (smallestUnit === 'nanosecond' && roundingIncrement === 1) return duration;
 
-  const destEpochNs = GetUTCEpochNanoseconds(
-    isoDateTime2.isoDate.year,
-    isoDateTime2.isoDate.month,
-    isoDateTime2.isoDate.day,
-    isoDateTime2.time.hour,
-    isoDateTime2.time.minute,
-    isoDateTime2.time.second,
-    isoDateTime2.time.millisecond,
-    isoDateTime2.time.microsecond,
-    isoDateTime2.time.nanosecond
-  );
+  const destEpochNs = GetUTCEpochNanoseconds(isoDateTime2);
   return RoundRelativeDuration(
     duration,
     destEpochNs,
@@ -4400,17 +4317,7 @@ export function DifferencePlainDateTimeWithTotal(
 
   if (unit === 'nanosecond') return JSBI.toNumber(duration.norm.totalNs);
 
-  const destEpochNs = GetUTCEpochNanoseconds(
-    isoDateTime2.isoDate.year,
-    isoDateTime2.isoDate.month,
-    isoDateTime2.isoDate.day,
-    isoDateTime2.time.hour,
-    isoDateTime2.time.minute,
-    isoDateTime2.time.second,
-    isoDateTime2.time.millisecond,
-    isoDateTime2.time.microsecond,
-    isoDateTime2.time.nanosecond
-  );
+  const destEpochNs = GetUTCEpochNanoseconds(isoDateTime2);
   return TotalRelativeDuration(duration, destEpochNs, isoDateTime1, null, calendar, unit);
 }
 
@@ -4584,7 +4491,8 @@ export function DifferenceTemporalPlainDate(
   if (!roundingIsNoop) {
     const midnight = { hour: 0, minute: 0, second: 0, millisecond: 0, microsecond: 0, nanosecond: 0 };
     const isoDateTime = CombineISODateAndTimeRecord(isoDate, midnight);
-    const destEpochNs = GetUTCEpochNanoseconds(isoOther.year, isoOther.month, isoOther.day, 0, 0, 0, 0, 0, 0);
+    const isoDateTimeOther = CombineISODateAndTimeRecord(isoOther, midnight);
+    const destEpochNs = GetUTCEpochNanoseconds(isoDateTimeOther);
     duration = RoundRelativeDuration(
       duration,
       destEpochNs,
@@ -4715,7 +4623,8 @@ export function DifferenceTemporalPlainYearMonth(
   if (settings.smallestUnit !== 'month' || settings.roundingIncrement !== 1) {
     const midnight = { hour: 0, minute: 0, second: 0, millisecond: 0, microsecond: 0, nanosecond: 0 };
     const isoDateTime = CombineISODateAndTimeRecord(thisDate, midnight);
-    const destEpochNs = GetUTCEpochNanoseconds(otherDate.year, otherDate.month, otherDate.day, 0, 0, 0, 0, 0, 0);
+    const isoDateTimeOther = CombineISODateAndTimeRecord(otherDate, midnight);
+    const destEpochNs = GetUTCEpochNanoseconds(isoDateTimeOther);
     duration = RoundRelativeDuration(
       duration,
       destEpochNs,

--- a/lib/ecmascript.ts
+++ b/lib/ecmascript.ts
@@ -5232,15 +5232,7 @@ export function RoundTemporalInstant(
 }
 
 export function RoundISODateTime(
-  year: number,
-  month: number,
-  day: number,
-  hour: number,
-  minute: number,
-  second: number,
-  millisecond: number,
-  microsecond: number,
-  nanosecond: number,
+  { year, month, day, hour, minute, second, millisecond, microsecond, nanosecond }: ISODateTime,
   increment: number,
   unit: UnitSmallerThanOrEqualTo<'day'>,
   roundingMode: Temporal.RoundingMode

--- a/lib/ecmascript.ts
+++ b/lib/ecmascript.ts
@@ -2610,7 +2610,7 @@ function FormatFractionalSeconds(
   return `.${fraction}`;
 }
 
-export function FormatTimeString(
+function FormatTimeString(
   hour: number,
   minute: number,
   second: number,
@@ -2713,6 +2713,14 @@ export function TemporalDateToString(
   const day = ISODateTimePartString(GetSlot(date, ISO_DAY));
   const calendar = FormatCalendarAnnotation(GetSlot(date, CALENDAR), showCalendar);
   return `${year}-${month}-${day}${calendar}`;
+}
+
+export function TimeRecordToString(
+  { hour, minute, second, millisecond, microsecond, nanosecond }: TimeRecord,
+  precision: SecondsStringPrecisionRecord['precision']
+) {
+  const subSecondNanoseconds = millisecond * 1e6 + microsecond * 1e3 + nanosecond;
+  return FormatTimeString(hour, minute, second, subSecondNanoseconds, precision);
 }
 
 export function TemporalDateTimeToString(

--- a/lib/ecmascript.ts
+++ b/lib/ecmascript.ts
@@ -999,6 +999,14 @@ export function CombineISODateAndTimeRecord(isoDate: ISODate, time: TimeRecord) 
   return { isoDate, time };
 }
 
+export function MidnightTimeRecord() {
+  return { deltaDays: 0, hour: 0, minute: 0, second: 0, millisecond: 0, microsecond: 0, nanosecond: 0 };
+}
+
+export function NoonTimeRecord() {
+  return { deltaDays: 0, hour: 12, minute: 0, second: 0, millisecond: 0, microsecond: 0, nanosecond: 0 };
+}
+
 export function GetTemporalOverflowOption(options: Temporal.AssignmentOptions) {
   return GetOption(options, 'overflow', ['constrain', 'reject'], 'constrain');
 }
@@ -1606,9 +1614,7 @@ export function ToTemporalDateTime(item: PlainDateTimeParams['from'][0], options
     let z;
     ({ year, month, day, time, calendar, z } = ParseTemporalDateTimeString(RequireString(item)));
     if (z) throw new RangeErrorCtor('Z designator not supported for PlainDateTime');
-    if (time === 'start-of-day') {
-      time = { hour: 0, minute: 0, second: 0, millisecond: 0, microsecond: 0, nanosecond: 0 };
-    }
+    if (time === 'start-of-day') time = MidnightTimeRecord();
     RejectDateTime(
       year,
       month,
@@ -2517,8 +2523,7 @@ function GetPossibleEpochNanoseconds(timeZone: string, isoDateTime: ISODateTime)
 }
 
 export function GetStartOfDay(timeZone: string, isoDate: ISODate) {
-  const midnight = { hour: 0, minute: 0, second: 0, millisecond: 0, microsecond: 0, nanosecond: 0 };
-  const isoDateTime = CombineISODateAndTimeRecord(isoDate, midnight);
+  const isoDateTime = CombineISODateAndTimeRecord(isoDate, MidnightTimeRecord());
   const possibleEpochNs = GetPossibleEpochNanoseconds(timeZone, isoDateTime);
   // If not a DST gap, return the single or earlier epochNs
   if (possibleEpochNs.length) return possibleEpochNs[0];
@@ -3427,8 +3432,7 @@ function RejectISODate(year: number, month: number, day: number) {
 
 function RejectDateRange(isoDate: ISODate) {
   // Noon avoids trouble at edges of DateTime range (excludes midnight)
-  const noon = { hour: 12, minute: 0, second: 0, millisecond: 0, microsecond: 0, nanosecond: 0 };
-  RejectDateTimeRange(CombineISODateAndTimeRecord(isoDate, noon));
+  RejectDateTimeRange(CombineISODateAndTimeRecord(isoDate, NoonTimeRecord()));
 }
 
 export function RejectTime(
@@ -4450,9 +4454,8 @@ export function DifferenceTemporalPlainDate(
   let duration = { date: dateDifference, norm: TimeDuration.ZERO };
   const roundingIsNoop = settings.smallestUnit === 'day' && settings.roundingIncrement === 1;
   if (!roundingIsNoop) {
-    const midnight = { hour: 0, minute: 0, second: 0, millisecond: 0, microsecond: 0, nanosecond: 0 };
-    const isoDateTime = CombineISODateAndTimeRecord(isoDate, midnight);
-    const isoDateTimeOther = CombineISODateAndTimeRecord(isoOther, midnight);
+    const isoDateTime = CombineISODateAndTimeRecord(isoDate, MidnightTimeRecord());
+    const isoDateTimeOther = CombineISODateAndTimeRecord(isoOther, MidnightTimeRecord());
     const destEpochNs = GetUTCEpochNanoseconds(isoDateTimeOther);
     duration = RoundRelativeDuration(
       duration,
@@ -4582,9 +4585,8 @@ export function DifferenceTemporalPlainYearMonth(
   const dateDifference = CalendarDateUntil(calendar, thisDate, otherDate, settings.largestUnit);
   let duration = { date: AdjustDateDurationRecord(dateDifference, 0, 0), norm: TimeDuration.ZERO };
   if (settings.smallestUnit !== 'month' || settings.roundingIncrement !== 1) {
-    const midnight = { hour: 0, minute: 0, second: 0, millisecond: 0, microsecond: 0, nanosecond: 0 };
-    const isoDateTime = CombineISODateAndTimeRecord(thisDate, midnight);
-    const isoDateTimeOther = CombineISODateAndTimeRecord(otherDate, midnight);
+    const isoDateTime = CombineISODateAndTimeRecord(thisDate, MidnightTimeRecord());
+    const isoDateTimeOther = CombineISODateAndTimeRecord(otherDate, MidnightTimeRecord());
     const destEpochNs = GetUTCEpochNanoseconds(isoDateTimeOther);
     duration = RoundRelativeDuration(
       duration,

--- a/lib/ecmascript.ts
+++ b/lib/ecmascript.ts
@@ -4400,7 +4400,15 @@ export function DifferencePlainDateTimeWithRounding(
   smallestUnit: Temporal.DateTimeUnit,
   roundingMode: Temporal.RoundingMode
 ) {
-  if (CompareISODateTime(y1, mon1, d1, h1, min1, s1, ms1, µs1, ns1, y2, mon2, d2, h2, min2, s2, ms2, µs2, ns2) == 0) {
+  const isoDateTime1 = {
+    isoDate: { year: y1, month: mon1, day: d1 },
+    time: { hour: h1, minute: min1, second: s1, millisecond: ms1, microsecond: µs1, nanosecond: ns1 }
+  };
+  const isoDateTime2 = {
+    isoDate: { year: y2, month: mon2, day: d2 },
+    time: { hour: h2, minute: min2, second: s2, millisecond: ms2, microsecond: µs2, nanosecond: ns2 }
+  };
+  if (CompareISODateTime(isoDateTime1, isoDateTime2) == 0) {
     return { date: ZeroDateDuration(), norm: TimeDuration.ZERO };
   }
 
@@ -4429,15 +4437,11 @@ export function DifferencePlainDateTimeWithRounding(
 
   if (smallestUnit === 'nanosecond' && roundingIncrement === 1) return duration;
 
-  const isoDateTime = {
-    isoDate: { year: y1, month: mon1, day: d1 },
-    time: { hour: h1, minute: min1, second: s1, millisecond: ms1, microsecond: µs1, nanosecond: ns1 }
-  };
   const destEpochNs = GetUTCEpochNanoseconds(y2, mon2, d2, h2, min2, s2, ms2, µs2, ns2);
   return RoundRelativeDuration(
     duration,
     destEpochNs,
-    isoDateTime,
+    isoDateTime1,
     null,
     calendar,
     largestUnit,
@@ -4469,7 +4473,15 @@ export function DifferencePlainDateTimeWithTotal(
   calendar: BuiltinCalendarId,
   unit: Temporal.DateTimeUnit
 ) {
-  if (CompareISODateTime(y1, mon1, d1, h1, min1, s1, ms1, µs1, ns1, y2, mon2, d2, h2, min2, s2, ms2, µs2, ns2) == 0) {
+  const isoDateTime1 = {
+    isoDate: { year: y1, month: mon1, day: d1 },
+    time: { hour: h1, minute: min1, second: s1, millisecond: ms1, microsecond: µs1, nanosecond: ns1 }
+  };
+  const isoDateTime2 = {
+    isoDate: { year: y2, month: mon2, day: d2 },
+    time: { hour: h2, minute: min2, second: s2, millisecond: ms2, microsecond: µs2, nanosecond: ns2 }
+  };
+  if (CompareISODateTime(isoDateTime1, isoDateTime2) == 0) {
     return 0;
   }
 
@@ -4498,12 +4510,8 @@ export function DifferencePlainDateTimeWithTotal(
 
   if (unit === 'nanosecond') return JSBI.toNumber(duration.norm.totalNs);
 
-  const isoDateTime = {
-    isoDate: { year: y1, month: mon1, day: d1 },
-    time: { hour: h1, minute: min1, second: s1, millisecond: ms1, microsecond: µs1, nanosecond: ns1 }
-  };
   const destEpochNs = GetUTCEpochNanoseconds(y2, mon2, d2, h2, min2, s2, ms2, µs2, ns2);
-  return TotalRelativeDuration(duration, destEpochNs, isoDateTime, null, calendar, unit);
+  return TotalRelativeDuration(duration, destEpochNs, isoDateTime1, null, calendar, unit);
 }
 
 export function DifferenceZonedDateTimeWithRounding(
@@ -5303,32 +5311,10 @@ export function CompareTimeRecord(time1: TimeRecord, time2: TimeRecord) {
   return 0;
 }
 
-export function CompareISODateTime(
-  y1: number,
-  m1: number,
-  d1: number,
-  h1: number,
-  min1: number,
-  s1: number,
-  ms1: number,
-  µs1: number,
-  ns1: number,
-  y2: number,
-  m2: number,
-  d2: number,
-  h2: number,
-  min2: number,
-  s2: number,
-  ms2: number,
-  µs2: number,
-  ns2: number
-) {
-  const dateResult = CompareISODate({ year: y1, month: m1, day: d1 }, { year: y2, month: m2, day: d2 });
+export function CompareISODateTime(isoDateTime1: ISODateTime, isoDateTime2: ISODateTime) {
+  const dateResult = CompareISODate(isoDateTime1.isoDate, isoDateTime2.isoDate);
   if (dateResult !== 0) return dateResult;
-  return CompareTimeRecord(
-    { hour: h1, minute: min1, second: s1, millisecond: ms1, microsecond: µs1, nanosecond: ns1 },
-    { hour: h2, minute: min2, second: s2, millisecond: ms2, microsecond: µs2, nanosecond: ns2 }
-  );
+  return CompareTimeRecord(isoDateTime1.time, isoDateTime2.time);
 }
 
 // Defaults to native bigint, or something "native bigint-like".

--- a/lib/ecmascript.ts
+++ b/lib/ecmascript.ts
@@ -2494,7 +2494,7 @@ function DisambiguatePossibleEpochNanoseconds(
   switch (disambiguation) {
     case 'earlier': {
       const norm = TimeDuration.normalize(0, 0, 0, 0, 0, -nanoseconds);
-      const earlierTime = AddTime(hour, minute, second, millisecond, microsecond, nanosecond, norm);
+      const earlierTime = AddTime(isoDateTime, norm);
       const earlierDate = BalanceISODate(year, month, day + earlierTime.deltaDays);
       return GetPossibleEpochNanoseconds(timeZone, { ...earlierTime, ...earlierDate })[0];
     }
@@ -2502,7 +2502,7 @@ function DisambiguatePossibleEpochNanoseconds(
     // fall through because 'compatible' means 'later' for "spring forward" transitions
     case 'later': {
       const norm = TimeDuration.normalize(0, 0, 0, 0, 0, nanoseconds);
-      const laterTime = AddTime(hour, minute, second, millisecond, microsecond, nanosecond, norm);
+      const laterTime = AddTime(isoDateTime, norm);
       const laterDate = BalanceISODate(year, month, day + laterTime.deltaDays);
       const possible = GetPossibleEpochNanoseconds(timeZone, { ...laterTime, ...laterDate });
       return possible[possible.length - 1];
@@ -4929,12 +4929,7 @@ export function DifferenceTemporalZonedDateTime(
 }
 
 export function AddTime(
-  hour: number,
-  minute: number,
-  secondParam: number,
-  millisecond: number,
-  microsecond: number,
-  nanosecondParam: number,
+  { hour, minute, second: secondParam, millisecond, microsecond, nanosecond: nanosecondParam }: TimeRecord,
   norm: TimeDuration
 ) {
   let second = secondParam;
@@ -5062,12 +5057,14 @@ export function AddDurationToDateTime(
 
   // Add the time part
   const timeResult = AddTime(
-    GetSlot(dateTime, ISO_HOUR),
-    GetSlot(dateTime, ISO_MINUTE),
-    GetSlot(dateTime, ISO_SECOND),
-    GetSlot(dateTime, ISO_MILLISECOND),
-    GetSlot(dateTime, ISO_MICROSECOND),
-    GetSlot(dateTime, ISO_NANOSECOND),
+    {
+      hour: GetSlot(dateTime, ISO_HOUR),
+      minute: GetSlot(dateTime, ISO_MINUTE),
+      second: GetSlot(dateTime, ISO_SECOND),
+      millisecond: GetSlot(dateTime, ISO_MILLISECOND),
+      microsecond: GetSlot(dateTime, ISO_MICROSECOND),
+      nanosecond: GetSlot(dateTime, ISO_NANOSECOND)
+    },
     normalizedDuration.norm
   );
   const dateDuration = AdjustDateDurationRecord(normalizedDuration.date, timeResult.deltaDays);
@@ -5106,12 +5103,14 @@ export function AddDurationToTime(
   if (operation === 'subtract') duration = CreateNegatedTemporalDuration(duration);
   const normalizedDuration = NormalizeDurationWith24HourDays(duration);
   let { hour, minute, second, millisecond, microsecond, nanosecond } = AddTime(
-    GetSlot(temporalTime, ISO_HOUR),
-    GetSlot(temporalTime, ISO_MINUTE),
-    GetSlot(temporalTime, ISO_SECOND),
-    GetSlot(temporalTime, ISO_MILLISECOND),
-    GetSlot(temporalTime, ISO_MICROSECOND),
-    GetSlot(temporalTime, ISO_NANOSECOND),
+    {
+      hour: GetSlot(temporalTime, ISO_HOUR),
+      minute: GetSlot(temporalTime, ISO_MINUTE),
+      second: GetSlot(temporalTime, ISO_SECOND),
+      millisecond: GetSlot(temporalTime, ISO_MILLISECOND),
+      microsecond: GetSlot(temporalTime, ISO_MICROSECOND),
+      nanosecond: GetSlot(temporalTime, ISO_NANOSECOND)
+    },
     normalizedDuration.norm
   );
   ({ hour, minute, second, millisecond, microsecond, nanosecond } = RegulateTime(

--- a/lib/ecmascript.ts
+++ b/lib/ecmascript.ts
@@ -1950,7 +1950,7 @@ export function InterpretISODateTimeOffset(
   // zone and date/time.
   if (offsetOpt === 'reject') {
     const offsetStr = FormatUTCOffsetNanoseconds(offsetNs);
-    const dtStr = TemporalDateTimeToString(dt, 'iso8601', 'auto');
+    const dtStr = ISODateTimeToString(dt, 'iso8601', 'auto');
     throw new RangeErrorCtor(`Offset ${offsetStr} is invalid for ${dtStr} in ${timeZone}`);
   }
   // fall through: offsetOpt === 'prefer', but the offset doesn't match
@@ -2106,7 +2106,7 @@ export function CreateTemporalDateTimeSlots(
   SetSlot(result, CALENDAR, calendar);
 
   if (DEBUG) {
-    let repr = TemporalDateTimeToString(iso, calendar, 'auto');
+    let repr = ISODateTimeToString(iso, calendar, 'auto');
     ObjectDefineProperty(result, '_repr_', {
       value: `Temporal.PlainDateTime <${repr}>`,
       writable: false,
@@ -2634,7 +2634,7 @@ export function TemporalInstantToString(
   if (outputTimeZone === undefined) outputTimeZone = 'UTC';
   const epochNs = GetSlot(instant, EPOCHNANOSECONDS);
   const iso = GetISODateTimeFor(outputTimeZone, epochNs);
-  const dateTimeString = TemporalDateTimeToString(iso, 'iso8601', precision, 'never');
+  const dateTimeString = ISODateTimeToString(iso, 'iso8601', precision, 'never');
   let timeZoneString = 'Z';
   if (timeZone !== undefined) {
     const offsetNs = GetOffsetNanosecondsFor(outputTimeZone, epochNs);
@@ -2723,7 +2723,7 @@ export function TimeRecordToString(
   return FormatTimeString(hour, minute, second, subSecondNanoseconds, precision);
 }
 
-export function TemporalDateTimeToString(
+export function ISODateTimeToString(
   isoDateTime: ISODateTime,
   calendar: BuiltinCalendarId,
   precision: SecondsStringPrecisionRecord['precision'],
@@ -2791,7 +2791,7 @@ export function TemporalZonedDateTimeToString(
   const tz = GetSlot(zdt, TIME_ZONE);
   const offsetNs = GetOffsetNanosecondsFor(tz, epochNs);
   const iso = GetISODateTimeFor(tz, epochNs);
-  let dateTimeString = TemporalDateTimeToString(iso, 'iso8601', precision, 'never');
+  let dateTimeString = ISODateTimeToString(iso, 'iso8601', precision, 'never');
   if (showOffset !== 'never') {
     dateTimeString += FormatDateTimeUTCOffsetRounded(offsetNs);
   }

--- a/lib/ecmascript.ts
+++ b/lib/ecmascript.ts
@@ -2487,22 +2487,18 @@ function DisambiguatePossibleEpochNanoseconds(
 }
 
 function GetPossibleEpochNanoseconds(timeZone: string, isoDateTime: ISODateTime) {
-  const {
-    isoDate: { year, month, day },
-    time: { hour, minute, second, millisecond, microsecond, nanosecond }
-  } = isoDateTime;
   const offsetMinutes = ParseTimeZoneIdentifier(timeZone).offsetMinutes;
   if (offsetMinutes !== undefined) {
     const balanced = BalanceISODateTime(
-      year,
-      month,
-      day,
-      hour,
-      minute - offsetMinutes,
-      second,
-      millisecond,
-      microsecond,
-      nanosecond
+      isoDateTime.isoDate.year,
+      isoDateTime.isoDate.month,
+      isoDateTime.isoDate.day,
+      isoDateTime.time.hour,
+      isoDateTime.time.minute - offsetMinutes,
+      isoDateTime.time.second,
+      isoDateTime.time.millisecond,
+      isoDateTime.time.microsecond,
+      isoDateTime.time.nanosecond
     );
     if (MathAbs(ISODateToEpochDays(balanced.isoDate.year, balanced.isoDate.month - 1, balanced.isoDate.day)) > 1e8) {
       throw new RangeErrorCtor('date/time value is outside the supported range');
@@ -2512,21 +2508,12 @@ function GetPossibleEpochNanoseconds(timeZone: string, isoDateTime: ISODateTime)
     return [epochNs];
   }
 
-  if (MathAbs(ISODateToEpochDays(year, month - 1, day)) > 1e8) {
+  if (
+    MathAbs(ISODateToEpochDays(isoDateTime.isoDate.year, isoDateTime.isoDate.month - 1, isoDateTime.isoDate.day)) > 1e8
+  ) {
     throw new RangeErrorCtor('date/time value is outside the supported range');
   }
-  return GetNamedTimeZoneEpochNanoseconds(
-    timeZone,
-    year,
-    month,
-    day,
-    hour,
-    minute,
-    second,
-    millisecond,
-    microsecond,
-    nanosecond
-  );
+  return GetNamedTimeZoneEpochNanoseconds(timeZone, isoDateTime);
 }
 
 export function GetStartOfDay(timeZone: string, isoDate: ISODate) {
@@ -3149,24 +3136,10 @@ export function GetFormatterParts(timeZone: string, epochMilliseconds: number) {
 // be only one match. But for repeated clock times after backwards transitions
 // (like when DST ends) there may be two matches. And for skipped clock times
 // after forward transitions, there will be no matches.
-function GetNamedTimeZoneEpochNanoseconds(
-  id: string,
-  year: number,
-  month: number,
-  day: number,
-  hour: number,
-  minute: number,
-  second: number,
-  millisecond: number,
-  microsecond: number,
-  nanosecond: number
-) {
+function GetNamedTimeZoneEpochNanoseconds(id: string, isoDateTime: ISODateTime) {
   // Get the offset of one day before and after the requested calendar date and
   // clock time, avoiding overflows if near the edge of the Instant range.
-  let ns = GetUTCEpochNanoseconds({
-    isoDate: { year, month, day },
-    time: { hour, minute, second, millisecond, microsecond, nanosecond }
-  });
+  let ns = GetUTCEpochNanoseconds(isoDateTime);
   let nsEarlier = JSBI.subtract(ns, DAY_NANOS_JSBI);
   if (JSBI.lessThan(nsEarlier, NS_MIN)) nsEarlier = ns;
   let nsLater = JSBI.add(ns, DAY_NANOS_JSBI);
@@ -3184,19 +3157,7 @@ function GetNamedTimeZoneEpochNanoseconds(
     (offsetNanoseconds) => {
       const epochNanoseconds = JSBI.subtract(ns, JSBI.BigInt(offsetNanoseconds));
       const parts = GetNamedTimeZoneDateTimeParts(id, epochNanoseconds);
-      if (
-        year !== parts.isoDate.year ||
-        month !== parts.isoDate.month ||
-        day !== parts.isoDate.day ||
-        hour !== parts.time.hour ||
-        minute !== parts.time.minute ||
-        second !== parts.time.second ||
-        millisecond !== parts.time.millisecond ||
-        microsecond !== parts.time.microsecond ||
-        nanosecond !== parts.time.nanosecond
-      ) {
-        return undefined;
-      }
+      if (CompareISODateTime(isoDateTime, parts) !== 0) return undefined;
       ValidateEpochNanoseconds(epochNanoseconds);
       return epochNanoseconds;
     }

--- a/lib/ecmascript.ts
+++ b/lib/ecmascript.ts
@@ -2175,7 +2175,8 @@ export function CreateTemporalYearMonthSlots(
   referenceISODay: number
 ) {
   RejectISODate(isoYear, isoMonth, referenceISODay);
-  RejectYearMonthRange(isoYear, isoMonth);
+  const isoDate = { year: isoYear, month: isoMonth, day: referenceISODay };
+  RejectYearMonthRange(isoDate);
 
   CreateSlots(result);
   SetSlot(result, ISO_YEAR, isoYear);
@@ -2342,7 +2343,7 @@ export function CalendarYearMonthFromFields(
   calendarImpl.resolveFields(fields, 'year-month');
   fields.day = 1;
   const result = calendarImpl.dateToISO(fields, overflow);
-  RejectYearMonthRange(result.year, result.month);
+  RejectYearMonthRange(result);
   return result;
 }
 
@@ -3562,7 +3563,7 @@ export function ValidateEpochNanoseconds(epochNanoseconds: JSBI) {
   }
 }
 
-function RejectYearMonthRange(year: number, month: number) {
+function RejectYearMonthRange({ year, month }: Omit<ISODate, 'day'>) {
   RejectToRange(year, YEAR_MIN, YEAR_MAX);
   if (year === YEAR_MIN) {
     RejectToRange(month, 4, 12);

--- a/lib/ecmascript.ts
+++ b/lib/ecmascript.ts
@@ -3800,46 +3800,25 @@ function DifferenceInstant(
 }
 
 function DifferenceISODateTime(
-  y1: number,
-  mon1: number,
-  d1: number,
-  h1: number,
-  min1: number,
-  s1: number,
-  ms1: number,
-  µs1: number,
-  ns1: number,
-  y2: number,
-  mon2: number,
-  d2: number,
-  h2: number,
-  min2: number,
-  s2: number,
-  ms2: number,
-  µs2: number,
-  ns2: number,
+  isoDateTime1: ISODateTime,
+  isoDateTime2: ISODateTime,
   calendar: BuiltinCalendarId,
   largestUnit: Temporal.DateTimeUnit
 ) {
-  let timeDuration = DifferenceTime(
-    { hour: h1, minute: min1, second: s1, millisecond: ms1, microsecond: µs1, nanosecond: ns1 },
-    { hour: h2, minute: min2, second: s2, millisecond: ms2, microsecond: µs2, nanosecond: ns2 }
-  );
+  let timeDuration = DifferenceTime(isoDateTime1.time, isoDateTime2.time);
 
   const timeSign = timeDuration.sign();
-  const isoDate1 = { year: y1, month: mon1, day: d1 };
-  const isoDate2 = { year: y2, month: mon2, day: d2 };
-  const dateSign = CompareISODate(isoDate2, isoDate1);
+  const dateSign = CompareISODate(isoDateTime2.isoDate, isoDateTime1.isoDate);
 
   // back-off a day from date2 so that the signs of the date and time diff match
-  let adjustedDate = isoDate2;
+  let adjustedDate = isoDateTime2.isoDate;
   if (dateSign === -timeSign) {
     adjustedDate = BalanceISODate(adjustedDate.year, adjustedDate.month, adjustedDate.day + timeSign);
     timeDuration = timeDuration.add24HourDays(-timeSign);
   }
 
   const dateLargestUnit = LargerOfTwoTemporalUnits('day', largestUnit) as Temporal.DateUnit;
-  const dateDifference = CalendarDateUntil(calendar, isoDate1, adjustedDate, dateLargestUnit);
+  const dateDifference = CalendarDateUntil(calendar, isoDateTime1.isoDate, adjustedDate, dateLargestUnit);
   if (largestUnit !== dateLargestUnit) {
     // largestUnit < days, so add the days in to the normalized duration
     timeDuration = timeDuration.add24HourDays(dateDifference.days);
@@ -4412,28 +4391,7 @@ export function DifferencePlainDateTimeWithRounding(
     return { date: ZeroDateDuration(), norm: TimeDuration.ZERO };
   }
 
-  const duration = DifferenceISODateTime(
-    y1,
-    mon1,
-    d1,
-    h1,
-    min1,
-    s1,
-    ms1,
-    µs1,
-    ns1,
-    y2,
-    mon2,
-    d2,
-    h2,
-    min2,
-    s2,
-    ms2,
-    µs2,
-    ns2,
-    calendar,
-    largestUnit
-  );
+  const duration = DifferenceISODateTime(isoDateTime1, isoDateTime2, calendar, largestUnit);
 
   if (smallestUnit === 'nanosecond' && roundingIncrement === 1) return duration;
 
@@ -4485,28 +4443,7 @@ export function DifferencePlainDateTimeWithTotal(
     return 0;
   }
 
-  const duration = DifferenceISODateTime(
-    y1,
-    mon1,
-    d1,
-    h1,
-    min1,
-    s1,
-    ms1,
-    µs1,
-    ns1,
-    y2,
-    mon2,
-    d2,
-    h2,
-    min2,
-    s2,
-    ms2,
-    µs2,
-    ns2,
-    calendar,
-    unit
-  );
+  const duration = DifferenceISODateTime(isoDateTime1, isoDateTime2, calendar, unit);
 
   if (unit === 'nanosecond') return JSBI.toNumber(duration.norm.totalNs);
 

--- a/lib/ecmascript.ts
+++ b/lib/ecmascript.ts
@@ -3752,26 +3752,13 @@ export function ISODateToEpochDays(y: number, m: number, d: number) {
   return GetUTCEpochMilliseconds(y, m + 1, d, 0, 0, 0, 0) / DAY_MS;
 }
 
-function DifferenceTime(
-  h1: number,
-  min1: number,
-  s1: number,
-  ms1: number,
-  µs1: number,
-  ns1: number,
-  h2: number,
-  min2: number,
-  s2: number,
-  ms2: number,
-  µs2: number,
-  ns2: number
-) {
-  const hours = h2 - h1;
-  const minutes = min2 - min1;
-  const seconds = s2 - s1;
-  const milliseconds = ms2 - ms1;
-  const microseconds = µs2 - µs1;
-  const nanoseconds = ns2 - ns1;
+function DifferenceTime(time1: TimeRecord, time2: TimeRecord) {
+  const hours = time2.hour - time1.hour;
+  const minutes = time2.minute - time1.minute;
+  const seconds = time2.second - time1.second;
+  const milliseconds = time2.millisecond - time1.millisecond;
+  const microseconds = time2.microsecond - time1.microsecond;
+  const nanoseconds = time2.nanosecond - time1.nanosecond;
   const norm = TimeDuration.normalize(hours, minutes, seconds, milliseconds, microseconds, nanoseconds);
   assert(norm.abs().sec < 86400, '_bt_.[[Days]] should be 0');
   return norm;
@@ -3789,18 +3776,18 @@ function DifferenceInstant(
 }
 
 function DifferenceISODateTime(
-  y1Param: number,
-  mon1Param: number,
-  d1Param: number,
+  y1: number,
+  mon1: number,
+  d1: number,
   h1: number,
   min1: number,
   s1: number,
   ms1: number,
   µs1: number,
   ns1: number,
-  y2Param: number,
-  mon2Param: number,
-  d2Param: number,
+  y2: number,
+  mon2: number,
+  d2: number,
   h2: number,
   min2: number,
   s2: number,
@@ -3810,14 +3797,10 @@ function DifferenceISODateTime(
   calendar: BuiltinCalendarId,
   largestUnit: Temporal.DateTimeUnit
 ) {
-  let y1 = y1Param;
-  let mon1 = mon1Param;
-  let d1 = d1Param;
-  let y2 = y2Param;
-  let mon2 = mon2Param;
-  let d2 = d2Param;
-
-  let timeDuration = DifferenceTime(h1, min1, s1, ms1, µs1, ns1, h2, min2, s2, ms2, µs2, ns2);
+  let timeDuration = DifferenceTime(
+    { hour: h1, minute: min1, second: s1, millisecond: ms1, microsecond: µs1, nanosecond: ns1 },
+    { hour: h2, minute: min2, second: s2, millisecond: ms2, microsecond: µs2, nanosecond: ns2 }
+  );
 
   const timeSign = timeDuration.sign();
   const isoDate1 = { year: y1, month: mon1, day: d1 };
@@ -3877,20 +3860,7 @@ function DifferenceZonedDateTime(
   // Detect ISO wall-clock overshoot.
   // If the diff of the ISO wall-clock times is opposite to the overall diff's sign,
   // we are guaranteed to need at least one day correction.
-  let timeDuration = DifferenceTime(
-    isoDtStart.hour,
-    isoDtStart.minute,
-    isoDtStart.second,
-    isoDtStart.millisecond,
-    isoDtStart.microsecond,
-    isoDtStart.nanosecond,
-    isoDtEnd.hour,
-    isoDtEnd.minute,
-    isoDtEnd.second,
-    isoDtEnd.millisecond,
-    isoDtEnd.microsecond,
-    isoDtEnd.nanosecond
-  );
+  let timeDuration = DifferenceTime(isoDtStart, isoDtEnd);
   if (timeDuration.sign() === -sign) {
     dayCorrection++;
   }
@@ -4798,18 +4768,22 @@ export function DifferenceTemporalPlainTime(
   const settings = GetDifferenceSettings(operation, resolvedOptions, 'time', [], 'nanosecond', 'hour');
 
   let norm = DifferenceTime(
-    GetSlot(plainTime, ISO_HOUR),
-    GetSlot(plainTime, ISO_MINUTE),
-    GetSlot(plainTime, ISO_SECOND),
-    GetSlot(plainTime, ISO_MILLISECOND),
-    GetSlot(plainTime, ISO_MICROSECOND),
-    GetSlot(plainTime, ISO_NANOSECOND),
-    GetSlot(other, ISO_HOUR),
-    GetSlot(other, ISO_MINUTE),
-    GetSlot(other, ISO_SECOND),
-    GetSlot(other, ISO_MILLISECOND),
-    GetSlot(other, ISO_MICROSECOND),
-    GetSlot(other, ISO_NANOSECOND)
+    {
+      hour: GetSlot(plainTime, ISO_HOUR),
+      minute: GetSlot(plainTime, ISO_MINUTE),
+      second: GetSlot(plainTime, ISO_SECOND),
+      millisecond: GetSlot(plainTime, ISO_MILLISECOND),
+      microsecond: GetSlot(plainTime, ISO_MICROSECOND),
+      nanosecond: GetSlot(plainTime, ISO_NANOSECOND)
+    },
+    {
+      hour: GetSlot(other, ISO_HOUR),
+      minute: GetSlot(other, ISO_MINUTE),
+      second: GetSlot(other, ISO_SECOND),
+      millisecond: GetSlot(other, ISO_MILLISECOND),
+      microsecond: GetSlot(other, ISO_MICROSECOND),
+      nanosecond: GetSlot(other, ISO_NANOSECOND)
+    }
   );
   let duration = { date: ZeroDateDuration(), norm };
   if (settings.smallestUnit !== 'nanosecond' || settings.roundingIncrement !== 1) {

--- a/lib/ecmascript.ts
+++ b/lib/ecmascript.ts
@@ -4396,44 +4396,28 @@ export function DifferencePlainDateTimeWithRounding(
 }
 
 export function DifferencePlainDateTimeWithTotal(
-  y1: number,
-  mon1: number,
-  d1: number,
-  h1: number,
-  min1: number,
-  s1: number,
-  ms1: number,
-  µs1: number,
-  ns1: number,
-  y2: number,
-  mon2: number,
-  d2: number,
-  h2: number,
-  min2: number,
-  s2: number,
-  ms2: number,
-  µs2: number,
-  ns2: number,
+  isoDateTime1: ISODateTime,
+  isoDateTime2: ISODateTime,
   calendar: BuiltinCalendarId,
   unit: Temporal.DateTimeUnit
 ) {
-  const isoDateTime1 = {
-    isoDate: { year: y1, month: mon1, day: d1 },
-    time: { hour: h1, minute: min1, second: s1, millisecond: ms1, microsecond: µs1, nanosecond: ns1 }
-  };
-  const isoDateTime2 = {
-    isoDate: { year: y2, month: mon2, day: d2 },
-    time: { hour: h2, minute: min2, second: s2, millisecond: ms2, microsecond: µs2, nanosecond: ns2 }
-  };
-  if (CompareISODateTime(isoDateTime1, isoDateTime2) == 0) {
-    return 0;
-  }
+  if (CompareISODateTime(isoDateTime1, isoDateTime2) == 0) return 0;
 
   const duration = DifferenceISODateTime(isoDateTime1, isoDateTime2, calendar, unit);
 
   if (unit === 'nanosecond') return JSBI.toNumber(duration.norm.totalNs);
 
-  const destEpochNs = GetUTCEpochNanoseconds(y2, mon2, d2, h2, min2, s2, ms2, µs2, ns2);
+  const destEpochNs = GetUTCEpochNanoseconds(
+    isoDateTime2.isoDate.year,
+    isoDateTime2.isoDate.month,
+    isoDateTime2.isoDate.day,
+    isoDateTime2.time.hour,
+    isoDateTime2.time.minute,
+    isoDateTime2.time.second,
+    isoDateTime2.time.millisecond,
+    isoDateTime2.time.microsecond,
+    isoDateTime2.time.nanosecond
+  );
   return TotalRelativeDuration(duration, destEpochNs, isoDateTime1, null, calendar, unit);
 }
 

--- a/lib/ecmascript.ts
+++ b/lib/ecmascript.ts
@@ -112,15 +112,9 @@ import {
   HasSlot,
   SetSlot,
   EPOCHNANOSECONDS,
-  ISO_YEAR,
-  ISO_MONTH,
-  ISO_DAY,
-  ISO_HOUR,
-  ISO_MINUTE,
-  ISO_SECOND,
-  ISO_MILLISECOND,
-  ISO_MICROSECOND,
-  ISO_NANOSECOND,
+  ISO_DATE,
+  ISO_DATE_TIME,
+  TIME,
   DATE_BRAND,
   YEAR_MONTH_BRAND,
   MONTH_DAY_BRAND,
@@ -511,26 +505,15 @@ export function IsTemporalDuration(item: unknown): item is Temporal.Duration {
 export function IsTemporalDate(item: unknown): item is Temporal.PlainDate {
   return HasSlot(item, DATE_BRAND);
 }
+
 export function IsTemporalTime(item: unknown): item is Temporal.PlainTime {
-  return (
-    HasSlot(item, ISO_HOUR, ISO_MINUTE, ISO_SECOND, ISO_MILLISECOND, ISO_MICROSECOND, ISO_NANOSECOND) &&
-    !HasSlot(item, ISO_YEAR, ISO_MONTH, ISO_DAY)
-  );
+  return HasSlot(item, TIME);
 }
+
 export function IsTemporalDateTime(item: unknown): item is Temporal.PlainDateTime {
-  return HasSlot(
-    item,
-    ISO_YEAR,
-    ISO_MONTH,
-    ISO_DAY,
-    ISO_HOUR,
-    ISO_MINUTE,
-    ISO_SECOND,
-    ISO_MILLISECOND,
-    ISO_MICROSECOND,
-    ISO_NANOSECOND
-  );
+  return HasSlot(item, ISO_DATE_TIME);
 }
+
 export function IsTemporalYearMonth(item: unknown): item is Temporal.PlainYearMonth {
   return HasSlot(item, YEAR_MONTH_BRAND);
 }
@@ -967,34 +950,6 @@ function ZeroDateDuration() {
   return { years: 0, months: 0, weeks: 0, days: 0 };
 }
 
-export function TemporalObjectToISODateRecord(
-  temporalObject: Temporal.PlainDate | Temporal.PlainDateTime | Temporal.PlainYearMonth | Temporal.PlainMonthDay
-) {
-  return {
-    year: GetSlot(temporalObject, ISO_YEAR),
-    month: GetSlot(temporalObject, ISO_MONTH),
-    day: GetSlot(temporalObject, ISO_DAY)
-  };
-}
-
-export function PlainDateTimeToISODateTimeRecord(plainDateTime: Temporal.PlainDateTime) {
-  return {
-    isoDate: {
-      year: GetSlot(plainDateTime, ISO_YEAR),
-      month: GetSlot(plainDateTime, ISO_MONTH),
-      day: GetSlot(plainDateTime, ISO_DAY)
-    },
-    time: {
-      hour: GetSlot(plainDateTime, ISO_HOUR),
-      minute: GetSlot(plainDateTime, ISO_MINUTE),
-      second: GetSlot(plainDateTime, ISO_SECOND),
-      millisecond: GetSlot(plainDateTime, ISO_MILLISECOND),
-      microsecond: GetSlot(plainDateTime, ISO_MICROSECOND),
-      nanosecond: GetSlot(plainDateTime, ISO_NANOSECOND)
-    }
-  };
-}
-
 export function CombineISODateAndTimeRecord(isoDate: ISODate, time: TimeRecord) {
   return { isoDate, time };
 }
@@ -1252,7 +1207,11 @@ export function GetTemporalRelativeToOption(options: {
       return { zonedRelativeTo: relativeTo };
     }
     if (IsTemporalDate(relativeTo)) return { plainRelativeTo: relativeTo };
-    if (IsTemporalDateTime(relativeTo)) return { plainRelativeTo: TemporalDateTimeToDate(relativeTo) };
+    if (IsTemporalDateTime(relativeTo)) {
+      return {
+        plainRelativeTo: CreateTemporalDate(GetSlot(relativeTo, ISO_DATE_TIME).isoDate, GetSlot(relativeTo, CALENDAR))
+      };
+    }
     calendar = GetTemporalCalendarIdentifierWithISODefault(relativeTo);
     const fields = PrepareCalendarFields(
       calendar,
@@ -1285,7 +1244,7 @@ export function GetTemporalRelativeToOption(options: {
     isoDate = { year, month, day };
   }
   if (timeZone === undefined) {
-    return { plainRelativeTo: CreateTemporalDate(isoDate.year, isoDate.month, isoDate.day, calendar) };
+    return { plainRelativeTo: CreateTemporalDate(isoDate, calendar) };
   }
   const offsetNs = offsetBehaviour === 'option' ? ParseDateTimeUTCOffset(castExists(offset)) : 0;
   const epochNanoseconds = InterpretISODateTimeOffset(
@@ -1344,7 +1303,9 @@ export function TemporalObjectToFields(
   temporalObject: Temporal.PlainDate | Temporal.PlainDateTime | Temporal.PlainYearMonth | Temporal.PlainMonthDay
 ) {
   const calendar = GetSlot(temporalObject, CALENDAR);
-  const isoDate = TemporalObjectToISODateRecord(temporalObject);
+  const isoDate = IsTemporalDateTime(temporalObject)
+    ? GetSlot(temporalObject, ISO_DATE_TIME).isoDate
+    : GetSlot(temporalObject, ISO_DATE);
   let type: ISODateToFieldsType = 'date';
   if (IsTemporalYearMonth(temporalObject)) {
     type = 'year-month';
@@ -1491,33 +1452,23 @@ export function ToTemporalDate(
   if (IsObject(item)) {
     if (IsTemporalDate(item)) {
       GetTemporalOverflowOption(GetOptionsObject(options));
-      return CreateTemporalDate(
-        GetSlot(item, ISO_YEAR),
-        GetSlot(item, ISO_MONTH),
-        GetSlot(item, ISO_DAY),
-        GetSlot(item, CALENDAR)
-      );
+      return CreateTemporalDate(GetSlot(item, ISO_DATE), GetSlot(item, CALENDAR));
     }
     if (IsTemporalZonedDateTime(item)) {
       const isoDateTime = GetISODateTimeFor(GetSlot(item, TIME_ZONE), GetSlot(item, EPOCHNANOSECONDS));
       GetTemporalOverflowOption(GetOptionsObject(options)); // validate and ignore
       const isoDate = isoDateTime.isoDate;
-      return CreateTemporalDate(isoDate.year, isoDate.month, isoDate.day, GetSlot(item, CALENDAR));
+      return CreateTemporalDate(isoDate, GetSlot(item, CALENDAR));
     }
     if (IsTemporalDateTime(item)) {
       GetTemporalOverflowOption(GetOptionsObject(options)); // validate and ignore
-      return CreateTemporalDate(
-        GetSlot(item, ISO_YEAR),
-        GetSlot(item, ISO_MONTH),
-        GetSlot(item, ISO_DAY),
-        GetSlot(item, CALENDAR)
-      );
+      return CreateTemporalDate(GetSlot(item, ISO_DATE_TIME).isoDate, GetSlot(item, CALENDAR));
     }
     const calendar = GetTemporalCalendarIdentifierWithISODefault(item);
     const fields = PrepareCalendarFields(calendar, item, ['day', 'month', 'monthCode', 'year'], [], []);
     const overflow = GetTemporalOverflowOption(GetOptionsObject(options));
-    const { year, month, day } = CalendarDateFromFields(calendar, fields, overflow);
-    return CreateTemporalDate(year, month, day, calendar);
+    const isoDate = CalendarDateFromFields(calendar, fields, overflow);
+    return CreateTemporalDate(isoDate, calendar);
   }
   let { year, month, day, calendar, z } = ParseTemporalDateString(RequireString(item));
   if (z) throw new RangeErrorCtor('Z designator not supported for PlainDate');
@@ -1525,7 +1476,7 @@ export function ToTemporalDate(
   calendar = CanonicalizeCalendar(calendar);
   uncheckedAssertNarrowedType<BuiltinCalendarId>(calendar, 'lowercased and canonicalized');
   GetTemporalOverflowOption(GetOptionsObject(options)); // validate and ignore
-  return CreateTemporalDate(year, month, day, calendar);
+  return CreateTemporalDate({ year, month, day }, calendar);
 }
 
 export function InterpretTemporalDateTimeFields(
@@ -1547,52 +1498,22 @@ export function InterpretTemporalDateTimeFields(
 }
 
 export function ToTemporalDateTime(item: PlainDateTimeParams['from'][0], options?: PlainDateTimeParams['from'][1]) {
-  let year, month, day, time, calendar;
+  let isoDate, time, calendar;
 
   if (IsObject(item)) {
     if (IsTemporalDateTime(item)) {
       GetTemporalOverflowOption(GetOptionsObject(options));
-      return CreateTemporalDateTime(
-        GetSlot(item, ISO_YEAR),
-        GetSlot(item, ISO_MONTH),
-        GetSlot(item, ISO_DAY),
-        GetSlot(item, ISO_HOUR),
-        GetSlot(item, ISO_MINUTE),
-        GetSlot(item, ISO_SECOND),
-        GetSlot(item, ISO_MILLISECOND),
-        GetSlot(item, ISO_MICROSECOND),
-        GetSlot(item, ISO_NANOSECOND),
-        GetSlot(item, CALENDAR)
-      );
+      return CreateTemporalDateTime(GetSlot(item, ISO_DATE_TIME), GetSlot(item, CALENDAR));
     }
     if (IsTemporalZonedDateTime(item)) {
       const isoDateTime = GetISODateTimeFor(GetSlot(item, TIME_ZONE), GetSlot(item, EPOCHNANOSECONDS));
       GetTemporalOverflowOption(GetOptionsObject(options));
-      return CreateTemporalDateTime(
-        isoDateTime.isoDate.year,
-        isoDateTime.isoDate.month,
-        isoDateTime.isoDate.day,
-        isoDateTime.time.hour,
-        isoDateTime.time.minute,
-        isoDateTime.time.second,
-        isoDateTime.time.millisecond,
-        isoDateTime.time.microsecond,
-        isoDateTime.time.nanosecond,
-        GetSlot(item, CALENDAR)
-      );
+      return CreateTemporalDateTime(isoDateTime, GetSlot(item, CALENDAR));
     }
     if (IsTemporalDate(item)) {
       GetTemporalOverflowOption(GetOptionsObject(options));
       return CreateTemporalDateTime(
-        GetSlot(item, ISO_YEAR),
-        GetSlot(item, ISO_MONTH),
-        GetSlot(item, ISO_DAY),
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
+        CombineISODateAndTimeRecord(GetSlot(item, ISO_DATE), MidnightTimeRecord()),
         GetSlot(item, CALENDAR)
       );
     }
@@ -1606,12 +1527,9 @@ export function ToTemporalDateTime(item: PlainDateTimeParams['from'][0], options
       []
     );
     const overflow = GetTemporalOverflowOption(GetOptionsObject(options));
-    ({
-      isoDate: { year, month, day },
-      time
-    } = InterpretTemporalDateTimeFields(calendar, fields, overflow));
+    ({ isoDate, time } = InterpretTemporalDateTimeFields(calendar, fields, overflow));
   } else {
-    let z;
+    let z, year, month, day;
     ({ year, month, day, time, calendar, z } = ParseTemporalDateTimeString(RequireString(item)));
     if (z) throw new RangeErrorCtor('Z designator not supported for PlainDateTime');
     if (time === 'start-of-day') time = MidnightTimeRecord();
@@ -1629,9 +1547,10 @@ export function ToTemporalDateTime(item: PlainDateTimeParams['from'][0], options
     if (!calendar) calendar = 'iso8601';
     calendar = CanonicalizeCalendar(calendar);
     GetTemporalOverflowOption(GetOptionsObject(options));
+    isoDate = { year, month, day };
   }
-  const { hour, minute, second, millisecond, microsecond, nanosecond } = time;
-  return CreateTemporalDateTime(year, month, day, hour, minute, second, millisecond, microsecond, nanosecond, calendar);
+  const isoDateTime = CombineISODateAndTimeRecord(isoDate, time);
+  return CreateTemporalDateTime(isoDateTime, calendar);
 }
 
 export function ToTemporalDuration(item: DurationParams['from'][0]) {
@@ -1733,12 +1652,7 @@ export function ToTemporalMonthDay(item: PlainMonthDayParams['from'][0], options
   if (IsObject(item)) {
     if (IsTemporalMonthDay(item)) {
       GetTemporalOverflowOption(GetOptionsObject(options));
-      return CreateTemporalMonthDay(
-        GetSlot(item, ISO_MONTH),
-        GetSlot(item, ISO_DAY),
-        GetSlot(item, CALENDAR),
-        GetSlot(item, ISO_YEAR)
-      );
+      return CreateTemporalMonthDay(GetSlot(item, ISO_DATE), GetSlot(item, CALENDAR));
     }
     let calendar;
     if (HasSlot(item, CALENDAR)) {
@@ -1750,8 +1664,8 @@ export function ToTemporalMonthDay(item: PlainMonthDayParams['from'][0], options
     }
     const fields = PrepareCalendarFields(calendar, item, ['day', 'month', 'monthCode', 'year'], [], []);
     const overflow = GetTemporalOverflowOption(GetOptionsObject(options));
-    const { year, month, day } = CalendarMonthDayFromFields(calendar, fields, overflow);
-    return CreateTemporalMonthDay(month, day, calendar, year);
+    const isoDate = CalendarMonthDayFromFields(calendar, fields, overflow);
+    return CreateTemporalMonthDay(isoDate, calendar);
   }
 
   let { month, day, referenceISOYear, calendar } = ParseTemporalMonthDayString(RequireString(item));
@@ -1763,57 +1677,37 @@ export function ToTemporalMonthDay(item: PlainMonthDayParams['from'][0], options
   if (referenceISOYear === undefined) {
     assert(calendar === 'iso8601', `missing year with non-"iso8601" calendar identifier ${calendar}`);
     const isoCalendarReferenceYear = 1972; // First leap year after Unix epoch
-    return CreateTemporalMonthDay(month, day, calendar, isoCalendarReferenceYear);
+    return CreateTemporalMonthDay({ year: isoCalendarReferenceYear, month, day }, calendar);
   }
-  const isoDate = { year: referenceISOYear, month, day };
-  const result = ISODateToFields(calendar, isoDate, 'month-day');
-  ({ year: referenceISOYear, month, day } = CalendarMonthDayFromFields(calendar, result, 'constrain'));
-  return CreateTemporalMonthDay(month, day, calendar, referenceISOYear);
+  const result = ISODateToFields(calendar, { year: referenceISOYear, month, day }, 'month-day');
+  const isoDate = CalendarMonthDayFromFields(calendar, result, 'constrain');
+  return CreateTemporalMonthDay(isoDate, calendar);
 }
 
 export function ToTemporalTime(item: PlainTimeParams['from'][0], options?: PlainTimeParams['from'][1]) {
-  let hour, minute, second, millisecond, microsecond, nanosecond;
-  const TemporalPlainTime = GetIntrinsic('%Temporal.PlainTime%');
+  let time;
   if (IsObject(item)) {
-    if (IsTemporalTime(item) || IsTemporalDateTime(item)) {
+    if (IsTemporalTime(item)) {
       GetTemporalOverflowOption(GetOptionsObject(options));
-      return new TemporalPlainTime(
-        GetSlot(item, ISO_HOUR),
-        GetSlot(item, ISO_MINUTE),
-        GetSlot(item, ISO_SECOND),
-        GetSlot(item, ISO_MILLISECOND),
-        GetSlot(item, ISO_MICROSECOND),
-        GetSlot(item, ISO_NANOSECOND)
-      );
+      return CreateTemporalTime(GetSlot(item, TIME));
+    }
+    if (IsTemporalDateTime(item)) {
+      GetTemporalOverflowOption(GetOptionsObject(options));
+      return CreateTemporalTime(GetSlot(item, ISO_DATE_TIME).time);
     }
     if (IsTemporalZonedDateTime(item)) {
       const isoDateTime = GetISODateTimeFor(GetSlot(item, TIME_ZONE), GetSlot(item, EPOCHNANOSECONDS));
       GetTemporalOverflowOption(GetOptionsObject(options));
-      return new TemporalPlainTime(
-        isoDateTime.time.hour,
-        isoDateTime.time.minute,
-        isoDateTime.time.second,
-        isoDateTime.time.millisecond,
-        isoDateTime.time.microsecond,
-        isoDateTime.time.nanosecond
-      );
+      return CreateTemporalTime(isoDateTime.time);
     }
-    ({ hour, minute, second, millisecond, microsecond, nanosecond } = ToTemporalTimeRecord(item));
+    const { hour, minute, second, millisecond, microsecond, nanosecond } = ToTemporalTimeRecord(item);
     const overflow = GetTemporalOverflowOption(GetOptionsObject(options));
-    ({ hour, minute, second, millisecond, microsecond, nanosecond } = RegulateTime(
-      hour,
-      minute,
-      second,
-      millisecond,
-      microsecond,
-      nanosecond,
-      overflow
-    ));
+    time = RegulateTime(hour, minute, second, millisecond, microsecond, nanosecond, overflow);
   } else {
-    ({ hour, minute, second, millisecond, microsecond, nanosecond } = ParseTemporalTimeString(RequireString(item)));
+    time = ParseTemporalTimeString(RequireString(item));
     GetTemporalOverflowOption(GetOptionsObject(options));
   }
-  return new TemporalPlainTime(hour, minute, second, millisecond, microsecond, nanosecond);
+  return CreateTemporalTime(time);
 }
 
 export function ToTemporalTimeOrMidnight(item: string | Temporal.PlainTime | Temporal.PlainTimeLike | undefined) {
@@ -1829,18 +1723,13 @@ export function ToTemporalYearMonth(
   if (IsObject(item)) {
     if (IsTemporalYearMonth(item)) {
       GetTemporalOverflowOption(GetOptionsObject(options));
-      return CreateTemporalYearMonth(
-        GetSlot(item, ISO_YEAR),
-        GetSlot(item, ISO_MONTH),
-        GetSlot(item, CALENDAR),
-        GetSlot(item, ISO_DAY)
-      );
+      return CreateTemporalYearMonth(GetSlot(item, ISO_DATE), GetSlot(item, CALENDAR));
     }
     const calendar = GetTemporalCalendarIdentifierWithISODefault(item);
     const fields = PrepareCalendarFields(calendar, item, ['month', 'monthCode', 'year'], [], []);
     const overflow = GetTemporalOverflowOption(GetOptionsObject(options));
-    const { year, month, day } = CalendarYearMonthFromFields(calendar, fields, overflow);
-    return CreateTemporalYearMonth(year, month, calendar, day);
+    const isoDate = CalendarYearMonthFromFields(calendar, fields, overflow);
+    return CreateTemporalYearMonth(isoDate, calendar);
   }
 
   let { year, month, referenceISODay, calendar } = ParseTemporalYearMonthString(RequireString(item));
@@ -1850,8 +1739,8 @@ export function ToTemporalYearMonth(
 
   const result = ISODateToFields(calendar, { year, month, day: referenceISODay }, 'year-month');
   GetTemporalOverflowOption(GetOptionsObject(options));
-  ({ year, month, day: referenceISODay } = CalendarYearMonthFromFields(calendar, result, 'constrain'));
-  return CreateTemporalYearMonth(year, month, calendar, referenceISODay);
+  const isoDate = CalendarYearMonthFromFields(calendar, result, 'constrain');
+  return CreateTemporalYearMonth(isoDate, calendar);
 }
 
 type OffsetBehaviour = 'wall' | 'exact' | 'option';
@@ -2007,20 +1896,11 @@ export function ToTemporalZonedDateTime(
   return CreateTemporalZonedDateTime(epochNanoseconds, timeZone, calendar);
 }
 
-export function CreateTemporalDateSlots(
-  result: Temporal.PlainDate,
-  isoYear: number,
-  isoMonth: number,
-  isoDay: number,
-  calendar: BuiltinCalendarId
-) {
-  RejectISODate(isoYear, isoMonth, isoDay);
-  RejectDateRange({ year: isoYear, month: isoMonth, day: isoDay });
+export function CreateTemporalDateSlots(result: Temporal.PlainDate, isoDate: ISODate, calendar: BuiltinCalendarId) {
+  RejectDateRange(isoDate);
 
   CreateSlots(result);
-  SetSlot(result, ISO_YEAR, isoYear);
-  SetSlot(result, ISO_MONTH, isoMonth);
-  SetSlot(result, ISO_DAY, isoDay);
+  SetSlot(result, ISO_DATE, isoDate);
   SetSlot(result, CALENDAR, calendar);
   SetSlot(result, DATE_BRAND, true);
 
@@ -2035,47 +1915,26 @@ export function CreateTemporalDateSlots(
   }
 }
 
-export function CreateTemporalDate(isoYear: number, isoMonth: number, isoDay: number, calendar: BuiltinCalendarId) {
+export function CreateTemporalDate(isoDate: ISODate, calendar: BuiltinCalendarId) {
   const TemporalPlainDate = GetIntrinsic('%Temporal.PlainDate%');
-  const result: Temporal.PlainDate = ObjectCreate(TemporalPlainDate.prototype);
-  CreateTemporalDateSlots(result, isoYear, isoMonth, isoDay, calendar);
+  const result = ObjectCreate(TemporalPlainDate.prototype);
+  CreateTemporalDateSlots(result, isoDate, calendar);
   return result;
 }
 
 export function CreateTemporalDateTimeSlots(
   result: Temporal.PlainDateTime,
-  isoYear: number,
-  isoMonth: number,
-  isoDay: number,
-  h: number,
-  min: number,
-  s: number,
-  ms: number,
-  µs: number,
-  ns: number,
+  isoDateTime: ISODateTime,
   calendar: BuiltinCalendarId
 ) {
-  RejectDateTime(isoYear, isoMonth, isoDay, h, min, s, ms, µs, ns);
-  const iso = {
-    isoDate: { year: isoYear, month: isoMonth, day: isoDay },
-    time: { hour: h, minute: min, second: s, millisecond: ms, microsecond: µs, nanosecond: ns }
-  };
-  RejectDateTimeRange(iso);
+  RejectDateTimeRange(isoDateTime);
 
   CreateSlots(result);
-  SetSlot(result, ISO_YEAR, isoYear);
-  SetSlot(result, ISO_MONTH, isoMonth);
-  SetSlot(result, ISO_DAY, isoDay);
-  SetSlot(result, ISO_HOUR, h);
-  SetSlot(result, ISO_MINUTE, min);
-  SetSlot(result, ISO_SECOND, s);
-  SetSlot(result, ISO_MILLISECOND, ms);
-  SetSlot(result, ISO_MICROSECOND, µs);
-  SetSlot(result, ISO_NANOSECOND, ns);
+  SetSlot(result, ISO_DATE_TIME, isoDateTime);
   SetSlot(result, CALENDAR, calendar);
 
   if (DEBUG) {
-    let repr = ISODateTimeToString(iso, calendar, 'auto');
+    let repr = ISODateTimeToString(isoDateTime, calendar, 'auto');
     ObjectDefineProperty(result, '_repr_', {
       value: `Temporal.PlainDateTime <${repr}>`,
       writable: false,
@@ -2085,38 +1944,22 @@ export function CreateTemporalDateTimeSlots(
   }
 }
 
-export function CreateTemporalDateTime(
-  isoYear: number,
-  isoMonth: number,
-  isoDay: number,
-  h: number,
-  min: number,
-  s: number,
-  ms: number,
-  µs: number,
-  ns: number,
-  calendar: BuiltinCalendarId = 'iso8601'
-) {
+export function CreateTemporalDateTime(isoDateTime: ISODateTime, calendar: BuiltinCalendarId) {
   const TemporalPlainDateTime = GetIntrinsic('%Temporal.PlainDateTime%');
   const result = ObjectCreate(TemporalPlainDateTime.prototype);
-  CreateTemporalDateTimeSlots(result, isoYear, isoMonth, isoDay, h, min, s, ms, µs, ns, calendar);
-  return result as Temporal.PlainDateTime;
+  CreateTemporalDateTimeSlots(result, isoDateTime, calendar);
+  return result;
 }
 
 export function CreateTemporalMonthDaySlots(
   result: Temporal.PlainMonthDay,
-  isoMonth: number,
-  isoDay: number,
-  calendar: BuiltinCalendarId,
-  referenceISOYear: number
+  isoDate: ISODate,
+  calendar: BuiltinCalendarId
 ) {
-  RejectISODate(referenceISOYear, isoMonth, isoDay);
-  RejectDateRange({ year: referenceISOYear, month: isoMonth, day: isoDay });
+  RejectDateRange(isoDate);
 
   CreateSlots(result);
-  SetSlot(result, ISO_MONTH, isoMonth);
-  SetSlot(result, ISO_DAY, isoDay);
-  SetSlot(result, ISO_YEAR, referenceISOYear);
+  SetSlot(result, ISO_DATE, isoDate);
   SetSlot(result, CALENDAR, calendar);
   SetSlot(result, MONTH_DAY_BRAND, true);
 
@@ -2131,33 +1974,43 @@ export function CreateTemporalMonthDaySlots(
   }
 }
 
-export function CreateTemporalMonthDay(
-  isoMonth: number,
-  isoDay: number,
-  calendar: BuiltinCalendarId,
-  referenceISOYear: number
-) {
+export function CreateTemporalMonthDay(isoDate: ISODate, calendar: BuiltinCalendarId) {
   const TemporalPlainMonthDay = GetIntrinsic('%Temporal.PlainMonthDay%');
-  const result: Temporal.PlainMonthDay = ObjectCreate(TemporalPlainMonthDay.prototype);
-  CreateTemporalMonthDaySlots(result, isoMonth, isoDay, calendar, referenceISOYear);
+  const result = ObjectCreate(TemporalPlainMonthDay.prototype);
+  CreateTemporalMonthDaySlots(result, isoDate, calendar);
+  return result;
+}
+
+export function CreateTemporalTimeSlots(result: Temporal.PlainTime, time: TimeRecord) {
+  CreateSlots(result);
+  SetSlot(result, TIME, time);
+
+  if (DEBUG) {
+    ObjectDefineProperty(result, '_repr_', {
+      value: `Temporal.PlainTime <${TimeRecordToString(time, 'auto')}>`,
+      writable: false,
+      enumerable: false,
+      configurable: false
+    });
+  }
+}
+
+export function CreateTemporalTime(time: TimeRecord) {
+  const TemporalPlainTime = GetIntrinsic('%Temporal.PlainTime%');
+  const result = ObjectCreate(TemporalPlainTime.prototype);
+  CreateTemporalTimeSlots(result, time);
   return result;
 }
 
 export function CreateTemporalYearMonthSlots(
   result: Temporal.PlainYearMonth,
-  isoYear: number,
-  isoMonth: number,
-  calendar: BuiltinCalendarId,
-  referenceISODay: number
+  isoDate: ISODate,
+  calendar: BuiltinCalendarId
 ) {
-  RejectISODate(isoYear, isoMonth, referenceISODay);
-  const isoDate = { year: isoYear, month: isoMonth, day: referenceISODay };
   RejectYearMonthRange(isoDate);
 
   CreateSlots(result);
-  SetSlot(result, ISO_YEAR, isoYear);
-  SetSlot(result, ISO_MONTH, isoMonth);
-  SetSlot(result, ISO_DAY, referenceISODay);
+  SetSlot(result, ISO_DATE, isoDate);
   SetSlot(result, CALENDAR, calendar);
   SetSlot(result, YEAR_MONTH_BRAND, true);
 
@@ -2172,15 +2025,10 @@ export function CreateTemporalYearMonthSlots(
   }
 }
 
-export function CreateTemporalYearMonth(
-  isoYear: number,
-  isoMonth: number,
-  calendar: BuiltinCalendarId,
-  referenceISODay: number
-) {
+export function CreateTemporalYearMonth(isoDate: ISODate, calendar: BuiltinCalendarId) {
   const TemporalPlainYearMonth = GetIntrinsic('%Temporal.PlainYearMonth%');
   const result = ObjectCreate(TemporalPlainYearMonth.prototype);
-  CreateTemporalYearMonthSlots(result, isoYear, isoMonth, calendar, referenceISODay);
+  CreateTemporalYearMonthSlots(result, isoDate, calendar);
   return result;
 }
 
@@ -2367,27 +2215,6 @@ export function TimeZoneEquals(one: string, two: string) {
   } else {
     return offsetMinutes1 === offsetMinutes2;
   }
-}
-
-export function TemporalDateTimeToDate(dateTime: Temporal.PlainDateTime) {
-  return CreateTemporalDate(
-    GetSlot(dateTime, ISO_YEAR),
-    GetSlot(dateTime, ISO_MONTH),
-    GetSlot(dateTime, ISO_DAY),
-    GetSlot(dateTime, CALENDAR)
-  );
-}
-
-export function TemporalDateTimeToTime(dateTime: Temporal.PlainDateTime) {
-  const Time = GetIntrinsic('%Temporal.PlainTime%');
-  return new Time(
-    GetSlot(dateTime, ISO_HOUR),
-    GetSlot(dateTime, ISO_MINUTE),
-    GetSlot(dateTime, ISO_SECOND),
-    GetSlot(dateTime, ISO_MILLISECOND),
-    GetSlot(dateTime, ISO_MICROSECOND),
-    GetSlot(dateTime, ISO_NANOSECOND)
-  );
 }
 
 export function GetOffsetNanosecondsFor(timeZone: string, epochNs: JSBI) {
@@ -2670,11 +2497,12 @@ export function TemporalDateToString(
   date: Temporal.PlainDate,
   showCalendar: Temporal.ShowCalendarOption['calendarName'] = 'auto'
 ) {
-  const year = ISOYearString(GetSlot(date, ISO_YEAR));
-  const month = ISODateTimePartString(GetSlot(date, ISO_MONTH));
-  const day = ISODateTimePartString(GetSlot(date, ISO_DAY));
+  const { year, month, day } = GetSlot(date, ISO_DATE);
+  const yearString = ISOYearString(year);
+  const monthString = ISODateTimePartString(month);
+  const dayString = ISODateTimePartString(day);
   const calendar = FormatCalendarAnnotation(GetSlot(date, CALENDAR), showCalendar);
-  return `${year}-${month}-${day}${calendar}`;
+  return `${yearString}-${monthString}-${dayString}${calendar}`;
 }
 
 export function TimeRecordToString(
@@ -2708,13 +2536,14 @@ export function TemporalMonthDayToString(
   monthDay: Temporal.PlainMonthDay,
   showCalendar: Temporal.ShowCalendarOption['calendarName'] = 'auto'
 ) {
-  const month = ISODateTimePartString(GetSlot(monthDay, ISO_MONTH));
-  const day = ISODateTimePartString(GetSlot(monthDay, ISO_DAY));
-  let resultString = `${month}-${day}`;
+  const { year, month, day } = GetSlot(monthDay, ISO_DATE);
+  const monthString = ISODateTimePartString(month);
+  const dayString = ISODateTimePartString(day);
+  let resultString = `${monthString}-${dayString}`;
   const calendar = GetSlot(monthDay, CALENDAR);
   if (showCalendar === 'always' || showCalendar === 'critical' || calendar !== 'iso8601') {
-    const year = ISOYearString(GetSlot(monthDay, ISO_YEAR));
-    resultString = `${year}-${resultString}`;
+    const yearString = ISOYearString(year);
+    resultString = `${yearString}-${resultString}`;
   }
   const calendarString = FormatCalendarAnnotation(calendar, showCalendar);
   if (calendarString) resultString += calendarString;
@@ -2725,13 +2554,14 @@ export function TemporalYearMonthToString(
   yearMonth: Temporal.PlainYearMonth,
   showCalendar: Temporal.ShowCalendarOption['calendarName'] = 'auto'
 ) {
-  const year = ISOYearString(GetSlot(yearMonth, ISO_YEAR));
-  const month = ISODateTimePartString(GetSlot(yearMonth, ISO_MONTH));
-  let resultString = `${year}-${month}`;
+  const { year, month, day } = GetSlot(yearMonth, ISO_DATE);
+  const yearString = ISOYearString(year);
+  const monthString = ISODateTimePartString(month);
+  let resultString = `${yearString}-${monthString}`;
   const calendar = GetSlot(yearMonth, CALENDAR);
   if (showCalendar === 'always' || showCalendar === 'critical' || calendar !== 'iso8601') {
-    const day = ISODateTimePartString(GetSlot(yearMonth, ISO_DAY));
-    resultString += `-${day}`;
+    const dayString = ISODateTimePartString(day);
+    resultString += `-${dayString}`;
   }
   const calendarString = FormatCalendarAnnotation(calendar, showCalendar);
   if (calendarString) resultString += calendarString;
@@ -3369,7 +3199,7 @@ export function UnbalanceDateDurationRelative(dateDuration: DateDuration, plainR
   if (DateDurationSign(yearsMonthsWeeksDuration) === 0) return dateDuration.days;
 
   // balance years, months, and weeks down to days
-  const isoDate = TemporalObjectToISODateRecord(plainRelativeTo);
+  const isoDate = GetSlot(plainRelativeTo, ISO_DATE);
   const later = CalendarDateAdd(GetSlot(plainRelativeTo, CALENDAR), isoDate, yearsMonthsWeeksDuration, 'constrain');
   const epochDaysEarlier = ISODateToEpochDays(isoDate.year, isoDate.month - 1, isoDate.day);
   const epochDaysLater = ISODateToEpochDays(later.year, later.month - 1, later.day);
@@ -3425,7 +3255,7 @@ export function RejectToRange(value: number, min: number, max: number) {
   if (value < min || value > max) throw new RangeErrorCtor(`value out of range: ${min} <= ${value} <= ${max}`);
 }
 
-function RejectISODate(year: number, month: number, day: number) {
+export function RejectISODate(year: number, month: number, day: number) {
   RejectToRange(month, 1, 12);
   RejectToRange(day, 1, ISODaysInMonth(year, month));
 }
@@ -3451,7 +3281,7 @@ export function RejectTime(
   RejectToRange(nanosecond, 0, 999);
 }
 
-function RejectDateTime(
+export function RejectDateTime(
   year: number,
   month: number,
   day: number,
@@ -4439,16 +4269,10 @@ export function DifferenceTemporalPlainDate(
   const settings = GetDifferenceSettings(operation, resolvedOptions, 'date', [], 'day', 'day');
 
   const Duration = GetIntrinsic('%Temporal.Duration%');
-  if (
-    GetSlot(plainDate, ISO_YEAR) === GetSlot(other, ISO_YEAR) &&
-    GetSlot(plainDate, ISO_MONTH) === GetSlot(other, ISO_MONTH) &&
-    GetSlot(plainDate, ISO_DAY) === GetSlot(other, ISO_DAY)
-  ) {
-    return new Duration();
-  }
+  const isoDate = GetSlot(plainDate, ISO_DATE);
+  const isoOther = GetSlot(other, ISO_DATE);
+  if (CompareISODate(isoDate, isoOther) === 0) return new Duration();
 
-  const isoDate = TemporalObjectToISODateRecord(plainDate);
-  const isoOther = TemporalObjectToISODateRecord(other);
   const dateDifference = CalendarDateUntil(calendar, isoDate, isoOther, settings.largestUnit);
 
   let duration = { date: dateDifference, norm: TimeDuration.ZERO };
@@ -4492,8 +4316,8 @@ export function DifferenceTemporalPlainDateTime(
   const settings = GetDifferenceSettings(operation, resolvedOptions, 'datetime', [], 'nanosecond', 'day');
 
   const Duration = GetIntrinsic('%Temporal.Duration%');
-  const isoDateTime1 = PlainDateTimeToISODateTimeRecord(plainDateTime);
-  const isoDateTime2 = PlainDateTimeToISODateTimeRecord(other);
+  const isoDateTime1 = GetSlot(plainDateTime, ISO_DATE_TIME);
+  const isoDateTime2 = GetSlot(other, ISO_DATE_TIME);
   if (CompareISODateTime(isoDateTime1, isoDateTime2) === 0) return new Duration();
 
   const duration = DifferencePlainDateTimeWithRounding(
@@ -4522,24 +4346,7 @@ export function DifferenceTemporalPlainTime(
   const resolvedOptions = GetOptionsObject(options);
   const settings = GetDifferenceSettings(operation, resolvedOptions, 'time', [], 'nanosecond', 'hour');
 
-  let norm = DifferenceTime(
-    {
-      hour: GetSlot(plainTime, ISO_HOUR),
-      minute: GetSlot(plainTime, ISO_MINUTE),
-      second: GetSlot(plainTime, ISO_SECOND),
-      millisecond: GetSlot(plainTime, ISO_MILLISECOND),
-      microsecond: GetSlot(plainTime, ISO_MICROSECOND),
-      nanosecond: GetSlot(plainTime, ISO_NANOSECOND)
-    },
-    {
-      hour: GetSlot(other, ISO_HOUR),
-      minute: GetSlot(other, ISO_MINUTE),
-      second: GetSlot(other, ISO_SECOND),
-      millisecond: GetSlot(other, ISO_MILLISECOND),
-      microsecond: GetSlot(other, ISO_MICROSECOND),
-      nanosecond: GetSlot(other, ISO_NANOSECOND)
-    }
-  );
+  let norm = DifferenceTime(GetSlot(plainTime, TIME), GetSlot(other, TIME));
   let duration = { date: ZeroDateDuration(), norm };
   if (settings.smallestUnit !== 'nanosecond' || settings.roundingIncrement !== 1) {
     duration = RoundTimeDuration(duration, settings.roundingIncrement, settings.smallestUnit, settings.roundingMode);
@@ -4567,11 +4374,7 @@ export function DifferenceTemporalPlainYearMonth(
   const settings = GetDifferenceSettings(operation, resolvedOptions, 'date', ['week', 'day'], 'month', 'year');
 
   const Duration = GetIntrinsic('%Temporal.Duration%');
-  if (
-    GetSlot(yearMonth, ISO_YEAR) === GetSlot(other, ISO_YEAR) &&
-    GetSlot(yearMonth, ISO_MONTH) === GetSlot(other, ISO_MONTH) &&
-    GetSlot(yearMonth, ISO_DAY) === GetSlot(other, ISO_DAY)
-  ) {
+  if (CompareISODate(GetSlot(yearMonth, ISO_DATE), GetSlot(other, ISO_DATE)) == 0) {
     return new Duration();
   }
 
@@ -4763,7 +4566,6 @@ export function AddDurationToDate(
   durationLike: PlainDateParams['add'][0],
   options: PlainDateParams['add'][1]
 ) {
-  const isoDate = TemporalObjectToISODateRecord(plainDate);
   const calendar = GetSlot(plainDate, CALENDAR);
 
   let duration = ToTemporalDuration(durationLike);
@@ -4773,8 +4575,8 @@ export function AddDurationToDate(
   const resolvedOptions = GetOptionsObject(options);
   const overflow = GetTemporalOverflowOption(resolvedOptions);
 
-  const addedDate = CalendarDateAdd(calendar, isoDate, dateDuration, overflow);
-  return CreateTemporalDate(addedDate.year, addedDate.month, addedDate.day, calendar);
+  const addedDate = CalendarDateAdd(calendar, GetSlot(plainDate, ISO_DATE), dateDuration, overflow);
+  return CreateTemporalDate(addedDate, calendar);
 }
 
 export function AddDurationToDateTime(
@@ -4793,7 +4595,7 @@ export function AddDurationToDateTime(
   const normalizedDuration = NormalizeDurationWith24HourDays(duration);
 
   // Add the time part
-  const isoDateTime = PlainDateTimeToISODateTimeRecord(dateTime);
+  const isoDateTime = GetSlot(dateTime, ISO_DATE_TIME);
   const timeResult = AddTime(isoDateTime.time, normalizedDuration.norm);
   const dateDuration = AdjustDateDurationRecord(normalizedDuration.date, timeResult.deltaDays);
 
@@ -4802,19 +4604,7 @@ export function AddDurationToDateTime(
   const addedDate = CalendarDateAdd(calendar, isoDateTime.isoDate, dateDuration, overflow);
 
   const result = CombineISODateAndTimeRecord(addedDate, timeResult);
-
-  return CreateTemporalDateTime(
-    result.isoDate.year,
-    result.isoDate.month,
-    result.isoDate.day,
-    result.time.hour,
-    result.time.minute,
-    result.time.second,
-    result.time.millisecond,
-    result.time.microsecond,
-    result.time.nanosecond,
-    calendar
-  );
+  return CreateTemporalDateTime(result, calendar);
 }
 
 export function AddDurationToTime(
@@ -4825,28 +4615,12 @@ export function AddDurationToTime(
   let duration = ToTemporalDuration(durationLike);
   if (operation === 'subtract') duration = CreateNegatedTemporalDuration(duration);
   const normalizedDuration = NormalizeDurationWith24HourDays(duration);
-  let { hour, minute, second, millisecond, microsecond, nanosecond } = AddTime(
-    {
-      hour: GetSlot(temporalTime, ISO_HOUR),
-      minute: GetSlot(temporalTime, ISO_MINUTE),
-      second: GetSlot(temporalTime, ISO_SECOND),
-      millisecond: GetSlot(temporalTime, ISO_MILLISECOND),
-      microsecond: GetSlot(temporalTime, ISO_MICROSECOND),
-      nanosecond: GetSlot(temporalTime, ISO_NANOSECOND)
-    },
+  const { hour, minute, second, millisecond, microsecond, nanosecond } = AddTime(
+    GetSlot(temporalTime, TIME),
     normalizedDuration.norm
   );
-  ({ hour, minute, second, millisecond, microsecond, nanosecond } = RegulateTime(
-    hour,
-    minute,
-    second,
-    millisecond,
-    microsecond,
-    nanosecond,
-    'reject'
-  ));
-  const PlainTime = GetIntrinsic('%Temporal.PlainTime%');
-  return new PlainTime(hour, minute, second, millisecond, microsecond, nanosecond);
+  const time = RegulateTime(hour, minute, second, millisecond, microsecond, nanosecond, 'reject');
+  return CreateTemporalTime(time);
 }
 
 export function AddDurationToYearMonth(
@@ -4874,8 +4648,8 @@ export function AddDurationToYearMonth(
   const addedDate = CalendarDateAdd(calendar, startDate, durationToAdd, overflow);
   const addedDateFields = ISODateToFields(calendar, addedDate, 'year-month');
 
-  const { year, month, day } = CalendarYearMonthFromFields(calendar, addedDateFields, overflow);
-  return CreateTemporalYearMonth(year, month, calendar, day);
+  const isoDate = CalendarYearMonthFromFields(calendar, addedDateFields, overflow);
+  return CreateTemporalYearMonth(isoDate, calendar);
 }
 
 export function AddDurationToZonedDateTime(

--- a/lib/ecmascript.ts
+++ b/lib/ecmascript.ts
@@ -5237,18 +5237,13 @@ export function RoundISODateTime(
   unit: UnitSmallerThanOrEqualTo<'day'>,
   roundingMode: Temporal.RoundingMode
 ) {
-  const time = RoundTime(hour, minute, second, millisecond, microsecond, nanosecond, increment, unit, roundingMode);
+  const time = RoundTime({ hour, minute, second, millisecond, microsecond, nanosecond }, increment, unit, roundingMode);
   const isoDate = BalanceISODate(year, month, day + time.deltaDays);
   return CombineISODateAndTimeRecord(isoDate, time);
 }
 
 export function RoundTime(
-  hour: number,
-  minute: number,
-  second: number,
-  millisecond: number,
-  microsecond: number,
-  nanosecond: number,
+  { hour, minute, second, millisecond, microsecond, nanosecond }: TimeRecord,
   increment: number,
   unit: TimeUnitOrDay,
   roundingMode: Temporal.RoundingMode

--- a/lib/instant.ts
+++ b/lib/instant.ts
@@ -34,7 +34,7 @@ export class Instant implements Temporal.Instant {
 
     if (DEBUG) {
       const iso = ES.GetISOPartsFromEpoch(ns);
-      const repr = ES.TemporalDateTimeToString(iso, 'iso8601', 'auto', 'never') + 'Z';
+      const repr = ES.ISODateTimeToString(iso, 'iso8601', 'auto', 'never') + 'Z';
       ObjectDefineProperty(this, '_repr_', {
         value: `${this[SymbolToStringTag]} <${repr}>`,
         writable: false,

--- a/lib/internaltypes.d.ts
+++ b/lib/internaltypes.d.ts
@@ -205,15 +205,8 @@ export interface ISODate {
 export type TimeRecord = Required<Temporal.PlainTimeLike>;
 
 export interface ISODateTime {
-  year: number;
-  month: number;
-  day: number;
-  hour: number;
-  minute: number;
-  second: number;
-  millisecond: number;
-  microsecond: number;
-  nanosecond: number;
+  isoDate: ISODate;
+  time: TimeRecord;
 }
 
 export interface DateDuration {

--- a/lib/intl.ts
+++ b/lib/intl.ts
@@ -544,8 +544,6 @@ function sameTemporalType(x: unknown, y: unknown) {
   return true;
 }
 
-const noon = { hour: 12, minute: 0, second: 0, millisecond: 0, microsecond: 0, nanosecond: 0 };
-
 type TypesWithToLocaleString =
   | Temporal.PlainDateTime
   | Temporal.PlainDate
@@ -583,7 +581,7 @@ function extractOverrides(temporalObj: Params['format'][0], main: DateTimeFormat
       );
     }
     const isoDate = ES.TemporalObjectToISODateRecord(temporalObj);
-    const isoDateTime = ES.CombineISODateAndTimeRecord(isoDate, noon);
+    const isoDateTime = ES.CombineISODateAndTimeRecord(isoDate, ES.NoonTimeRecord());
     return {
       epochNs: ES.GetEpochNanosecondsFor(GetSlot(main, TZ_CANONICAL), isoDateTime, 'compatible'),
       formatter: getSlotLazy(main, YM)
@@ -599,7 +597,7 @@ function extractOverrides(temporalObj: Params['format'][0], main: DateTimeFormat
       );
     }
     const isoDate = ES.TemporalObjectToISODateRecord(temporalObj);
-    const isoDateTime = ES.CombineISODateAndTimeRecord(isoDate, noon);
+    const isoDateTime = ES.CombineISODateAndTimeRecord(isoDate, ES.NoonTimeRecord());
     return {
       epochNs: ES.GetEpochNanosecondsFor(GetSlot(main, TZ_CANONICAL), isoDateTime, 'compatible'),
       formatter: getSlotLazy(main, MD)
@@ -615,7 +613,7 @@ function extractOverrides(temporalObj: Params['format'][0], main: DateTimeFormat
       );
     }
     const isoDate = ES.TemporalObjectToISODateRecord(temporalObj);
-    const isoDateTime = ES.CombineISODateAndTimeRecord(isoDate, noon);
+    const isoDateTime = ES.CombineISODateAndTimeRecord(isoDate, ES.NoonTimeRecord());
     return {
       epochNs: ES.GetEpochNanosecondsFor(GetSlot(main, TZ_CANONICAL), isoDateTime, 'compatible'),
       formatter: getSlotLazy(main, DATE)

--- a/lib/intl.ts
+++ b/lib/intl.ts
@@ -31,12 +31,8 @@ import {
   HasSlot,
   EPOCHNANOSECONDS,
   INST,
-  ISO_HOUR,
-  ISO_MINUTE,
-  ISO_SECOND,
-  ISO_MILLISECOND,
-  ISO_MICROSECOND,
-  ISO_NANOSECOND,
+  ISO_DATE,
+  ISO_DATE_TIME,
   LOCALE,
   MD,
   OPTIONS,
@@ -44,6 +40,7 @@ import {
   ResetSlot,
   SetSlot,
   TIME,
+  TIME_FMT,
   TZ_CANONICAL,
   TZ_ORIGINAL,
   YM
@@ -51,7 +48,7 @@ import {
 import type { Temporal } from '..';
 import type { DateTimeFormatParams as Params, DateTimeFormatReturn as Return } from './internaltypes';
 
-type LazySlot = typeof DATE | typeof YM | typeof MD | typeof TIME | typeof DATETIME | typeof INST;
+type LazySlot = typeof DATE | typeof YM | typeof MD | typeof TIME_FMT | typeof DATETIME | typeof INST;
 
 // Construction of built-in Intl.DateTimeFormat objects is sloooooow,
 // so we'll only create those instances when we need them.
@@ -153,7 +150,7 @@ function createDateTimeFormat(
   SetSlot(dtf, DATE, dateAmend);
   SetSlot(dtf, YM, yearMonthAmend);
   SetSlot(dtf, MD, monthDayAmend);
-  SetSlot(dtf, TIME, timeAmend);
+  SetSlot(dtf, TIME_FMT, timeAmend);
   SetSlot(dtf, DATETIME, datetimeAmend);
   SetSlot(dtf, INST, instantAmend);
 
@@ -557,18 +554,11 @@ function extractOverrides(temporalObj: Params['format'][0], main: DateTimeFormat
   if (ES.IsTemporalTime(temporalObj)) {
     const isoDateTime = {
       isoDate: { year: 1970, month: 1, day: 1 },
-      time: {
-        hour: GetSlot(temporalObj, ISO_HOUR),
-        minute: GetSlot(temporalObj, ISO_MINUTE),
-        second: GetSlot(temporalObj, ISO_SECOND),
-        millisecond: GetSlot(temporalObj, ISO_MILLISECOND),
-        microsecond: GetSlot(temporalObj, ISO_MICROSECOND),
-        nanosecond: GetSlot(temporalObj, ISO_NANOSECOND)
-      }
+      time: GetSlot(temporalObj, TIME)
     };
     return {
       epochNs: ES.GetEpochNanosecondsFor(GetSlot(main, TZ_CANONICAL), isoDateTime, 'compatible'),
-      formatter: getSlotLazy(main, TIME)
+      formatter: getSlotLazy(main, TIME_FMT)
     };
   }
 
@@ -580,8 +570,7 @@ function extractOverrides(temporalObj: Params['format'][0], main: DateTimeFormat
         `cannot format PlainYearMonth with calendar ${calendar} in locale with calendar ${mainCalendar}`
       );
     }
-    const isoDate = ES.TemporalObjectToISODateRecord(temporalObj);
-    const isoDateTime = ES.CombineISODateAndTimeRecord(isoDate, ES.NoonTimeRecord());
+    const isoDateTime = ES.CombineISODateAndTimeRecord(GetSlot(temporalObj, ISO_DATE), ES.NoonTimeRecord());
     return {
       epochNs: ES.GetEpochNanosecondsFor(GetSlot(main, TZ_CANONICAL), isoDateTime, 'compatible'),
       formatter: getSlotLazy(main, YM)
@@ -596,8 +585,7 @@ function extractOverrides(temporalObj: Params['format'][0], main: DateTimeFormat
         `cannot format PlainMonthDay with calendar ${calendar} in locale with calendar ${mainCalendar}`
       );
     }
-    const isoDate = ES.TemporalObjectToISODateRecord(temporalObj);
-    const isoDateTime = ES.CombineISODateAndTimeRecord(isoDate, ES.NoonTimeRecord());
+    const isoDateTime = ES.CombineISODateAndTimeRecord(GetSlot(temporalObj, ISO_DATE), ES.NoonTimeRecord());
     return {
       epochNs: ES.GetEpochNanosecondsFor(GetSlot(main, TZ_CANONICAL), isoDateTime, 'compatible'),
       formatter: getSlotLazy(main, MD)
@@ -612,8 +600,7 @@ function extractOverrides(temporalObj: Params['format'][0], main: DateTimeFormat
         `cannot format PlainDate with calendar ${calendar} in locale with calendar ${mainCalendar}`
       );
     }
-    const isoDate = ES.TemporalObjectToISODateRecord(temporalObj);
-    const isoDateTime = ES.CombineISODateAndTimeRecord(isoDate, ES.NoonTimeRecord());
+    const isoDateTime = ES.CombineISODateAndTimeRecord(GetSlot(temporalObj, ISO_DATE), ES.NoonTimeRecord());
     return {
       epochNs: ES.GetEpochNanosecondsFor(GetSlot(main, TZ_CANONICAL), isoDateTime, 'compatible'),
       formatter: getSlotLazy(main, DATE)
@@ -628,7 +615,7 @@ function extractOverrides(temporalObj: Params['format'][0], main: DateTimeFormat
         `cannot format PlainDateTime with calendar ${calendar} in locale with calendar ${mainCalendar}`
       );
     }
-    const isoDateTime = ES.PlainDateTimeToISODateTimeRecord(temporalObj);
+    const isoDateTime = GetSlot(temporalObj, ISO_DATE_TIME);
     return {
       epochNs: ES.GetEpochNanosecondsFor(GetSlot(main, TZ_CANONICAL), isoDateTime, 'compatible'),
       formatter: getSlotLazy(main, DATETIME)

--- a/lib/intl.ts
+++ b/lib/intl.ts
@@ -558,15 +558,15 @@ type TypesWithToLocaleString =
 function extractOverrides(temporalObj: Params['format'][0], main: DateTimeFormatImpl) {
   if (ES.IsTemporalTime(temporalObj)) {
     const isoDateTime = {
-      year: 1970,
-      month: 1,
-      day: 1,
-      hour: GetSlot(temporalObj, ISO_HOUR),
-      minute: GetSlot(temporalObj, ISO_MINUTE),
-      second: GetSlot(temporalObj, ISO_SECOND),
-      millisecond: GetSlot(temporalObj, ISO_MILLISECOND),
-      microsecond: GetSlot(temporalObj, ISO_MICROSECOND),
-      nanosecond: GetSlot(temporalObj, ISO_NANOSECOND)
+      isoDate: { year: 1970, month: 1, day: 1 },
+      time: {
+        hour: GetSlot(temporalObj, ISO_HOUR),
+        minute: GetSlot(temporalObj, ISO_MINUTE),
+        second: GetSlot(temporalObj, ISO_SECOND),
+        millisecond: GetSlot(temporalObj, ISO_MILLISECOND),
+        microsecond: GetSlot(temporalObj, ISO_MICROSECOND),
+        nanosecond: GetSlot(temporalObj, ISO_NANOSECOND)
+      }
     };
     return {
       epochNs: ES.GetEpochNanosecondsFor(GetSlot(main, TZ_CANONICAL), isoDateTime, 'compatible'),
@@ -583,7 +583,7 @@ function extractOverrides(temporalObj: Params['format'][0], main: DateTimeFormat
       );
     }
     const isoDate = ES.TemporalObjectToISODateRecord(temporalObj);
-    const isoDateTime = { ...isoDate, ...noon };
+    const isoDateTime = ES.CombineISODateAndTimeRecord(isoDate, noon);
     return {
       epochNs: ES.GetEpochNanosecondsFor(GetSlot(main, TZ_CANONICAL), isoDateTime, 'compatible'),
       formatter: getSlotLazy(main, YM)
@@ -599,7 +599,7 @@ function extractOverrides(temporalObj: Params['format'][0], main: DateTimeFormat
       );
     }
     const isoDate = ES.TemporalObjectToISODateRecord(temporalObj);
-    const isoDateTime = { ...isoDate, ...noon };
+    const isoDateTime = ES.CombineISODateAndTimeRecord(isoDate, noon);
     return {
       epochNs: ES.GetEpochNanosecondsFor(GetSlot(main, TZ_CANONICAL), isoDateTime, 'compatible'),
       formatter: getSlotLazy(main, MD)
@@ -615,7 +615,7 @@ function extractOverrides(temporalObj: Params['format'][0], main: DateTimeFormat
       );
     }
     const isoDate = ES.TemporalObjectToISODateRecord(temporalObj);
-    const isoDateTime = { ...isoDate, ...noon };
+    const isoDateTime = ES.CombineISODateAndTimeRecord(isoDate, noon);
     return {
       epochNs: ES.GetEpochNanosecondsFor(GetSlot(main, TZ_CANONICAL), isoDateTime, 'compatible'),
       formatter: getSlotLazy(main, DATE)

--- a/lib/now.ts
+++ b/lib/now.ts
@@ -2,6 +2,7 @@ import { ObjectDefineProperty, SymbolToStringTag } from './primordials';
 
 import * as ES from './ecmascript';
 import { GetIntrinsic } from './intrinsicclass';
+import { GetSlot, ISO_DATE_TIME } from './slots';
 import type { Temporal } from '..';
 
 const instant: (typeof Temporal.Now)['instant'] = () => {
@@ -10,29 +11,18 @@ const instant: (typeof Temporal.Now)['instant'] = () => {
 };
 const plainDateTimeISO: (typeof Temporal.Now)['plainDateTimeISO'] = (temporalTimeZoneLike = ES.DefaultTimeZone()) => {
   const timeZone = ES.ToTemporalTimeZoneIdentifier(temporalTimeZoneLike);
-  const iso = ES.GetISODateTimeFor(timeZone, ES.SystemUTCEpochNanoSeconds());
-  return ES.CreateTemporalDateTime(
-    iso.isoDate.year,
-    iso.isoDate.month,
-    iso.isoDate.day,
-    iso.time.hour,
-    iso.time.minute,
-    iso.time.second,
-    iso.time.millisecond,
-    iso.time.microsecond,
-    iso.time.nanosecond,
-    'iso8601'
-  );
+  const isoDateTime = ES.GetISODateTimeFor(timeZone, ES.SystemUTCEpochNanoSeconds());
+  return ES.CreateTemporalDateTime(isoDateTime, 'iso8601');
 };
 const zonedDateTimeISO: (typeof Temporal.Now)['zonedDateTimeISO'] = (temporalTimeZoneLike = ES.DefaultTimeZone()) => {
   const timeZone = ES.ToTemporalTimeZoneIdentifier(temporalTimeZoneLike);
   return ES.CreateTemporalZonedDateTime(ES.SystemUTCEpochNanoSeconds(), timeZone, 'iso8601');
 };
 const plainDateISO: (typeof Temporal.Now)['plainDateISO'] = (temporalTimeZoneLike = ES.DefaultTimeZone()) => {
-  return ES.TemporalDateTimeToDate(plainDateTimeISO(temporalTimeZoneLike));
+  return ES.CreateTemporalDate(GetSlot(plainDateTimeISO(temporalTimeZoneLike), ISO_DATE_TIME).isoDate, 'iso8601');
 };
 const plainTimeISO: (typeof Temporal.Now)['plainTimeISO'] = (temporalTimeZoneLike = ES.DefaultTimeZone()) => {
-  return ES.TemporalDateTimeToTime(plainDateTimeISO(temporalTimeZoneLike));
+  return ES.CreateTemporalTime(GetSlot(plainDateTimeISO(temporalTimeZoneLike), ISO_DATE_TIME).time);
 };
 const timeZoneId: (typeof Temporal.Now)['timeZoneId'] = () => {
   return ES.DefaultTimeZone();

--- a/lib/now.ts
+++ b/lib/now.ts
@@ -2,8 +2,11 @@ import { ObjectDefineProperty, SymbolToStringTag } from './primordials';
 
 import * as ES from './ecmascript';
 import { GetIntrinsic } from './intrinsicclass';
-import { GetSlot, ISO_DATE_TIME } from './slots';
 import type { Temporal } from '..';
+
+function SystemDateTime(timeZone: string) {
+  return ES.GetISODateTimeFor(timeZone, ES.SystemUTCEpochNanoSeconds());
+}
 
 const instant: (typeof Temporal.Now)['instant'] = () => {
   const Instant = GetIntrinsic('%Temporal.Instant%');
@@ -11,7 +14,7 @@ const instant: (typeof Temporal.Now)['instant'] = () => {
 };
 const plainDateTimeISO: (typeof Temporal.Now)['plainDateTimeISO'] = (temporalTimeZoneLike = ES.DefaultTimeZone()) => {
   const timeZone = ES.ToTemporalTimeZoneIdentifier(temporalTimeZoneLike);
-  const isoDateTime = ES.GetISODateTimeFor(timeZone, ES.SystemUTCEpochNanoSeconds());
+  const isoDateTime = SystemDateTime(timeZone);
   return ES.CreateTemporalDateTime(isoDateTime, 'iso8601');
 };
 const zonedDateTimeISO: (typeof Temporal.Now)['zonedDateTimeISO'] = (temporalTimeZoneLike = ES.DefaultTimeZone()) => {
@@ -19,10 +22,14 @@ const zonedDateTimeISO: (typeof Temporal.Now)['zonedDateTimeISO'] = (temporalTim
   return ES.CreateTemporalZonedDateTime(ES.SystemUTCEpochNanoSeconds(), timeZone, 'iso8601');
 };
 const plainDateISO: (typeof Temporal.Now)['plainDateISO'] = (temporalTimeZoneLike = ES.DefaultTimeZone()) => {
-  return ES.CreateTemporalDate(GetSlot(plainDateTimeISO(temporalTimeZoneLike), ISO_DATE_TIME).isoDate, 'iso8601');
+  const timeZone = ES.ToTemporalTimeZoneIdentifier(temporalTimeZoneLike);
+  const isoDateTime = SystemDateTime(timeZone);
+  return ES.CreateTemporalDate(isoDateTime.isoDate, 'iso8601');
 };
 const plainTimeISO: (typeof Temporal.Now)['plainTimeISO'] = (temporalTimeZoneLike = ES.DefaultTimeZone()) => {
-  return ES.CreateTemporalTime(GetSlot(plainDateTimeISO(temporalTimeZoneLike), ISO_DATE_TIME).time);
+  const timeZone = ES.ToTemporalTimeZoneIdentifier(temporalTimeZoneLike);
+  const isoDateTime = SystemDateTime(timeZone);
+  return ES.CreateTemporalTime(isoDateTime.time);
 };
 const timeZoneId: (typeof Temporal.Now)['timeZoneId'] = () => {
   return ES.DefaultTimeZone();

--- a/lib/now.ts
+++ b/lib/now.ts
@@ -12,15 +12,15 @@ const plainDateTimeISO: (typeof Temporal.Now)['plainDateTimeISO'] = (temporalTim
   const timeZone = ES.ToTemporalTimeZoneIdentifier(temporalTimeZoneLike);
   const iso = ES.GetISODateTimeFor(timeZone, ES.SystemUTCEpochNanoSeconds());
   return ES.CreateTemporalDateTime(
-    iso.year,
-    iso.month,
-    iso.day,
-    iso.hour,
-    iso.minute,
-    iso.second,
-    iso.millisecond,
-    iso.microsecond,
-    iso.nanosecond,
+    iso.isoDate.year,
+    iso.isoDate.month,
+    iso.isoDate.day,
+    iso.time.hour,
+    iso.time.minute,
+    iso.time.second,
+    iso.time.millisecond,
+    iso.time.microsecond,
+    iso.time.nanosecond,
     'iso8601'
   );
 };

--- a/lib/plaindate.ts
+++ b/lib/plaindate.ts
@@ -2,36 +2,25 @@ import { TypeError as TypeErrorCtor } from './primordials';
 
 import * as ES from './ecmascript';
 import { MakeIntrinsicClass } from './intrinsicclass';
-import {
-  ISO_YEAR,
-  ISO_MONTH,
-  ISO_DAY,
-  ISO_HOUR,
-  ISO_MINUTE,
-  ISO_SECOND,
-  ISO_MILLISECOND,
-  ISO_MICROSECOND,
-  ISO_NANOSECOND,
-  CALENDAR,
-  GetSlot
-} from './slots';
+import { CALENDAR, GetSlot, ISO_DATE, TIME } from './slots';
 import type { Temporal } from '..';
 import { DateTimeFormat } from './intl';
 import type { PlainDateParams as Params, PlainDateReturn as Return } from './internaltypes';
 
 export class PlainDate implements Temporal.PlainDate {
   constructor(
-    isoYearParam: Params['constructor'][0],
-    isoMonthParam: Params['constructor'][1],
-    isoDayParam: Params['constructor'][2],
+    isoYear: Params['constructor'][0],
+    isoMonth: Params['constructor'][1],
+    isoDay: Params['constructor'][2],
     calendarParam: Params['constructor'][3] = 'iso8601'
   ) {
-    const isoYear = ES.ToIntegerWithTruncation(isoYearParam);
-    const isoMonth = ES.ToIntegerWithTruncation(isoMonthParam);
-    const isoDay = ES.ToIntegerWithTruncation(isoDayParam);
+    const year = ES.ToIntegerWithTruncation(isoYear);
+    const month = ES.ToIntegerWithTruncation(isoMonth);
+    const day = ES.ToIntegerWithTruncation(isoDay);
     const calendar = ES.CanonicalizeCalendar(calendarParam === undefined ? 'iso8601' : ES.RequireString(calendarParam));
+    ES.RejectISODate(year, month, day);
 
-    ES.CreateTemporalDateSlots(this, isoYear, isoMonth, isoDay, calendar);
+    ES.CreateTemporalDateSlots(this, { year, month, day }, calendar);
   }
   get calendarId(): Return['calendarId'] {
     if (!ES.IsTemporalDate(this)) throw new TypeErrorCtor('invalid receiver');
@@ -39,77 +28,77 @@ export class PlainDate implements Temporal.PlainDate {
   }
   get era(): Return['era'] {
     if (!ES.IsTemporalDate(this)) throw new TypeErrorCtor('invalid receiver');
-    const isoDate = ES.TemporalObjectToISODateRecord(this);
+    const isoDate = GetSlot(this, ISO_DATE);
     return ES.calendarImplForObj(this).isoToDate(isoDate, { era: true }).era;
   }
   get eraYear(): Return['eraYear'] {
     if (!ES.IsTemporalDate(this)) throw new TypeErrorCtor('invalid receiver');
-    const isoDate = ES.TemporalObjectToISODateRecord(this);
+    const isoDate = GetSlot(this, ISO_DATE);
     return ES.calendarImplForObj(this).isoToDate(isoDate, { eraYear: true }).eraYear;
   }
   get year(): Return['year'] {
     if (!ES.IsTemporalDate(this)) throw new TypeErrorCtor('invalid receiver');
-    const isoDate = ES.TemporalObjectToISODateRecord(this);
+    const isoDate = GetSlot(this, ISO_DATE);
     return ES.calendarImplForObj(this).isoToDate(isoDate, { year: true }).year;
   }
   get month(): Return['month'] {
     if (!ES.IsTemporalDate(this)) throw new TypeErrorCtor('invalid receiver');
-    const isoDate = ES.TemporalObjectToISODateRecord(this);
+    const isoDate = GetSlot(this, ISO_DATE);
     return ES.calendarImplForObj(this).isoToDate(isoDate, { month: true }).month;
   }
   get monthCode(): Return['monthCode'] {
     if (!ES.IsTemporalDate(this)) throw new TypeErrorCtor('invalid receiver');
-    const isoDate = ES.TemporalObjectToISODateRecord(this);
+    const isoDate = GetSlot(this, ISO_DATE);
     return ES.calendarImplForObj(this).isoToDate(isoDate, { monthCode: true }).monthCode;
   }
   get day(): Return['day'] {
     if (!ES.IsTemporalDate(this)) throw new TypeErrorCtor('invalid receiver');
-    const isoDate = ES.TemporalObjectToISODateRecord(this);
+    const isoDate = GetSlot(this, ISO_DATE);
     return ES.calendarImplForObj(this).isoToDate(isoDate, { day: true }).day;
   }
   get dayOfWeek(): Return['dayOfWeek'] {
     if (!ES.IsTemporalDate(this)) throw new TypeErrorCtor('invalid receiver');
-    const isoDate = ES.TemporalObjectToISODateRecord(this);
+    const isoDate = GetSlot(this, ISO_DATE);
     return ES.calendarImplForObj(this).isoToDate(isoDate, { dayOfWeek: true }).dayOfWeek;
   }
   get dayOfYear(): Return['dayOfYear'] {
     if (!ES.IsTemporalDate(this)) throw new TypeErrorCtor('invalid receiver');
-    const isoDate = ES.TemporalObjectToISODateRecord(this);
+    const isoDate = GetSlot(this, ISO_DATE);
     return ES.calendarImplForObj(this).isoToDate(isoDate, { dayOfYear: true }).dayOfYear;
   }
   get weekOfYear(): Return['weekOfYear'] {
     if (!ES.IsTemporalDate(this)) throw new TypeErrorCtor('invalid receiver');
-    const isoDate = ES.TemporalObjectToISODateRecord(this);
+    const isoDate = GetSlot(this, ISO_DATE);
     return ES.calendarImplForObj(this).isoToDate(isoDate, { weekOfYear: true }).weekOfYear.week;
   }
   get yearOfWeek(): Return['weekOfYear'] {
     if (!ES.IsTemporalDate(this)) throw new TypeErrorCtor('invalid receiver');
-    const isoDate = ES.TemporalObjectToISODateRecord(this);
+    const isoDate = GetSlot(this, ISO_DATE);
     return ES.calendarImplForObj(this).isoToDate(isoDate, { weekOfYear: true }).weekOfYear.year;
   }
   get daysInWeek(): Return['daysInWeek'] {
     if (!ES.IsTemporalDate(this)) throw new TypeErrorCtor('invalid receiver');
-    const isoDate = ES.TemporalObjectToISODateRecord(this);
+    const isoDate = GetSlot(this, ISO_DATE);
     return ES.calendarImplForObj(this).isoToDate(isoDate, { daysInWeek: true }).daysInWeek;
   }
   get daysInMonth(): Return['daysInMonth'] {
     if (!ES.IsTemporalDate(this)) throw new TypeErrorCtor('invalid receiver');
-    const isoDate = ES.TemporalObjectToISODateRecord(this);
+    const isoDate = GetSlot(this, ISO_DATE);
     return ES.calendarImplForObj(this).isoToDate(isoDate, { daysInMonth: true }).daysInMonth;
   }
   get daysInYear(): Return['daysInYear'] {
     if (!ES.IsTemporalDate(this)) throw new TypeErrorCtor('invalid receiver');
-    const isoDate = ES.TemporalObjectToISODateRecord(this);
+    const isoDate = GetSlot(this, ISO_DATE);
     return ES.calendarImplForObj(this).isoToDate(isoDate, { daysInYear: true }).daysInYear;
   }
   get monthsInYear(): Return['monthsInYear'] {
     if (!ES.IsTemporalDate(this)) throw new TypeErrorCtor('invalid receiver');
-    const isoDate = ES.TemporalObjectToISODateRecord(this);
+    const isoDate = GetSlot(this, ISO_DATE);
     return ES.calendarImplForObj(this).isoToDate(isoDate, { monthsInYear: true }).monthsInYear;
   }
   get inLeapYear(): Return['inLeapYear'] {
     if (!ES.IsTemporalDate(this)) throw new TypeErrorCtor('invalid receiver');
-    const isoDate = ES.TemporalObjectToISODateRecord(this);
+    const isoDate = GetSlot(this, ISO_DATE);
     return ES.calendarImplForObj(this).isoToDate(isoDate, { inLeapYear: true }).inLeapYear;
   }
   with(temporalDateLike: Params['with'][0], options: Params['with'][1] = undefined): Return['with'] {
@@ -131,13 +120,13 @@ export class PlainDate implements Temporal.PlainDate {
     fields = ES.CalendarMergeFields(calendar, fields, partialDate);
 
     const overflow = ES.GetTemporalOverflowOption(ES.GetOptionsObject(options));
-    const { year, month, day } = ES.CalendarDateFromFields(calendar, fields, overflow);
-    return ES.CreateTemporalDate(year, month, day, calendar);
+    const isoDate = ES.CalendarDateFromFields(calendar, fields, overflow);
+    return ES.CreateTemporalDate(isoDate, calendar);
   }
   withCalendar(calendarParam: Params['withCalendar'][0]): Return['withCalendar'] {
     if (!ES.IsTemporalDate(this)) throw new TypeErrorCtor('invalid receiver');
     const calendar = ES.ToTemporalCalendarIdentifier(calendarParam);
-    return ES.CreateTemporalDate(GetSlot(this, ISO_YEAR), GetSlot(this, ISO_MONTH), GetSlot(this, ISO_DAY), calendar);
+    return ES.CreateTemporalDate(GetSlot(this, ISO_DATE), calendar);
   }
   add(temporalDurationLike: Params['add'][0], options: Params['add'][1] = undefined): Return['add'] {
     if (!ES.IsTemporalDate(this)) throw new TypeErrorCtor('invalid receiver');
@@ -161,9 +150,7 @@ export class PlainDate implements Temporal.PlainDate {
   equals(otherParam: Params['equals'][0]): Return['equals'] {
     if (!ES.IsTemporalDate(this)) throw new TypeErrorCtor('invalid receiver');
     const other = ES.ToTemporalDate(otherParam);
-    if (GetSlot(this, ISO_YEAR) !== GetSlot(other, ISO_YEAR)) return false;
-    if (GetSlot(this, ISO_MONTH) !== GetSlot(other, ISO_MONTH)) return false;
-    if (GetSlot(this, ISO_DAY) !== GetSlot(other, ISO_DAY)) return false;
+    if (ES.CompareISODate(GetSlot(this, ISO_DATE), GetSlot(other, ISO_DATE)) !== 0) return false;
     return ES.CalendarEquals(GetSlot(this, CALENDAR), GetSlot(other, CALENDAR));
   }
   toString(options: Params['toString'][0] = undefined): string {
@@ -189,18 +176,8 @@ export class PlainDate implements Temporal.PlainDate {
   toPlainDateTime(temporalTimeParam: Params['toPlainDateTime'][0] = undefined): Return['toPlainDateTime'] {
     if (!ES.IsTemporalDate(this)) throw new TypeErrorCtor('invalid receiver');
     const temporalTime = ES.ToTemporalTimeOrMidnight(temporalTimeParam);
-    return ES.CreateTemporalDateTime(
-      GetSlot(this, ISO_YEAR),
-      GetSlot(this, ISO_MONTH),
-      GetSlot(this, ISO_DAY),
-      GetSlot(temporalTime, ISO_HOUR),
-      GetSlot(temporalTime, ISO_MINUTE),
-      GetSlot(temporalTime, ISO_SECOND),
-      GetSlot(temporalTime, ISO_MILLISECOND),
-      GetSlot(temporalTime, ISO_MICROSECOND),
-      GetSlot(temporalTime, ISO_NANOSECOND),
-      GetSlot(this, CALENDAR)
-    );
+    const isoDateTime = ES.CombineISODateAndTimeRecord(GetSlot(this, ISO_DATE), GetSlot(temporalTime, TIME));
+    return ES.CreateTemporalDateTime(isoDateTime, GetSlot(this, CALENDAR));
   }
   toZonedDateTime(item: Params['toZonedDateTime'][0]): Return['toZonedDateTime'] {
     if (!ES.IsTemporalDate(this)) throw new TypeErrorCtor('invalid receiver');
@@ -218,21 +195,14 @@ export class PlainDate implements Temporal.PlainDate {
       timeZone = ES.ToTemporalTimeZoneIdentifier(item);
     }
 
-    const isoDate = ES.TemporalObjectToISODateRecord(this);
+    const isoDate = GetSlot(this, ISO_DATE);
     let epochNs;
     if (temporalTime === undefined) {
       epochNs = ES.GetStartOfDay(timeZone, isoDate);
     } else {
       temporalTime = ES.ToTemporalTime(temporalTime);
-      const dt = ES.CombineISODateAndTimeRecord(isoDate, {
-        hour: GetSlot(temporalTime, ISO_HOUR),
-        minute: GetSlot(temporalTime, ISO_MINUTE),
-        second: GetSlot(temporalTime, ISO_SECOND),
-        millisecond: GetSlot(temporalTime, ISO_MILLISECOND),
-        microsecond: GetSlot(temporalTime, ISO_MICROSECOND),
-        nanosecond: GetSlot(temporalTime, ISO_NANOSECOND)
-      });
-      epochNs = ES.GetEpochNanosecondsFor(timeZone, dt, 'compatible');
+      const isoDateTime = ES.CombineISODateAndTimeRecord(isoDate, GetSlot(temporalTime, TIME));
+      epochNs = ES.GetEpochNanosecondsFor(timeZone, isoDateTime, 'compatible');
     }
     return ES.CreateTemporalZonedDateTime(epochNs, timeZone, GetSlot(this, CALENDAR));
   }
@@ -240,15 +210,15 @@ export class PlainDate implements Temporal.PlainDate {
     if (!ES.IsTemporalDate(this)) throw new TypeErrorCtor('invalid receiver');
     const calendar = GetSlot(this, CALENDAR);
     const fields = ES.TemporalObjectToFields(this);
-    const { year, month, day } = ES.CalendarYearMonthFromFields(calendar, fields, 'constrain');
-    return ES.CreateTemporalYearMonth(year, month, calendar, day);
+    const isoDate = ES.CalendarYearMonthFromFields(calendar, fields, 'constrain');
+    return ES.CreateTemporalYearMonth(isoDate, calendar);
   }
   toPlainMonthDay(): Return['toPlainMonthDay'] {
     if (!ES.IsTemporalDate(this)) throw new TypeErrorCtor('invalid receiver');
     const calendar = GetSlot(this, CALENDAR);
     const fields = ES.TemporalObjectToFields(this);
-    const { year, month, day } = ES.CalendarMonthDayFromFields(calendar, fields, 'constrain');
-    return ES.CreateTemporalMonthDay(month, day, calendar, year);
+    const isoDate = ES.CalendarMonthDayFromFields(calendar, fields, 'constrain');
+    return ES.CreateTemporalMonthDay(isoDate, calendar);
   }
 
   static from(item: Params['from'][0], options: Params['from'][1] = undefined): Return['from'] {
@@ -257,10 +227,7 @@ export class PlainDate implements Temporal.PlainDate {
   static compare(oneParam: Params['compare'][0], twoParam: Params['compare'][1]): Return['compare'] {
     const one = ES.ToTemporalDate(oneParam);
     const two = ES.ToTemporalDate(twoParam);
-    return ES.CompareISODate(
-      { year: GetSlot(one, ISO_YEAR), month: GetSlot(one, ISO_MONTH), day: GetSlot(one, ISO_DAY) },
-      { year: GetSlot(two, ISO_YEAR), month: GetSlot(two, ISO_MONTH), day: GetSlot(two, ISO_DAY) }
-    );
+    return ES.CompareISODate(GetSlot(one, ISO_DATE), GetSlot(two, ISO_DATE));
   }
   [Symbol.toStringTag]!: 'Temporal.PlainDate';
 }

--- a/lib/plaindate.ts
+++ b/lib/plaindate.ts
@@ -258,12 +258,8 @@ export class PlainDate implements Temporal.PlainDate {
     const one = ES.ToTemporalDate(oneParam);
     const two = ES.ToTemporalDate(twoParam);
     return ES.CompareISODate(
-      GetSlot(one, ISO_YEAR),
-      GetSlot(one, ISO_MONTH),
-      GetSlot(one, ISO_DAY),
-      GetSlot(two, ISO_YEAR),
-      GetSlot(two, ISO_MONTH),
-      GetSlot(two, ISO_DAY)
+      { year: GetSlot(one, ISO_YEAR), month: GetSlot(one, ISO_MONTH), day: GetSlot(one, ISO_DAY) },
+      { year: GetSlot(two, ISO_YEAR), month: GetSlot(two, ISO_MONTH), day: GetSlot(two, ISO_DAY) }
     );
   }
   [Symbol.toStringTag]!: 'Temporal.PlainDate';

--- a/lib/plaindate.ts
+++ b/lib/plaindate.ts
@@ -173,10 +173,10 @@ export class PlainDate implements Temporal.PlainDate {
   valueOf(): never {
     ES.ValueOfThrows('PlainDate');
   }
-  toPlainDateTime(temporalTimeParam: Params['toPlainDateTime'][0] = undefined): Return['toPlainDateTime'] {
+  toPlainDateTime(temporalTime: Params['toPlainDateTime'][0] = undefined): Return['toPlainDateTime'] {
     if (!ES.IsTemporalDate(this)) throw new TypeErrorCtor('invalid receiver');
-    const temporalTime = ES.ToTemporalTimeOrMidnight(temporalTimeParam);
-    const isoDateTime = ES.CombineISODateAndTimeRecord(GetSlot(this, ISO_DATE), GetSlot(temporalTime, TIME));
+    const time = ES.ToTimeRecordOrMidnight(temporalTime);
+    const isoDateTime = ES.CombineISODateAndTimeRecord(GetSlot(this, ISO_DATE), time);
     return ES.CreateTemporalDateTime(isoDateTime, GetSlot(this, CALENDAR));
   }
   toZonedDateTime(item: Params['toZonedDateTime'][0]): Return['toZonedDateTime'] {

--- a/lib/plaindate.ts
+++ b/lib/plaindate.ts
@@ -109,7 +109,7 @@ export class PlainDate implements Temporal.PlainDate {
     ES.RejectTemporalLikeObject(temporalDateLike);
 
     const calendar = GetSlot(this, CALENDAR);
-    let fields = ES.TemporalObjectToFields(this);
+    let fields = ES.ISODateToFields(calendar, GetSlot(this, ISO_DATE));
     const partialDate = ES.PrepareCalendarFields(
       calendar,
       temporalDateLike,
@@ -209,14 +209,14 @@ export class PlainDate implements Temporal.PlainDate {
   toPlainYearMonth(): Return['toPlainYearMonth'] {
     if (!ES.IsTemporalDate(this)) throw new TypeErrorCtor('invalid receiver');
     const calendar = GetSlot(this, CALENDAR);
-    const fields = ES.TemporalObjectToFields(this);
+    const fields = ES.ISODateToFields(calendar, GetSlot(this, ISO_DATE));
     const isoDate = ES.CalendarYearMonthFromFields(calendar, fields, 'constrain');
     return ES.CreateTemporalYearMonth(isoDate, calendar);
   }
   toPlainMonthDay(): Return['toPlainMonthDay'] {
     if (!ES.IsTemporalDate(this)) throw new TypeErrorCtor('invalid receiver');
     const calendar = GetSlot(this, CALENDAR);
-    const fields = ES.TemporalObjectToFields(this);
+    const fields = ES.ISODateToFields(calendar, GetSlot(this, ISO_DATE));
     const isoDate = ES.CalendarMonthDayFromFields(calendar, fields, 'constrain');
     return ES.CreateTemporalMonthDay(isoDate, calendar);
   }

--- a/lib/plaindatetime.ts
+++ b/lib/plaindatetime.ts
@@ -314,30 +314,9 @@ export class PlainDateTime implements Temporal.PlainDateTime {
   equals(otherParam: Params['equals'][0]): Return['equals'] {
     if (!ES.IsTemporalDateTime(this)) throw new TypeErrorCtor('invalid receiver');
     const other = ES.ToTemporalDateTime(otherParam);
-    if (
-      ES.CompareISODateTime(
-        GetSlot(this, ISO_YEAR),
-        GetSlot(this, ISO_MONTH),
-        GetSlot(this, ISO_DAY),
-        GetSlot(this, ISO_HOUR),
-        GetSlot(this, ISO_MINUTE),
-        GetSlot(this, ISO_SECOND),
-        GetSlot(this, ISO_MILLISECOND),
-        GetSlot(this, ISO_MICROSECOND),
-        GetSlot(this, ISO_NANOSECOND),
-        GetSlot(other, ISO_YEAR),
-        GetSlot(other, ISO_MONTH),
-        GetSlot(other, ISO_DAY),
-        GetSlot(other, ISO_HOUR),
-        GetSlot(other, ISO_MINUTE),
-        GetSlot(other, ISO_SECOND),
-        GetSlot(other, ISO_MILLISECOND),
-        GetSlot(other, ISO_MICROSECOND),
-        GetSlot(other, ISO_NANOSECOND)
-      ) !== 0
-    ) {
-      return false;
-    }
+    const isoDateTime = ES.PlainDateTimeToISODateTimeRecord(this);
+    const isoDateTimeOther = ES.PlainDateTimeToISODateTimeRecord(other);
+    if (ES.CompareISODateTime(isoDateTime, isoDateTimeOther) !== 0) return false;
     return ES.CalendarEquals(GetSlot(this, CALENDAR), GetSlot(other, CALENDAR));
   }
   toString(options: Params['toString'][0] = undefined): string {
@@ -396,26 +375,9 @@ export class PlainDateTime implements Temporal.PlainDateTime {
   static compare(oneParam: Params['compare'][0], twoParam: Params['compare'][1]): Return['compare'] {
     const one = ES.ToTemporalDateTime(oneParam);
     const two = ES.ToTemporalDateTime(twoParam);
-    return ES.CompareISODateTime(
-      GetSlot(one, ISO_YEAR),
-      GetSlot(one, ISO_MONTH),
-      GetSlot(one, ISO_DAY),
-      GetSlot(one, ISO_HOUR),
-      GetSlot(one, ISO_MINUTE),
-      GetSlot(one, ISO_SECOND),
-      GetSlot(one, ISO_MILLISECOND),
-      GetSlot(one, ISO_MICROSECOND),
-      GetSlot(one, ISO_NANOSECOND),
-      GetSlot(two, ISO_YEAR),
-      GetSlot(two, ISO_MONTH),
-      GetSlot(two, ISO_DAY),
-      GetSlot(two, ISO_HOUR),
-      GetSlot(two, ISO_MINUTE),
-      GetSlot(two, ISO_SECOND),
-      GetSlot(two, ISO_MILLISECOND),
-      GetSlot(two, ISO_MICROSECOND),
-      GetSlot(two, ISO_NANOSECOND)
-    );
+    const isoDateTime1 = ES.PlainDateTimeToISODateTimeRecord(one);
+    const isoDateTime2 = ES.PlainDateTimeToISODateTimeRecord(two);
+    return ES.CompareISODateTime(isoDateTime1, isoDateTime2);
   }
   [Symbol.toStringTag]!: 'Temporal.PlainDateTime';
 }

--- a/lib/plaindatetime.ts
+++ b/lib/plaindatetime.ts
@@ -283,54 +283,33 @@ export class PlainDateTime implements Temporal.PlainDateTime {
     const inclusive = maximum === 1;
     ES.ValidateTemporalRoundingIncrement(roundingIncrement, maximum, inclusive);
 
-    let year = GetSlot(this, ISO_YEAR);
-    let month = GetSlot(this, ISO_MONTH);
-    let day = GetSlot(this, ISO_DAY);
-    let hour = GetSlot(this, ISO_HOUR);
-    let minute = GetSlot(this, ISO_MINUTE);
-    let second = GetSlot(this, ISO_SECOND);
-    let millisecond = GetSlot(this, ISO_MILLISECOND);
-    let microsecond = GetSlot(this, ISO_MICROSECOND);
-    let nanosecond = GetSlot(this, ISO_NANOSECOND);
+    const isoDateTime = ES.PlainDateTimeToISODateTimeRecord(this);
     if (roundingIncrement === 1 && smallestUnit === 'nanosecond') {
       return ES.CreateTemporalDateTime(
-        year,
-        month,
-        day,
-        hour,
-        minute,
-        second,
-        millisecond,
-        microsecond,
-        nanosecond,
+        isoDateTime.year,
+        isoDateTime.month,
+        isoDateTime.day,
+        isoDateTime.hour,
+        isoDateTime.minute,
+        isoDateTime.second,
+        isoDateTime.millisecond,
+        isoDateTime.microsecond,
+        isoDateTime.nanosecond,
         GetSlot(this, CALENDAR)
       );
     }
-    ({ year, month, day, hour, minute, second, millisecond, microsecond, nanosecond } = ES.RoundISODateTime(
-      year,
-      month,
-      day,
-      hour,
-      minute,
-      second,
-      millisecond,
-      microsecond,
-      nanosecond,
-      roundingIncrement,
-      smallestUnit,
-      roundingMode
-    ));
+    const result = ES.RoundISODateTime(isoDateTime, roundingIncrement, smallestUnit, roundingMode);
 
     return ES.CreateTemporalDateTime(
-      year,
-      month,
-      day,
-      hour,
-      minute,
-      second,
-      millisecond,
-      microsecond,
-      nanosecond,
+      result.year,
+      result.month,
+      result.day,
+      result.hour,
+      result.minute,
+      result.second,
+      result.millisecond,
+      result.microsecond,
+      result.nanosecond,
       GetSlot(this, CALENDAR)
     );
   }
@@ -372,20 +351,7 @@ export class PlainDateTime implements Temporal.PlainDateTime {
     const smallestUnit = ES.GetTemporalUnitValuedOption(resolvedOptions, 'smallestUnit', 'time', undefined);
     if (smallestUnit === 'hour') throw new RangeErrorCtor('smallestUnit must be a time unit other than "hour"');
     const { precision, unit, increment } = ES.ToSecondsStringPrecisionRecord(smallestUnit, digits);
-    const result = ES.RoundISODateTime(
-      GetSlot(this, ISO_YEAR),
-      GetSlot(this, ISO_MONTH),
-      GetSlot(this, ISO_DAY),
-      GetSlot(this, ISO_HOUR),
-      GetSlot(this, ISO_MINUTE),
-      GetSlot(this, ISO_SECOND),
-      GetSlot(this, ISO_MILLISECOND),
-      GetSlot(this, ISO_MICROSECOND),
-      GetSlot(this, ISO_NANOSECOND),
-      increment,
-      unit,
-      roundingMode
-    );
+    const result = ES.RoundISODateTime(ES.PlainDateTimeToISODateTimeRecord(this), increment, unit, roundingMode);
     ES.RejectDateTimeRange(result);
     return ES.TemporalDateTimeToString(result, GetSlot(this, CALENDAR), precision, showCalendar);
   }

--- a/lib/plaindatetime.ts
+++ b/lib/plaindatetime.ts
@@ -189,8 +189,12 @@ export class PlainDateTime implements Temporal.PlainDateTime {
     fields = ES.CalendarMergeFields(calendar, fields, partialDateTime);
 
     const overflow = ES.GetTemporalOverflowOption(ES.GetOptionsObject(options));
-    const { year, month, day, time } = ES.InterpretTemporalDateTimeFields(calendar, fields, overflow);
-    const { hour, minute, second, millisecond, microsecond, nanosecond } = time;
+    const {
+      year,
+      month,
+      day,
+      time: { hour, minute, second, millisecond, microsecond, nanosecond }
+    } = ES.InterpretTemporalDateTimeFields(calendar, fields, overflow);
 
     return ES.CreateTemporalDateTime(
       year,

--- a/lib/plaindatetime.ts
+++ b/lib/plaindatetime.ts
@@ -353,7 +353,7 @@ export class PlainDateTime implements Temporal.PlainDateTime {
     const { precision, unit, increment } = ES.ToSecondsStringPrecisionRecord(smallestUnit, digits);
     const result = ES.RoundISODateTime(ES.PlainDateTimeToISODateTimeRecord(this), increment, unit, roundingMode);
     ES.RejectDateTimeRange(result);
-    return ES.TemporalDateTimeToString(result, GetSlot(this, CALENDAR), precision, showCalendar);
+    return ES.ISODateTimeToString(result, GetSlot(this, CALENDAR), precision, showCalendar);
   }
   toJSON(): Return['toJSON'] {
     if (!ES.IsTemporalDateTime(this)) throw new TypeErrorCtor('invalid receiver');
@@ -368,7 +368,7 @@ export class PlainDateTime implements Temporal.PlainDateTime {
       microsecond: GetSlot(this, ISO_MICROSECOND),
       nanosecond: GetSlot(this, ISO_NANOSECOND)
     };
-    return ES.TemporalDateTimeToString(isoDateTime, GetSlot(this, CALENDAR), 'auto');
+    return ES.ISODateTimeToString(isoDateTime, GetSlot(this, CALENDAR), 'auto');
   }
   toLocaleString(
     locales: Params['toLocaleString'][0] = undefined,

--- a/lib/plaindatetime.ts
+++ b/lib/plaindatetime.ts
@@ -3,7 +3,7 @@ import { RangeError as RangeErrorCtor, TypeError as TypeErrorCtor } from './prim
 import * as ES from './ecmascript';
 import { MakeIntrinsicClass } from './intrinsicclass';
 
-import { CALENDAR, GetSlot, ISO_DATE_TIME, TIME } from './slots';
+import { CALENDAR, GetSlot, ISO_DATE_TIME } from './slots';
 import type { Temporal } from '..';
 import { DateTimeFormat } from './intl';
 import type { PlainDateTimeParams as Params, PlainDateTimeReturn as Return } from './internaltypes';
@@ -174,13 +174,10 @@ export class PlainDateTime implements Temporal.PlainDateTime {
     const newDateTime = ES.InterpretTemporalDateTimeFields(calendar, fields, overflow);
     return ES.CreateTemporalDateTime(newDateTime, calendar);
   }
-  withPlainTime(temporalTimeParam: Params['withPlainTime'][0] = undefined): Return['withPlainTime'] {
+  withPlainTime(temporalTime: Params['withPlainTime'][0] = undefined): Return['withPlainTime'] {
     if (!ES.IsTemporalDateTime(this)) throw new TypeErrorCtor('invalid receiver');
-    const temporalTime = ES.ToTemporalTimeOrMidnight(temporalTimeParam);
-    const isoDateTime = ES.CombineISODateAndTimeRecord(
-      GetSlot(this, ISO_DATE_TIME).isoDate,
-      GetSlot(temporalTime, TIME)
-    );
+    const time = ES.ToTimeRecordOrMidnight(temporalTime);
+    const isoDateTime = ES.CombineISODateAndTimeRecord(GetSlot(this, ISO_DATE_TIME).isoDate, time);
     return ES.CreateTemporalDateTime(isoDateTime, GetSlot(this, CALENDAR));
   }
   withCalendar(calendarParam: Params['withCalendar'][0]): Return['withCalendar'] {

--- a/lib/plaindatetime.ts
+++ b/lib/plaindatetime.ts
@@ -190,9 +190,7 @@ export class PlainDateTime implements Temporal.PlainDateTime {
 
     const overflow = ES.GetTemporalOverflowOption(ES.GetOptionsObject(options));
     const {
-      year,
-      month,
-      day,
+      isoDate: { year, month, day },
       time: { hour, minute, second, millisecond, microsecond, nanosecond }
     } = ES.InterpretTemporalDateTimeFields(calendar, fields, overflow);
 
@@ -286,30 +284,30 @@ export class PlainDateTime implements Temporal.PlainDateTime {
     const isoDateTime = ES.PlainDateTimeToISODateTimeRecord(this);
     if (roundingIncrement === 1 && smallestUnit === 'nanosecond') {
       return ES.CreateTemporalDateTime(
-        isoDateTime.year,
-        isoDateTime.month,
-        isoDateTime.day,
-        isoDateTime.hour,
-        isoDateTime.minute,
-        isoDateTime.second,
-        isoDateTime.millisecond,
-        isoDateTime.microsecond,
-        isoDateTime.nanosecond,
+        isoDateTime.isoDate.year,
+        isoDateTime.isoDate.month,
+        isoDateTime.isoDate.day,
+        isoDateTime.time.hour,
+        isoDateTime.time.minute,
+        isoDateTime.time.second,
+        isoDateTime.time.millisecond,
+        isoDateTime.time.microsecond,
+        isoDateTime.time.nanosecond,
         GetSlot(this, CALENDAR)
       );
     }
     const result = ES.RoundISODateTime(isoDateTime, roundingIncrement, smallestUnit, roundingMode);
 
     return ES.CreateTemporalDateTime(
-      result.year,
-      result.month,
-      result.day,
-      result.hour,
-      result.minute,
-      result.second,
-      result.millisecond,
-      result.microsecond,
-      result.nanosecond,
+      result.isoDate.year,
+      result.isoDate.month,
+      result.isoDate.day,
+      result.time.hour,
+      result.time.minute,
+      result.time.second,
+      result.time.millisecond,
+      result.time.microsecond,
+      result.time.nanosecond,
       GetSlot(this, CALENDAR)
     );
   }
@@ -357,17 +355,7 @@ export class PlainDateTime implements Temporal.PlainDateTime {
   }
   toJSON(): Return['toJSON'] {
     if (!ES.IsTemporalDateTime(this)) throw new TypeErrorCtor('invalid receiver');
-    const isoDateTime = {
-      year: GetSlot(this, ISO_YEAR),
-      month: GetSlot(this, ISO_MONTH),
-      day: GetSlot(this, ISO_DAY),
-      hour: GetSlot(this, ISO_HOUR),
-      minute: GetSlot(this, ISO_MINUTE),
-      second: GetSlot(this, ISO_SECOND),
-      millisecond: GetSlot(this, ISO_MILLISECOND),
-      microsecond: GetSlot(this, ISO_MICROSECOND),
-      nanosecond: GetSlot(this, ISO_NANOSECOND)
-    };
+    const isoDateTime = ES.PlainDateTimeToISODateTimeRecord(this);
     return ES.ISODateTimeToString(isoDateTime, GetSlot(this, CALENDAR), 'auto');
   }
   toLocaleString(

--- a/lib/plaindatetime.ts
+++ b/lib/plaindatetime.ts
@@ -3,28 +3,16 @@ import { RangeError as RangeErrorCtor, TypeError as TypeErrorCtor } from './prim
 import * as ES from './ecmascript';
 import { MakeIntrinsicClass } from './intrinsicclass';
 
-import {
-  ISO_YEAR,
-  ISO_MONTH,
-  ISO_DAY,
-  ISO_HOUR,
-  ISO_MINUTE,
-  ISO_SECOND,
-  ISO_MILLISECOND,
-  ISO_MICROSECOND,
-  ISO_NANOSECOND,
-  CALENDAR,
-  GetSlot
-} from './slots';
+import { CALENDAR, GetSlot, ISO_DATE_TIME, TIME } from './slots';
 import type { Temporal } from '..';
 import { DateTimeFormat } from './intl';
-import type { BuiltinCalendarId, PlainDateTimeParams as Params, PlainDateTimeReturn as Return } from './internaltypes';
+import type { PlainDateTimeParams as Params, PlainDateTimeReturn as Return } from './internaltypes';
 
 export class PlainDateTime implements Temporal.PlainDateTime {
   constructor(
-    isoYearParam: Params['constructor'][0],
-    isoMonthParam: Params['constructor'][1],
-    isoDayParam: Params['constructor'][2],
+    isoYear: Params['constructor'][0],
+    isoMonth: Params['constructor'][1],
+    isoDay: Params['constructor'][2],
     hourParam: Params['constructor'][3] = 0,
     minuteParam: Params['constructor'][4] = 0,
     secondParam: Params['constructor'][5] = 0,
@@ -33,9 +21,9 @@ export class PlainDateTime implements Temporal.PlainDateTime {
     nanosecondParam: Params['constructor'][8] = 0,
     calendarParam: Params['constructor'][9] = 'iso8601'
   ) {
-    const isoYear = ES.ToIntegerWithTruncation(isoYearParam);
-    const isoMonth = ES.ToIntegerWithTruncation(isoMonthParam);
-    const isoDay = ES.ToIntegerWithTruncation(isoDayParam);
+    const year = ES.ToIntegerWithTruncation(isoYear);
+    const month = ES.ToIntegerWithTruncation(isoMonth);
+    const day = ES.ToIntegerWithTruncation(isoDay);
     const hour = hourParam === undefined ? 0 : ES.ToIntegerWithTruncation(hourParam);
     const minute = minuteParam === undefined ? 0 : ES.ToIntegerWithTruncation(minuteParam);
     const second = secondParam === undefined ? 0 : ES.ToIntegerWithTruncation(secondParam);
@@ -43,19 +31,12 @@ export class PlainDateTime implements Temporal.PlainDateTime {
     const microsecond = microsecondParam === undefined ? 0 : ES.ToIntegerWithTruncation(microsecondParam);
     const nanosecond = nanosecondParam === undefined ? 0 : ES.ToIntegerWithTruncation(nanosecondParam);
     const calendar = ES.CanonicalizeCalendar(calendarParam === undefined ? 'iso8601' : ES.RequireString(calendarParam));
-    ES.uncheckedAssertNarrowedType<BuiltinCalendarId>(calendar, 'lowercased and canonicalized');
+
+    ES.RejectDateTime(year, month, day, hour, minute, second, millisecond, microsecond, nanosecond);
 
     ES.CreateTemporalDateTimeSlots(
       this,
-      isoYear,
-      isoMonth,
-      isoDay,
-      hour,
-      minute,
-      second,
-      millisecond,
-      microsecond,
-      nanosecond,
+      { isoDate: { year, month, day }, time: { hour, minute, second, millisecond, microsecond, nanosecond } },
       calendar
     );
   }
@@ -65,101 +46,101 @@ export class PlainDateTime implements Temporal.PlainDateTime {
   }
   get year(): Return['year'] {
     if (!ES.IsTemporalDateTime(this)) throw new TypeErrorCtor('invalid receiver');
-    const isoDate = ES.TemporalObjectToISODateRecord(this);
+    const isoDate = GetSlot(this, ISO_DATE_TIME).isoDate;
     return ES.calendarImplForObj(this).isoToDate(isoDate, { year: true }).year;
   }
   get month(): Return['month'] {
     if (!ES.IsTemporalDateTime(this)) throw new TypeErrorCtor('invalid receiver');
-    const isoDate = ES.TemporalObjectToISODateRecord(this);
+    const isoDate = GetSlot(this, ISO_DATE_TIME).isoDate;
     return ES.calendarImplForObj(this).isoToDate(isoDate, { month: true }).month;
   }
   get monthCode(): Return['monthCode'] {
     if (!ES.IsTemporalDateTime(this)) throw new TypeErrorCtor('invalid receiver');
-    const isoDate = ES.TemporalObjectToISODateRecord(this);
+    const isoDate = GetSlot(this, ISO_DATE_TIME).isoDate;
     return ES.calendarImplForObj(this).isoToDate(isoDate, { monthCode: true }).monthCode;
   }
   get day(): Return['day'] {
     if (!ES.IsTemporalDateTime(this)) throw new TypeErrorCtor('invalid receiver');
-    const isoDate = ES.TemporalObjectToISODateRecord(this);
+    const isoDate = GetSlot(this, ISO_DATE_TIME).isoDate;
     return ES.calendarImplForObj(this).isoToDate(isoDate, { day: true }).day;
   }
   get hour(): Return['hour'] {
     if (!ES.IsTemporalDateTime(this)) throw new TypeErrorCtor('invalid receiver');
-    return GetSlot(this, ISO_HOUR);
+    return GetSlot(this, ISO_DATE_TIME).time.hour;
   }
   get minute(): Return['minute'] {
     if (!ES.IsTemporalDateTime(this)) throw new TypeErrorCtor('invalid receiver');
-    return GetSlot(this, ISO_MINUTE);
+    return GetSlot(this, ISO_DATE_TIME).time.minute;
   }
   get second(): Return['second'] {
     if (!ES.IsTemporalDateTime(this)) throw new TypeErrorCtor('invalid receiver');
-    return GetSlot(this, ISO_SECOND);
+    return GetSlot(this, ISO_DATE_TIME).time.second;
   }
   get millisecond(): Return['millisecond'] {
     if (!ES.IsTemporalDateTime(this)) throw new TypeErrorCtor('invalid receiver');
-    return GetSlot(this, ISO_MILLISECOND);
+    return GetSlot(this, ISO_DATE_TIME).time.millisecond;
   }
   get microsecond(): Return['microsecond'] {
     if (!ES.IsTemporalDateTime(this)) throw new TypeErrorCtor('invalid receiver');
-    return GetSlot(this, ISO_MICROSECOND);
+    return GetSlot(this, ISO_DATE_TIME).time.microsecond;
   }
   get nanosecond(): Return['nanosecond'] {
     if (!ES.IsTemporalDateTime(this)) throw new TypeErrorCtor('invalid receiver');
-    return GetSlot(this, ISO_NANOSECOND);
+    return GetSlot(this, ISO_DATE_TIME).time.nanosecond;
   }
   get era(): Return['era'] {
     if (!ES.IsTemporalDateTime(this)) throw new TypeErrorCtor('invalid receiver');
-    const isoDate = ES.TemporalObjectToISODateRecord(this);
+    const isoDate = GetSlot(this, ISO_DATE_TIME).isoDate;
     return ES.calendarImplForObj(this).isoToDate(isoDate, { era: true }).era;
   }
   get eraYear(): Return['eraYear'] {
     if (!ES.IsTemporalDateTime(this)) throw new TypeErrorCtor('invalid receiver');
-    const isoDate = ES.TemporalObjectToISODateRecord(this);
+    const isoDate = GetSlot(this, ISO_DATE_TIME).isoDate;
     return ES.calendarImplForObj(this).isoToDate(isoDate, { eraYear: true }).eraYear;
   }
   get dayOfWeek(): Return['dayOfWeek'] {
     if (!ES.IsTemporalDateTime(this)) throw new TypeErrorCtor('invalid receiver');
-    const isoDate = ES.TemporalObjectToISODateRecord(this);
+    const isoDate = GetSlot(this, ISO_DATE_TIME).isoDate;
     return ES.calendarImplForObj(this).isoToDate(isoDate, { dayOfWeek: true }).dayOfWeek;
   }
   get dayOfYear(): Return['dayOfYear'] {
     if (!ES.IsTemporalDateTime(this)) throw new TypeErrorCtor('invalid receiver');
-    const isoDate = ES.TemporalObjectToISODateRecord(this);
+    const isoDate = GetSlot(this, ISO_DATE_TIME).isoDate;
     return ES.calendarImplForObj(this).isoToDate(isoDate, { dayOfYear: true }).dayOfYear;
   }
   get weekOfYear(): Return['weekOfYear'] {
     if (!ES.IsTemporalDateTime(this)) throw new TypeErrorCtor('invalid receiver');
-    const isoDate = ES.TemporalObjectToISODateRecord(this);
+    const isoDate = GetSlot(this, ISO_DATE_TIME).isoDate;
     return ES.calendarImplForObj(this).isoToDate(isoDate, { weekOfYear: true }).weekOfYear.week;
   }
   get yearOfWeek(): Return['yearOfWeek'] {
     if (!ES.IsTemporalDateTime(this)) throw new TypeErrorCtor('invalid receiver');
-    const isoDate = ES.TemporalObjectToISODateRecord(this);
+    const isoDate = GetSlot(this, ISO_DATE_TIME).isoDate;
     return ES.calendarImplForObj(this).isoToDate(isoDate, { weekOfYear: true }).weekOfYear.year;
   }
   get daysInWeek(): Return['daysInWeek'] {
     if (!ES.IsTemporalDateTime(this)) throw new TypeErrorCtor('invalid receiver');
-    const isoDate = ES.TemporalObjectToISODateRecord(this);
+    const isoDate = GetSlot(this, ISO_DATE_TIME).isoDate;
     return ES.calendarImplForObj(this).isoToDate(isoDate, { daysInWeek: true }).daysInWeek;
   }
   get daysInYear(): Return['daysInYear'] {
     if (!ES.IsTemporalDateTime(this)) throw new TypeErrorCtor('invalid receiver');
-    const isoDate = ES.TemporalObjectToISODateRecord(this);
+    const isoDate = GetSlot(this, ISO_DATE_TIME).isoDate;
     return ES.calendarImplForObj(this).isoToDate(isoDate, { daysInYear: true }).daysInYear;
   }
   get daysInMonth(): Return['daysInMonth'] {
     if (!ES.IsTemporalDateTime(this)) throw new TypeErrorCtor('invalid receiver');
-    const isoDate = ES.TemporalObjectToISODateRecord(this);
+    const isoDate = GetSlot(this, ISO_DATE_TIME).isoDate;
     return ES.calendarImplForObj(this).isoToDate(isoDate, { daysInMonth: true }).daysInMonth;
   }
   get monthsInYear(): Return['monthsInYear'] {
     if (!ES.IsTemporalDateTime(this)) throw new TypeErrorCtor('invalid receiver');
-    const isoDate = ES.TemporalObjectToISODateRecord(this);
+    const isoDate = GetSlot(this, ISO_DATE_TIME).isoDate;
     return ES.calendarImplForObj(this).isoToDate(isoDate, { monthsInYear: true }).monthsInYear;
   }
   get inLeapYear(): Return['inLeapYear'] {
     if (!ES.IsTemporalDateTime(this)) throw new TypeErrorCtor('invalid receiver');
-    const isoDate = ES.TemporalObjectToISODateRecord(this);
+    const isoDate = GetSlot(this, ISO_DATE_TIME).isoDate;
     return ES.calendarImplForObj(this).isoToDate(isoDate, { inLeapYear: true }).inLeapYear;
   }
   with(temporalDateTimeLike: Params['with'][0], options: Params['with'][1] = undefined): Return['with'] {
@@ -170,14 +151,15 @@ export class PlainDateTime implements Temporal.PlainDateTime {
     ES.RejectTemporalLikeObject(temporalDateTimeLike);
 
     const calendar = GetSlot(this, CALENDAR);
+    const isoDateTime = GetSlot(this, ISO_DATE_TIME);
     let fields = {
       ...ES.TemporalObjectToFields(this),
-      hour: GetSlot(this, ISO_HOUR),
-      minute: GetSlot(this, ISO_MINUTE),
-      second: GetSlot(this, ISO_SECOND),
-      millisecond: GetSlot(this, ISO_MILLISECOND),
-      microsecond: GetSlot(this, ISO_MICROSECOND),
-      nanosecond: GetSlot(this, ISO_NANOSECOND)
+      hour: isoDateTime.time.hour,
+      minute: isoDateTime.time.minute,
+      second: isoDateTime.time.second,
+      millisecond: isoDateTime.time.millisecond,
+      microsecond: isoDateTime.time.microsecond,
+      nanosecond: isoDateTime.time.nanosecond
     };
     const partialDateTime = ES.PrepareCalendarFields(
       calendar,
@@ -189,55 +171,22 @@ export class PlainDateTime implements Temporal.PlainDateTime {
     fields = ES.CalendarMergeFields(calendar, fields, partialDateTime);
 
     const overflow = ES.GetTemporalOverflowOption(ES.GetOptionsObject(options));
-    const {
-      isoDate: { year, month, day },
-      time: { hour, minute, second, millisecond, microsecond, nanosecond }
-    } = ES.InterpretTemporalDateTimeFields(calendar, fields, overflow);
-
-    return ES.CreateTemporalDateTime(
-      year,
-      month,
-      day,
-      hour,
-      minute,
-      second,
-      millisecond,
-      microsecond,
-      nanosecond,
-      calendar
-    );
+    const newDateTime = ES.InterpretTemporalDateTimeFields(calendar, fields, overflow);
+    return ES.CreateTemporalDateTime(newDateTime, calendar);
   }
   withPlainTime(temporalTimeParam: Params['withPlainTime'][0] = undefined): Return['withPlainTime'] {
     if (!ES.IsTemporalDateTime(this)) throw new TypeErrorCtor('invalid receiver');
     const temporalTime = ES.ToTemporalTimeOrMidnight(temporalTimeParam);
-    return ES.CreateTemporalDateTime(
-      GetSlot(this, ISO_YEAR),
-      GetSlot(this, ISO_MONTH),
-      GetSlot(this, ISO_DAY),
-      GetSlot(temporalTime, ISO_HOUR),
-      GetSlot(temporalTime, ISO_MINUTE),
-      GetSlot(temporalTime, ISO_SECOND),
-      GetSlot(temporalTime, ISO_MILLISECOND),
-      GetSlot(temporalTime, ISO_MICROSECOND),
-      GetSlot(temporalTime, ISO_NANOSECOND),
-      GetSlot(this, CALENDAR)
+    const isoDateTime = ES.CombineISODateAndTimeRecord(
+      GetSlot(this, ISO_DATE_TIME).isoDate,
+      GetSlot(temporalTime, TIME)
     );
+    return ES.CreateTemporalDateTime(isoDateTime, GetSlot(this, CALENDAR));
   }
   withCalendar(calendarParam: Params['withCalendar'][0]): Return['withCalendar'] {
     if (!ES.IsTemporalDateTime(this)) throw new TypeErrorCtor('invalid receiver');
     const calendar = ES.ToTemporalCalendarIdentifier(calendarParam);
-    return ES.CreateTemporalDateTime(
-      GetSlot(this, ISO_YEAR),
-      GetSlot(this, ISO_MONTH),
-      GetSlot(this, ISO_DAY),
-      GetSlot(this, ISO_HOUR),
-      GetSlot(this, ISO_MINUTE),
-      GetSlot(this, ISO_SECOND),
-      GetSlot(this, ISO_MILLISECOND),
-      GetSlot(this, ISO_MICROSECOND),
-      GetSlot(this, ISO_NANOSECOND),
-      calendar
-    );
+    return ES.CreateTemporalDateTime(GetSlot(this, ISO_DATE_TIME), calendar);
   }
   add(temporalDurationLike: Params['add'][0], options: Params['add'][1] = undefined): Return['add'] {
     if (!ES.IsTemporalDateTime(this)) throw new TypeErrorCtor('invalid receiver');
@@ -281,42 +230,18 @@ export class PlainDateTime implements Temporal.PlainDateTime {
     const inclusive = maximum === 1;
     ES.ValidateTemporalRoundingIncrement(roundingIncrement, maximum, inclusive);
 
-    const isoDateTime = ES.PlainDateTimeToISODateTimeRecord(this);
+    const isoDateTime = GetSlot(this, ISO_DATE_TIME);
     if (roundingIncrement === 1 && smallestUnit === 'nanosecond') {
-      return ES.CreateTemporalDateTime(
-        isoDateTime.isoDate.year,
-        isoDateTime.isoDate.month,
-        isoDateTime.isoDate.day,
-        isoDateTime.time.hour,
-        isoDateTime.time.minute,
-        isoDateTime.time.second,
-        isoDateTime.time.millisecond,
-        isoDateTime.time.microsecond,
-        isoDateTime.time.nanosecond,
-        GetSlot(this, CALENDAR)
-      );
+      return ES.CreateTemporalDateTime(isoDateTime, GetSlot(this, CALENDAR));
     }
     const result = ES.RoundISODateTime(isoDateTime, roundingIncrement, smallestUnit, roundingMode);
 
-    return ES.CreateTemporalDateTime(
-      result.isoDate.year,
-      result.isoDate.month,
-      result.isoDate.day,
-      result.time.hour,
-      result.time.minute,
-      result.time.second,
-      result.time.millisecond,
-      result.time.microsecond,
-      result.time.nanosecond,
-      GetSlot(this, CALENDAR)
-    );
+    return ES.CreateTemporalDateTime(result, GetSlot(this, CALENDAR));
   }
   equals(otherParam: Params['equals'][0]): Return['equals'] {
     if (!ES.IsTemporalDateTime(this)) throw new TypeErrorCtor('invalid receiver');
     const other = ES.ToTemporalDateTime(otherParam);
-    const isoDateTime = ES.PlainDateTimeToISODateTimeRecord(this);
-    const isoDateTimeOther = ES.PlainDateTimeToISODateTimeRecord(other);
-    if (ES.CompareISODateTime(isoDateTime, isoDateTimeOther) !== 0) return false;
+    if (ES.CompareISODateTime(GetSlot(this, ISO_DATE_TIME), GetSlot(other, ISO_DATE_TIME)) !== 0) return false;
     return ES.CalendarEquals(GetSlot(this, CALENDAR), GetSlot(other, CALENDAR));
   }
   toString(options: Params['toString'][0] = undefined): string {
@@ -328,14 +253,13 @@ export class PlainDateTime implements Temporal.PlainDateTime {
     const smallestUnit = ES.GetTemporalUnitValuedOption(resolvedOptions, 'smallestUnit', 'time', undefined);
     if (smallestUnit === 'hour') throw new RangeErrorCtor('smallestUnit must be a time unit other than "hour"');
     const { precision, unit, increment } = ES.ToSecondsStringPrecisionRecord(smallestUnit, digits);
-    const result = ES.RoundISODateTime(ES.PlainDateTimeToISODateTimeRecord(this), increment, unit, roundingMode);
+    const result = ES.RoundISODateTime(GetSlot(this, ISO_DATE_TIME), increment, unit, roundingMode);
     ES.RejectDateTimeRange(result);
     return ES.ISODateTimeToString(result, GetSlot(this, CALENDAR), precision, showCalendar);
   }
   toJSON(): Return['toJSON'] {
     if (!ES.IsTemporalDateTime(this)) throw new TypeErrorCtor('invalid receiver');
-    const isoDateTime = ES.PlainDateTimeToISODateTimeRecord(this);
-    return ES.ISODateTimeToString(isoDateTime, GetSlot(this, CALENDAR), 'auto');
+    return ES.ISODateTimeToString(GetSlot(this, ISO_DATE_TIME), GetSlot(this, CALENDAR), 'auto');
   }
   toLocaleString(
     locales: Params['toLocaleString'][0] = undefined,
@@ -356,17 +280,16 @@ export class PlainDateTime implements Temporal.PlainDateTime {
     const timeZone = ES.ToTemporalTimeZoneIdentifier(temporalTimeZoneLike);
     const resolvedOptions = ES.GetOptionsObject(options);
     const disambiguation = ES.GetTemporalDisambiguationOption(resolvedOptions);
-    const isoDateTime = ES.PlainDateTimeToISODateTimeRecord(this);
-    const epochNs = ES.GetEpochNanosecondsFor(timeZone, isoDateTime, disambiguation);
+    const epochNs = ES.GetEpochNanosecondsFor(timeZone, GetSlot(this, ISO_DATE_TIME), disambiguation);
     return ES.CreateTemporalZonedDateTime(epochNs, timeZone, GetSlot(this, CALENDAR));
   }
   toPlainDate(): Return['toPlainDate'] {
     if (!ES.IsTemporalDateTime(this)) throw new TypeErrorCtor('invalid receiver');
-    return ES.TemporalDateTimeToDate(this);
+    return ES.CreateTemporalDate(GetSlot(this, ISO_DATE_TIME).isoDate, GetSlot(this, CALENDAR));
   }
   toPlainTime(): Return['toPlainTime'] {
     if (!ES.IsTemporalDateTime(this)) throw new TypeErrorCtor('invalid receiver');
-    return ES.TemporalDateTimeToTime(this);
+    return ES.CreateTemporalTime(GetSlot(this, ISO_DATE_TIME).time);
   }
 
   static from(item: Params['from'][0], options: Params['from'][1] = undefined): Return['from'] {
@@ -375,9 +298,7 @@ export class PlainDateTime implements Temporal.PlainDateTime {
   static compare(oneParam: Params['compare'][0], twoParam: Params['compare'][1]): Return['compare'] {
     const one = ES.ToTemporalDateTime(oneParam);
     const two = ES.ToTemporalDateTime(twoParam);
-    const isoDateTime1 = ES.PlainDateTimeToISODateTimeRecord(one);
-    const isoDateTime2 = ES.PlainDateTimeToISODateTimeRecord(two);
-    return ES.CompareISODateTime(isoDateTime1, isoDateTime2);
+    return ES.CompareISODateTime(GetSlot(one, ISO_DATE_TIME), GetSlot(two, ISO_DATE_TIME));
   }
   [Symbol.toStringTag]!: 'Temporal.PlainDateTime';
 }

--- a/lib/plaindatetime.ts
+++ b/lib/plaindatetime.ts
@@ -386,17 +386,7 @@ export class PlainDateTime implements Temporal.PlainDateTime {
       unit,
       roundingMode
     );
-    ES.RejectDateTimeRange(
-      result.year,
-      result.month,
-      result.day,
-      result.hour,
-      result.minute,
-      result.second,
-      result.millisecond,
-      result.microsecond,
-      result.nanosecond
-    );
+    ES.RejectDateTimeRange(result);
     return ES.TemporalDateTimeToString(result, GetSlot(this, CALENDAR), precision, showCalendar);
   }
   toJSON(): Return['toJSON'] {

--- a/lib/plaindatetime.ts
+++ b/lib/plaindatetime.ts
@@ -153,7 +153,7 @@ export class PlainDateTime implements Temporal.PlainDateTime {
     const calendar = GetSlot(this, CALENDAR);
     const isoDateTime = GetSlot(this, ISO_DATE_TIME);
     let fields = {
-      ...ES.TemporalObjectToFields(this),
+      ...ES.ISODateToFields(calendar, isoDateTime.isoDate),
       hour: isoDateTime.time.hour,
       minute: isoDateTime.time.minute,
       second: isoDateTime.time.second,

--- a/lib/plainmonthday.ts
+++ b/lib/plainmonthday.ts
@@ -46,7 +46,7 @@ export class PlainMonthDay implements Temporal.PlainMonthDay {
     ES.RejectTemporalLikeObject(temporalMonthDayLike);
 
     const calendar = GetSlot(this, CALENDAR);
-    let fields = ES.TemporalObjectToFields(this);
+    let fields = ES.ISODateToFields(calendar, GetSlot(this, ISO_DATE), 'month-day');
     const partialMonthDay = ES.PrepareCalendarFields(
       calendar,
       temporalMonthDayLike,
@@ -91,7 +91,7 @@ export class PlainMonthDay implements Temporal.PlainMonthDay {
     if (!ES.IsObject(item)) throw new TypeError('argument should be an object');
     const calendar = GetSlot(this, CALENDAR);
 
-    const fields = ES.TemporalObjectToFields(this);
+    const fields = ES.ISODateToFields(calendar, GetSlot(this, ISO_DATE), 'month-day');
     const inputFields = ES.PrepareCalendarFields(calendar, item, ['year'], [], []);
     let mergedFields = ES.CalendarMergeFields(calendar, fields, inputFields);
     const isoDate = ES.CalendarDateFromFields(calendar, mergedFields, 'constrain');

--- a/lib/plaintime.ts
+++ b/lib/plaintime.ts
@@ -4,97 +4,55 @@ import {
   TypeError as TypeErrorCtor,
 
   // class static functions and methods
-  ArrayPrototypeEvery,
-  ObjectAssign,
-  ObjectDefineProperty,
-  SymbolToStringTag
+  ObjectAssign
 } from './primordials';
 
-import { DEBUG } from './debug';
 import * as ES from './ecmascript';
 import { MakeIntrinsicClass } from './intrinsicclass';
 
-import {
-  ISO_HOUR,
-  ISO_MINUTE,
-  ISO_SECOND,
-  ISO_MILLISECOND,
-  ISO_MICROSECOND,
-  ISO_NANOSECOND,
-  CreateSlots,
-  GetSlot,
-  SetSlot
-} from './slots';
+import { GetSlot, TIME } from './slots';
 import type { Temporal } from '..';
 import { DateTimeFormat } from './intl';
 import type { PlainTimeParams as Params, PlainTimeReturn as Return } from './internaltypes';
 
 export class PlainTime implements Temporal.PlainTime {
-  constructor(
-    isoHourParam = 0,
-    isoMinuteParam = 0,
-    isoSecondParam = 0,
-    isoMillisecondParam = 0,
-    isoMicrosecondParam = 0,
-    isoNanosecondParam = 0
-  ) {
-    const isoHour = isoHourParam === undefined ? 0 : ES.ToIntegerWithTruncation(isoHourParam);
-    const isoMinute = isoMinuteParam === undefined ? 0 : ES.ToIntegerWithTruncation(isoMinuteParam);
-    const isoSecond = isoSecondParam === undefined ? 0 : ES.ToIntegerWithTruncation(isoSecondParam);
-    const isoMillisecond = isoMillisecondParam === undefined ? 0 : ES.ToIntegerWithTruncation(isoMillisecondParam);
-    const isoMicrosecond = isoMicrosecondParam === undefined ? 0 : ES.ToIntegerWithTruncation(isoMicrosecondParam);
-    const isoNanosecond = isoNanosecondParam === undefined ? 0 : ES.ToIntegerWithTruncation(isoNanosecondParam);
+  constructor(isoHour = 0, isoMinute = 0, isoSecond = 0, isoMillisecond = 0, isoMicrosecond = 0, isoNanosecond = 0) {
+    const hour = isoHour === undefined ? 0 : ES.ToIntegerWithTruncation(isoHour);
+    const minute = isoMinute === undefined ? 0 : ES.ToIntegerWithTruncation(isoMinute);
+    const second = isoSecond === undefined ? 0 : ES.ToIntegerWithTruncation(isoSecond);
+    const millisecond = isoMillisecond === undefined ? 0 : ES.ToIntegerWithTruncation(isoMillisecond);
+    const microsecond = isoMicrosecond === undefined ? 0 : ES.ToIntegerWithTruncation(isoMicrosecond);
+    const nanosecond = isoNanosecond === undefined ? 0 : ES.ToIntegerWithTruncation(isoNanosecond);
 
-    ES.RejectTime(isoHour, isoMinute, isoSecond, isoMillisecond, isoMicrosecond, isoNanosecond);
-    CreateSlots(this);
-    SetSlot(this, ISO_HOUR, isoHour);
-    SetSlot(this, ISO_MINUTE, isoMinute);
-    SetSlot(this, ISO_SECOND, isoSecond);
-    SetSlot(this, ISO_MILLISECOND, isoMillisecond);
-    SetSlot(this, ISO_MICROSECOND, isoMicrosecond);
-    SetSlot(this, ISO_NANOSECOND, isoNanosecond);
+    ES.RejectTime(hour, minute, second, millisecond, microsecond, nanosecond);
+    const time = { hour, minute, second, millisecond, microsecond, nanosecond };
 
-    if (DEBUG) {
-      const time = {
-        hour: isoHour,
-        minute: isoMinute,
-        second: isoSecond,
-        millisecond: isoMillisecond,
-        microsecond: isoMicrosecond,
-        nanosecond: isoNanosecond
-      };
-      ObjectDefineProperty(this, '_repr_', {
-        value: `${this[SymbolToStringTag]} <${ES.TimeRecordToString(time, 'auto')}>`,
-        writable: false,
-        enumerable: false,
-        configurable: false
-      });
-    }
+    ES.CreateTemporalTimeSlots(this, time);
   }
 
   get hour(): Return['hour'] {
     if (!ES.IsTemporalTime(this)) throw new TypeErrorCtor('invalid receiver');
-    return GetSlot(this, ISO_HOUR);
+    return GetSlot(this, TIME).hour;
   }
   get minute(): Return['minute'] {
     if (!ES.IsTemporalTime(this)) throw new TypeErrorCtor('invalid receiver');
-    return GetSlot(this, ISO_MINUTE);
+    return GetSlot(this, TIME).minute;
   }
   get second(): Return['second'] {
     if (!ES.IsTemporalTime(this)) throw new TypeErrorCtor('invalid receiver');
-    return GetSlot(this, ISO_SECOND);
+    return GetSlot(this, TIME).second;
   }
   get millisecond(): Return['millisecond'] {
     if (!ES.IsTemporalTime(this)) throw new TypeErrorCtor('invalid receiver');
-    return GetSlot(this, ISO_MILLISECOND);
+    return GetSlot(this, TIME).millisecond;
   }
   get microsecond(): Return['microsecond'] {
     if (!ES.IsTemporalTime(this)) throw new TypeErrorCtor('invalid receiver');
-    return GetSlot(this, ISO_MICROSECOND);
+    return GetSlot(this, TIME).microsecond;
   }
   get nanosecond(): Return['nanosecond'] {
     if (!ES.IsTemporalTime(this)) throw new TypeErrorCtor('invalid receiver');
-    return GetSlot(this, ISO_NANOSECOND);
+    return GetSlot(this, TIME).nanosecond;
   }
 
   with(temporalTimeLike: Params['with'][0], options: Params['with'][1] = undefined): Return['with'] {
@@ -156,30 +114,13 @@ export class PlainTime implements Temporal.PlainTime {
     };
     ES.ValidateTemporalRoundingIncrement(roundingIncrement, MAX_INCREMENTS[smallestUnit], false);
 
-    const { hour, minute, second, millisecond, microsecond, nanosecond } = ES.RoundTime(
-      {
-        hour: GetSlot(this, ISO_HOUR),
-        minute: GetSlot(this, ISO_MINUTE),
-        second: GetSlot(this, ISO_SECOND),
-        millisecond: GetSlot(this, ISO_MILLISECOND),
-        microsecond: GetSlot(this, ISO_MICROSECOND),
-        nanosecond: GetSlot(this, ISO_NANOSECOND)
-      },
-      roundingIncrement,
-      smallestUnit,
-      roundingMode
-    );
-
-    return new PlainTime(hour, minute, second, millisecond, microsecond, nanosecond);
+    const time = ES.RoundTime(GetSlot(this, TIME), roundingIncrement, smallestUnit, roundingMode);
+    return ES.CreateTemporalTime(time);
   }
   equals(otherParam: Params['equals'][0]): Return['equals'] {
     if (!ES.IsTemporalTime(this)) throw new TypeErrorCtor('invalid receiver');
     const other = ES.ToTemporalTime(otherParam);
-    return ES.Call(
-      ArrayPrototypeEvery,
-      [ISO_HOUR, ISO_MINUTE, ISO_SECOND, ISO_MILLISECOND, ISO_MICROSECOND, ISO_NANOSECOND],
-      [(slot) => GetSlot(this, slot) === GetSlot(other, slot)]
-    );
+    return ES.CompareTimeRecord(GetSlot(this, TIME), GetSlot(other, TIME)) === 0;
   }
 
   toString(options: Params['toString'][0] = undefined): string {
@@ -190,32 +131,12 @@ export class PlainTime implements Temporal.PlainTime {
     const smallestUnit = ES.GetTemporalUnitValuedOption(resolvedOptions, 'smallestUnit', 'time', undefined);
     if (smallestUnit === 'hour') throw new RangeErrorCtor('smallestUnit must be a time unit other than "hour"');
     const { precision, unit, increment } = ES.ToSecondsStringPrecisionRecord(smallestUnit, digits);
-    const time = ES.RoundTime(
-      {
-        hour: GetSlot(this, ISO_HOUR),
-        minute: GetSlot(this, ISO_MINUTE),
-        second: GetSlot(this, ISO_SECOND),
-        millisecond: GetSlot(this, ISO_MILLISECOND),
-        microsecond: GetSlot(this, ISO_MICROSECOND),
-        nanosecond: GetSlot(this, ISO_NANOSECOND)
-      },
-      increment,
-      unit,
-      roundingMode
-    );
+    const time = ES.RoundTime(GetSlot(this, TIME), increment, unit, roundingMode);
     return ES.TimeRecordToString(time, precision);
   }
   toJSON(): Return['toJSON'] {
     if (!ES.IsTemporalTime(this)) throw new TypeErrorCtor('invalid receiver');
-    const time = {
-      hour: GetSlot(this, ISO_HOUR),
-      minute: GetSlot(this, ISO_MINUTE),
-      second: GetSlot(this, ISO_SECOND),
-      millisecond: GetSlot(this, ISO_MILLISECOND),
-      microsecond: GetSlot(this, ISO_MICROSECOND),
-      nanosecond: GetSlot(this, ISO_NANOSECOND)
-    };
-    return ES.TimeRecordToString(time, 'auto');
+    return ES.TimeRecordToString(GetSlot(this, TIME), 'auto');
   }
   toLocaleString(
     locales: Params['toLocaleString'][0] = undefined,
@@ -234,24 +155,7 @@ export class PlainTime implements Temporal.PlainTime {
   static compare(oneParam: Params['compare'][0], twoParam: Params['compare'][1]): Return['compare'] {
     const one = ES.ToTemporalTime(oneParam);
     const two = ES.ToTemporalTime(twoParam);
-    return ES.CompareTimeRecord(
-      {
-        hour: GetSlot(one, ISO_HOUR),
-        minute: GetSlot(one, ISO_MINUTE),
-        second: GetSlot(one, ISO_SECOND),
-        millisecond: GetSlot(one, ISO_MILLISECOND),
-        microsecond: GetSlot(one, ISO_MICROSECOND),
-        nanosecond: GetSlot(one, ISO_NANOSECOND)
-      },
-      {
-        hour: GetSlot(two, ISO_HOUR),
-        minute: GetSlot(two, ISO_MINUTE),
-        second: GetSlot(two, ISO_SECOND),
-        millisecond: GetSlot(two, ISO_MILLISECOND),
-        microsecond: GetSlot(two, ISO_MICROSECOND),
-        nanosecond: GetSlot(two, ISO_NANOSECOND)
-      }
-    );
+    return ES.CompareTimeRecord(GetSlot(one, TIME), GetSlot(two, TIME));
   }
   [Symbol.toStringTag]!: 'Temporal.PlainTime';
 }

--- a/lib/plaintime.ts
+++ b/lib/plaintime.ts
@@ -156,23 +156,19 @@ export class PlainTime implements Temporal.PlainTime {
     };
     ES.ValidateTemporalRoundingIncrement(roundingIncrement, MAX_INCREMENTS[smallestUnit], false);
 
-    let hour = GetSlot(this, ISO_HOUR);
-    let minute = GetSlot(this, ISO_MINUTE);
-    let second = GetSlot(this, ISO_SECOND);
-    let millisecond = GetSlot(this, ISO_MILLISECOND);
-    let microsecond = GetSlot(this, ISO_MICROSECOND);
-    let nanosecond = GetSlot(this, ISO_NANOSECOND);
-    ({ hour, minute, second, millisecond, microsecond, nanosecond } = ES.RoundTime(
-      hour,
-      minute,
-      second,
-      millisecond,
-      microsecond,
-      nanosecond,
+    const { hour, minute, second, millisecond, microsecond, nanosecond } = ES.RoundTime(
+      {
+        hour: GetSlot(this, ISO_HOUR),
+        minute: GetSlot(this, ISO_MINUTE),
+        second: GetSlot(this, ISO_SECOND),
+        millisecond: GetSlot(this, ISO_MILLISECOND),
+        microsecond: GetSlot(this, ISO_MICROSECOND),
+        nanosecond: GetSlot(this, ISO_NANOSECOND)
+      },
       roundingIncrement,
       smallestUnit,
       roundingMode
-    ));
+    );
 
     return new PlainTime(hour, minute, second, millisecond, microsecond, nanosecond);
   }
@@ -195,12 +191,14 @@ export class PlainTime implements Temporal.PlainTime {
     if (smallestUnit === 'hour') throw new RangeErrorCtor('smallestUnit must be a time unit other than "hour"');
     const { precision, unit, increment } = ES.ToSecondsStringPrecisionRecord(smallestUnit, digits);
     const time = ES.RoundTime(
-      GetSlot(this, ISO_HOUR),
-      GetSlot(this, ISO_MINUTE),
-      GetSlot(this, ISO_SECOND),
-      GetSlot(this, ISO_MILLISECOND),
-      GetSlot(this, ISO_MICROSECOND),
-      GetSlot(this, ISO_NANOSECOND),
+      {
+        hour: GetSlot(this, ISO_HOUR),
+        minute: GetSlot(this, ISO_MINUTE),
+        second: GetSlot(this, ISO_SECOND),
+        millisecond: GetSlot(this, ISO_MILLISECOND),
+        microsecond: GetSlot(this, ISO_MICROSECOND),
+        nanosecond: GetSlot(this, ISO_NANOSECOND)
+      },
       increment,
       unit,
       roundingMode

--- a/lib/plaintime.ts
+++ b/lib/plaintime.ts
@@ -236,19 +236,23 @@ export class PlainTime implements Temporal.PlainTime {
   static compare(oneParam: Params['compare'][0], twoParam: Params['compare'][1]): Return['compare'] {
     const one = ES.ToTemporalTime(oneParam);
     const two = ES.ToTemporalTime(twoParam);
-    return ES.CompareTemporalTime(
-      GetSlot(one, ISO_HOUR),
-      GetSlot(one, ISO_MINUTE),
-      GetSlot(one, ISO_SECOND),
-      GetSlot(one, ISO_MILLISECOND),
-      GetSlot(one, ISO_MICROSECOND),
-      GetSlot(one, ISO_NANOSECOND),
-      GetSlot(two, ISO_HOUR),
-      GetSlot(two, ISO_MINUTE),
-      GetSlot(two, ISO_SECOND),
-      GetSlot(two, ISO_MILLISECOND),
-      GetSlot(two, ISO_MICROSECOND),
-      GetSlot(two, ISO_NANOSECOND)
+    return ES.CompareTimeRecord(
+      {
+        hour: GetSlot(one, ISO_HOUR),
+        minute: GetSlot(one, ISO_MINUTE),
+        second: GetSlot(one, ISO_SECOND),
+        millisecond: GetSlot(one, ISO_MILLISECOND),
+        microsecond: GetSlot(one, ISO_MICROSECOND),
+        nanosecond: GetSlot(one, ISO_NANOSECOND)
+      },
+      {
+        hour: GetSlot(two, ISO_HOUR),
+        minute: GetSlot(two, ISO_MINUTE),
+        second: GetSlot(two, ISO_SECOND),
+        millisecond: GetSlot(two, ISO_MILLISECOND),
+        microsecond: GetSlot(two, ISO_MICROSECOND),
+        nanosecond: GetSlot(two, ISO_NANOSECOND)
+      }
     );
   }
   [Symbol.toStringTag]!: 'Temporal.PlainTime';

--- a/lib/plaintime.ts
+++ b/lib/plaintime.ts
@@ -29,43 +29,6 @@ import type { Temporal } from '..';
 import { DateTimeFormat } from './intl';
 import type { PlainTimeParams as Params, PlainTimeReturn as Return } from './internaltypes';
 
-type TemporalTimeToStringOptions = {
-  unit: ReturnType<typeof ES.ToSecondsStringPrecisionRecord>['unit'];
-  increment: ReturnType<typeof ES.ToSecondsStringPrecisionRecord>['increment'];
-  roundingMode: Temporal.RoundingMode;
-};
-
-function TemporalTimeToString(
-  time: Temporal.PlainTime,
-  precision: ReturnType<typeof ES.ToSecondsStringPrecisionRecord>['precision'],
-  options: TemporalTimeToStringOptions | undefined = undefined
-) {
-  let hour = GetSlot(time, ISO_HOUR);
-  let minute = GetSlot(time, ISO_MINUTE);
-  let second = GetSlot(time, ISO_SECOND);
-  let millisecond = GetSlot(time, ISO_MILLISECOND);
-  let microsecond = GetSlot(time, ISO_MICROSECOND);
-  let nanosecond = GetSlot(time, ISO_NANOSECOND);
-
-  if (options) {
-    const { unit, increment, roundingMode } = options;
-    ({ hour, minute, second, millisecond, microsecond, nanosecond } = ES.RoundTime(
-      hour,
-      minute,
-      second,
-      millisecond,
-      microsecond,
-      nanosecond,
-      increment,
-      unit,
-      roundingMode
-    ));
-  }
-
-  const subSecondNanoseconds = millisecond * 1e6 + microsecond * 1e3 + nanosecond;
-  return ES.FormatTimeString(hour, minute, second, subSecondNanoseconds, precision);
-}
-
 export class PlainTime implements Temporal.PlainTime {
   constructor(
     isoHourParam = 0,
@@ -92,8 +55,16 @@ export class PlainTime implements Temporal.PlainTime {
     SetSlot(this, ISO_NANOSECOND, isoNanosecond);
 
     if (DEBUG) {
+      const time = {
+        hour: isoHour,
+        minute: isoMinute,
+        second: isoSecond,
+        millisecond: isoMillisecond,
+        microsecond: isoMicrosecond,
+        nanosecond: isoNanosecond
+      };
       ObjectDefineProperty(this, '_repr_', {
-        value: `${this[SymbolToStringTag]} <${TemporalTimeToString(this, 'auto')}>`,
+        value: `${this[SymbolToStringTag]} <${ES.TimeRecordToString(time, 'auto')}>`,
         writable: false,
         enumerable: false,
         configurable: false
@@ -223,11 +194,30 @@ export class PlainTime implements Temporal.PlainTime {
     const smallestUnit = ES.GetTemporalUnitValuedOption(resolvedOptions, 'smallestUnit', 'time', undefined);
     if (smallestUnit === 'hour') throw new RangeErrorCtor('smallestUnit must be a time unit other than "hour"');
     const { precision, unit, increment } = ES.ToSecondsStringPrecisionRecord(smallestUnit, digits);
-    return TemporalTimeToString(this, precision, { unit, increment, roundingMode });
+    const time = ES.RoundTime(
+      GetSlot(this, ISO_HOUR),
+      GetSlot(this, ISO_MINUTE),
+      GetSlot(this, ISO_SECOND),
+      GetSlot(this, ISO_MILLISECOND),
+      GetSlot(this, ISO_MICROSECOND),
+      GetSlot(this, ISO_NANOSECOND),
+      increment,
+      unit,
+      roundingMode
+    );
+    return ES.TimeRecordToString(time, precision);
   }
   toJSON(): Return['toJSON'] {
     if (!ES.IsTemporalTime(this)) throw new TypeErrorCtor('invalid receiver');
-    return TemporalTimeToString(this, 'auto');
+    const time = {
+      hour: GetSlot(this, ISO_HOUR),
+      minute: GetSlot(this, ISO_MINUTE),
+      second: GetSlot(this, ISO_SECOND),
+      millisecond: GetSlot(this, ISO_MILLISECOND),
+      microsecond: GetSlot(this, ISO_MICROSECOND),
+      nanosecond: GetSlot(this, ISO_NANOSECOND)
+    };
+    return ES.TimeRecordToString(time, 'auto');
   }
   toLocaleString(
     locales: Params['toLocaleString'][0] = undefined,

--- a/lib/plainyearmonth.ts
+++ b/lib/plainyearmonth.ts
@@ -158,12 +158,8 @@ export class PlainYearMonth implements Temporal.PlainYearMonth {
     const one = ES.ToTemporalYearMonth(oneParam);
     const two = ES.ToTemporalYearMonth(twoParam);
     return ES.CompareISODate(
-      GetSlot(one, ISO_YEAR),
-      GetSlot(one, ISO_MONTH),
-      GetSlot(one, ISO_DAY),
-      GetSlot(two, ISO_YEAR),
-      GetSlot(two, ISO_MONTH),
-      GetSlot(two, ISO_DAY)
+      { year: GetSlot(one, ISO_YEAR), month: GetSlot(one, ISO_MONTH), day: GetSlot(one, ISO_DAY) },
+      { year: GetSlot(two, ISO_YEAR), month: GetSlot(two, ISO_MONTH), day: GetSlot(two, ISO_DAY) }
     );
   }
   [Symbol.toStringTag]!: 'Temporal.PlainYearMonth';

--- a/lib/plainyearmonth.ts
+++ b/lib/plainyearmonth.ts
@@ -79,7 +79,7 @@ export class PlainYearMonth implements Temporal.PlainYearMonth {
     ES.RejectTemporalLikeObject(temporalYearMonthLike);
 
     const calendar = GetSlot(this, CALENDAR);
-    let fields = ES.TemporalObjectToFields(this);
+    let fields = ES.ISODateToFields(calendar, GetSlot(this, ISO_DATE), 'year-month');
     const partialYearMonth = ES.PrepareCalendarFields(
       calendar,
       temporalYearMonthLike,
@@ -143,7 +143,7 @@ export class PlainYearMonth implements Temporal.PlainYearMonth {
     if (!ES.IsObject(item)) throw new TypeErrorCtor('argument should be an object');
     const calendar = GetSlot(this, CALENDAR);
 
-    const fields = ES.TemporalObjectToFields(this);
+    const fields = ES.ISODateToFields(calendar, GetSlot(this, ISO_DATE), 'year-month');
     const inputFields = ES.PrepareCalendarFields(calendar, item, ['day'], [], []);
     const mergedFields = ES.CalendarMergeFields(calendar, fields, inputFields);
     const isoDate = ES.CalendarDateFromFields(calendar, mergedFields, 'constrain');

--- a/lib/slots.ts
+++ b/lib/slots.ts
@@ -11,22 +11,23 @@ import {
 
 import type JSBI from 'jsbi';
 import type { Temporal } from '..';
-import type { BuiltinCalendarId, AnySlottedType, FormatterOrAmender } from './internaltypes';
+import type {
+  BuiltinCalendarId,
+  AnySlottedType,
+  FormatterOrAmender,
+  ISODate,
+  ISODateTime,
+  TimeRecord
+} from './internaltypes';
 import type { DateTimeFormatImpl } from './intl';
 
 // Instant
 export const EPOCHNANOSECONDS = 'slot-epochNanoSeconds';
 
 // DateTime, Date, Time, YearMonth, MonthDay
-export const ISO_YEAR = 'slot-year';
-export const ISO_MONTH = 'slot-month';
-export const ISO_DAY = 'slot-day';
-export const ISO_HOUR = 'slot-hour';
-export const ISO_MINUTE = 'slot-minute';
-export const ISO_SECOND = 'slot-second';
-export const ISO_MILLISECOND = 'slot-millisecond';
-export const ISO_MICROSECOND = 'slot-microsecond';
-export const ISO_NANOSECOND = 'slot-nanosecond';
+export const ISO_DATE = 'slot-iso-date';
+export const ISO_DATE_TIME = 'slot-iso-date-time';
+export const TIME = 'slot-time';
 export const CALENDAR = 'slot-calendar';
 // Date, YearMonth, and MonthDay all have the same slots, disambiguation needed:
 export const DATE_BRAND = 'slot-date-brand';
@@ -52,7 +53,7 @@ export const NANOSECONDS = 'slot-nanoseconds';
 export const DATE = 'date';
 export const YM = 'ym';
 export const MD = 'md';
-export const TIME = 'time';
+export const TIME_FMT = 'time';
 export const DATETIME = 'datetime';
 export const INST = 'instant';
 export const ORIGINAL = 'original';
@@ -76,15 +77,9 @@ interface Slots extends SlotInfoRecord {
   [EPOCHNANOSECONDS]: SlotInfo<JSBI, Temporal.Instant | Temporal.ZonedDateTime>; // number? JSBI?
 
   // DateTime, Date, Time, YearMonth, MonthDay
-  [ISO_YEAR]: SlotInfo<number, TypesWithCalendarUnits>;
-  [ISO_MONTH]: SlotInfo<number, TypesWithCalendarUnits>;
-  [ISO_DAY]: SlotInfo<number, TypesWithCalendarUnits>;
-  [ISO_HOUR]: SlotInfo<number, TypesWithCalendarUnits>;
-  [ISO_MINUTE]: SlotInfo<number, TypesWithCalendarUnits>;
-  [ISO_SECOND]: SlotInfo<number, TypesWithCalendarUnits>;
-  [ISO_MILLISECOND]: SlotInfo<number, TypesWithCalendarUnits>;
-  [ISO_MICROSECOND]: SlotInfo<number, TypesWithCalendarUnits>;
-  [ISO_NANOSECOND]: SlotInfo<number, TypesWithCalendarUnits>;
+  [ISO_DATE]: SlotInfo<ISODate, Temporal.PlainDate | Temporal.PlainMonthDay | Temporal.PlainYearMonth>;
+  [ISO_DATE_TIME]: SlotInfo<ISODateTime, Temporal.PlainDateTime>;
+  [TIME]: SlotInfo<TimeRecord, Temporal.PlainTime>;
   [CALENDAR]: SlotInfo<BuiltinCalendarId, TypesWithCalendarUnits>;
 
   // Date, YearMonth, MonthDay common slots
@@ -111,7 +106,7 @@ interface Slots extends SlotInfoRecord {
   [DATE]: SlotInfo<FormatterOrAmender, DateTimeFormatImpl>;
   [YM]: SlotInfo<FormatterOrAmender, DateTimeFormatImpl>;
   [MD]: SlotInfo<FormatterOrAmender, DateTimeFormatImpl>;
-  [TIME]: SlotInfo<FormatterOrAmender, DateTimeFormatImpl>;
+  [TIME_FMT]: SlotInfo<FormatterOrAmender, DateTimeFormatImpl>;
   [DATETIME]: SlotInfo<FormatterOrAmender, DateTimeFormatImpl>;
   [INST]: SlotInfo<FormatterOrAmender, DateTimeFormatImpl>;
   [ORIGINAL]: SlotInfo<globalThis.Intl.DateTimeFormat, DateTimeFormatImpl>;
@@ -125,7 +120,6 @@ interface Slots extends SlotInfoRecord {
 type TypesWithCalendarUnits =
   | Temporal.PlainDateTime
   | Temporal.PlainDate
-  | Temporal.PlainTime
   | Temporal.PlainYearMonth
   | Temporal.PlainMonthDay
   | Temporal.ZonedDateTime;
@@ -135,15 +129,9 @@ interface SlotsToTypes {
   [EPOCHNANOSECONDS]: Temporal.Instant;
 
   // DateTime, Date, Time, YearMonth, MonthDay
-  [ISO_YEAR]: TypesWithCalendarUnits;
-  [ISO_MONTH]: TypesWithCalendarUnits;
-  [ISO_DAY]: TypesWithCalendarUnits;
-  [ISO_HOUR]: TypesWithCalendarUnits;
-  [ISO_MINUTE]: TypesWithCalendarUnits;
-  [ISO_SECOND]: TypesWithCalendarUnits;
-  [ISO_MILLISECOND]: TypesWithCalendarUnits;
-  [ISO_MICROSECOND]: TypesWithCalendarUnits;
-  [ISO_NANOSECOND]: TypesWithCalendarUnits;
+  [ISO_DATE]: Temporal.PlainDate | Temporal.PlainYearMonth | Temporal.PlainMonthDay;
+  [ISO_DATE_TIME]: Temporal.PlainDateTime;
+  [TIME]: Temporal.PlainTime;
   [CALENDAR]: TypesWithCalendarUnits;
 
   // Date, YearMonth, MonthDay common slots
@@ -170,7 +158,7 @@ interface SlotsToTypes {
   [DATE]: DateTimeFormatImpl;
   [YM]: DateTimeFormatImpl;
   [MD]: DateTimeFormatImpl;
-  [TIME]: DateTimeFormatImpl;
+  [TIME_FMT]: DateTimeFormatImpl;
   [DATETIME]: DateTimeFormatImpl;
   [INST]: DateTimeFormatImpl;
   [ORIGINAL]: DateTimeFormatImpl;

--- a/lib/zoneddatetime.ts
+++ b/lib/zoneddatetime.ts
@@ -344,15 +344,7 @@ export class ZonedDateTime implements Temporal.ZonedDateTime {
       // smallestUnit < day
       // Round based on ISO-calendar time units
       const { year, month, day, hour, minute, second, millisecond, microsecond, nanosecond } = ES.RoundISODateTime(
-        iso.year,
-        iso.month,
-        iso.day,
-        iso.hour,
-        iso.minute,
-        iso.second,
-        iso.millisecond,
-        iso.microsecond,
-        iso.nanosecond,
+        iso,
         roundingIncrement,
         smallestUnit,
         roundingMode

--- a/lib/zoneddatetime.ts
+++ b/lib/zoneddatetime.ts
@@ -10,18 +10,7 @@ import {
 import { assert } from './assert';
 import * as ES from './ecmascript';
 import { GetIntrinsic, MakeIntrinsicClass } from './intrinsicclass';
-import {
-  CALENDAR,
-  EPOCHNANOSECONDS,
-  ISO_HOUR,
-  ISO_MICROSECOND,
-  ISO_MILLISECOND,
-  ISO_MINUTE,
-  ISO_NANOSECOND,
-  ISO_SECOND,
-  TIME_ZONE,
-  GetSlot
-} from './slots';
+import { CALENDAR, EPOCHNANOSECONDS, TIME, TIME_ZONE, GetSlot } from './slots';
 import { TimeDuration } from './timeduration';
 import type { Temporal } from '..';
 import { DateTimeFormat } from './intl';
@@ -237,15 +226,7 @@ export class ZonedDateTime implements Temporal.ZonedDateTime {
       epochNs = ES.GetStartOfDay(timeZone, iso);
     } else {
       const temporalTime = ES.ToTemporalTime(temporalTimeParam);
-      const time = {
-        hour: GetSlot(temporalTime, ISO_HOUR),
-        minute: GetSlot(temporalTime, ISO_MINUTE),
-        second: GetSlot(temporalTime, ISO_SECOND),
-        millisecond: GetSlot(temporalTime, ISO_MILLISECOND),
-        microsecond: GetSlot(temporalTime, ISO_MICROSECOND),
-        nanosecond: GetSlot(temporalTime, ISO_NANOSECOND)
-      };
-      const dt = ES.CombineISODateAndTimeRecord(iso, time);
+      const dt = ES.CombineISODateAndTimeRecord(iso, GetSlot(temporalTime, TIME));
       epochNs = ES.GetEpochNanosecondsFor(timeZone, dt, 'compatible');
     }
     return ES.CreateTemporalZonedDateTime(epochNs, timeZone, calendar);
@@ -496,32 +477,15 @@ export class ZonedDateTime implements Temporal.ZonedDateTime {
   }
   toPlainDate(): Return['toPlainDate'] {
     if (!ES.IsTemporalZonedDateTime(this)) throw new TypeErrorCtor('invalid receiver');
-    const {
-      isoDate: { year, month, day }
-    } = dateTime(this);
-    return ES.CreateTemporalDate(year, month, day, GetSlot(this, CALENDAR));
+    return ES.CreateTemporalDate(dateTime(this).isoDate, GetSlot(this, CALENDAR));
   }
   toPlainTime(): Return['toPlainTime'] {
     if (!ES.IsTemporalZonedDateTime(this)) throw new TypeErrorCtor('invalid receiver');
-    const { hour, minute, second, millisecond, microsecond, nanosecond } = dateTime(this).time;
-    const PlainTime = GetIntrinsic('%Temporal.PlainTime%');
-    return new PlainTime(hour, minute, second, millisecond, microsecond, nanosecond);
+    return ES.CreateTemporalTime(dateTime(this).time);
   }
   toPlainDateTime(): Return['toPlainDateTime'] {
     if (!ES.IsTemporalZonedDateTime(this)) throw new TypeErrorCtor('invalid receiver');
-    const isoDateTime = dateTime(this);
-    return ES.CreateTemporalDateTime(
-      isoDateTime.isoDate.year,
-      isoDateTime.isoDate.month,
-      isoDateTime.isoDate.day,
-      isoDateTime.time.hour,
-      isoDateTime.time.minute,
-      isoDateTime.time.second,
-      isoDateTime.time.millisecond,
-      isoDateTime.time.microsecond,
-      isoDateTime.time.nanosecond,
-      GetSlot(this, CALENDAR)
-    );
+    return ES.CreateTemporalDateTime(dateTime(this), GetSlot(this, CALENDAR));
   }
 
   static from(item: Params['from'][0], optionsParam: Params['from'][1] = undefined): Return['from'] {

--- a/lib/zoneddatetime.ts
+++ b/lib/zoneddatetime.ts
@@ -213,9 +213,7 @@ export class ZonedDateTime implements Temporal.ZonedDateTime {
     const newDateTime = ES.InterpretTemporalDateTimeFields(calendar, fields, overflow);
     const newOffsetNs = ES.ParseDateTimeUTCOffset(fields.offset);
     const epochNanoseconds = ES.InterpretISODateTimeOffset(
-      newDateTime.isoDate.year,
-      newDateTime.isoDate.month,
-      newDateTime.isoDate.day,
+      newDateTime.isoDate,
       newDateTime.time,
       'option',
       newOffsetNs,
@@ -351,9 +349,7 @@ export class ZonedDateTime implements Temporal.ZonedDateTime {
       // disambiguation algorithm will be used.
       const offsetNs = ES.GetOffsetNanosecondsFor(timeZone, thisNs);
       epochNanoseconds = ES.InterpretISODateTimeOffset(
-        roundedDateTime.isoDate.year,
-        roundedDateTime.isoDate.month,
-        roundedDateTime.isoDate.day,
+        roundedDateTime.isoDate,
         roundedDateTime.time,
         'option',
         offsetNs,

--- a/lib/zoneddatetime.ts
+++ b/lib/zoneddatetime.ts
@@ -64,51 +64,51 @@ export class ZonedDateTime implements Temporal.ZonedDateTime {
   }
   get year(): Return['year'] {
     if (!ES.IsTemporalZonedDateTime(this)) throw new TypeErrorCtor('invalid receiver');
-    return ES.calendarImplForObj(this).isoToDate(date(this), { year: true }).year;
+    return ES.calendarImplForObj(this).isoToDate(dateTime(this).isoDate, { year: true }).year;
   }
   get month(): Return['month'] {
     if (!ES.IsTemporalZonedDateTime(this)) throw new TypeErrorCtor('invalid receiver');
-    return ES.calendarImplForObj(this).isoToDate(date(this), { month: true }).month;
+    return ES.calendarImplForObj(this).isoToDate(dateTime(this).isoDate, { month: true }).month;
   }
   get monthCode(): Return['monthCode'] {
     if (!ES.IsTemporalZonedDateTime(this)) throw new TypeErrorCtor('invalid receiver');
-    return ES.calendarImplForObj(this).isoToDate(date(this), { monthCode: true }).monthCode;
+    return ES.calendarImplForObj(this).isoToDate(dateTime(this).isoDate, { monthCode: true }).monthCode;
   }
   get day(): Return['day'] {
     if (!ES.IsTemporalZonedDateTime(this)) throw new TypeErrorCtor('invalid receiver');
-    return ES.calendarImplForObj(this).isoToDate(date(this), { day: true }).day;
+    return ES.calendarImplForObj(this).isoToDate(dateTime(this).isoDate, { day: true }).day;
   }
   get hour(): Return['hour'] {
     if (!ES.IsTemporalZonedDateTime(this)) throw new TypeErrorCtor('invalid receiver');
-    return dateTime(this).hour;
+    return dateTime(this).time.hour;
   }
   get minute(): Return['minute'] {
     if (!ES.IsTemporalZonedDateTime(this)) throw new TypeErrorCtor('invalid receiver');
-    return dateTime(this).minute;
+    return dateTime(this).time.minute;
   }
   get second(): Return['second'] {
     if (!ES.IsTemporalZonedDateTime(this)) throw new TypeErrorCtor('invalid receiver');
-    return dateTime(this).second;
+    return dateTime(this).time.second;
   }
   get millisecond(): Return['millisecond'] {
     if (!ES.IsTemporalZonedDateTime(this)) throw new TypeErrorCtor('invalid receiver');
-    return dateTime(this).millisecond;
+    return dateTime(this).time.millisecond;
   }
   get microsecond(): Return['microsecond'] {
     if (!ES.IsTemporalZonedDateTime(this)) throw new TypeErrorCtor('invalid receiver');
-    return dateTime(this).microsecond;
+    return dateTime(this).time.microsecond;
   }
   get nanosecond(): Return['nanosecond'] {
     if (!ES.IsTemporalZonedDateTime(this)) throw new TypeErrorCtor('invalid receiver');
-    return dateTime(this).nanosecond;
+    return dateTime(this).time.nanosecond;
   }
   get era(): Return['era'] {
     if (!ES.IsTemporalZonedDateTime(this)) throw new TypeErrorCtor('invalid receiver');
-    return ES.calendarImplForObj(this).isoToDate(date(this), { era: true }).era;
+    return ES.calendarImplForObj(this).isoToDate(dateTime(this).isoDate, { era: true }).era;
   }
   get eraYear(): Return['eraYear'] {
     if (!ES.IsTemporalZonedDateTime(this)) throw new TypeErrorCtor('invalid receiver');
-    return ES.calendarImplForObj(this).isoToDate(date(this), { eraYear: true }).eraYear;
+    return ES.calendarImplForObj(this).isoToDate(dateTime(this).isoDate, { eraYear: true }).eraYear;
   }
   get epochMilliseconds(): Return['epochMilliseconds'] {
     if (!ES.IsTemporalZonedDateTime(this)) throw new TypeErrorCtor('invalid receiver');
@@ -121,24 +121,24 @@ export class ZonedDateTime implements Temporal.ZonedDateTime {
   }
   get dayOfWeek(): Return['dayOfWeek'] {
     if (!ES.IsTemporalZonedDateTime(this)) throw new TypeErrorCtor('invalid receiver');
-    return ES.calendarImplForObj(this).isoToDate(date(this), { dayOfWeek: true }).dayOfWeek;
+    return ES.calendarImplForObj(this).isoToDate(dateTime(this).isoDate, { dayOfWeek: true }).dayOfWeek;
   }
   get dayOfYear(): Return['dayOfYear'] {
     if (!ES.IsTemporalZonedDateTime(this)) throw new TypeErrorCtor('invalid receiver');
-    return ES.calendarImplForObj(this).isoToDate(date(this), { dayOfYear: true }).dayOfYear;
+    return ES.calendarImplForObj(this).isoToDate(dateTime(this).isoDate, { dayOfYear: true }).dayOfYear;
   }
   get weekOfYear(): Return['weekOfYear'] {
     if (!ES.IsTemporalZonedDateTime(this)) throw new TypeErrorCtor('invalid receiver');
-    return ES.calendarImplForObj(this).isoToDate(date(this), { weekOfYear: true }).weekOfYear.week;
+    return ES.calendarImplForObj(this).isoToDate(dateTime(this).isoDate, { weekOfYear: true }).weekOfYear.week;
   }
   get yearOfWeek(): Return['yearOfWeek'] {
     if (!ES.IsTemporalZonedDateTime(this)) throw new TypeErrorCtor('invalid receiver');
-    return ES.calendarImplForObj(this).isoToDate(date(this), { weekOfYear: true }).weekOfYear.year;
+    return ES.calendarImplForObj(this).isoToDate(dateTime(this).isoDate, { weekOfYear: true }).weekOfYear.year;
   }
   get hoursInDay(): Return['hoursInDay'] {
     if (!ES.IsTemporalZonedDateTime(this)) throw new TypeErrorCtor('invalid receiver');
     const timeZone = GetSlot(this, TIME_ZONE);
-    const today = date(this);
+    const today = dateTime(this).isoDate;
     const tomorrow = ES.BalanceISODate(today.year, today.month, today.day + 1);
     const todayNs = ES.GetStartOfDay(timeZone, today);
     const tomorrowNs = ES.GetStartOfDay(timeZone, tomorrow);
@@ -147,23 +147,23 @@ export class ZonedDateTime implements Temporal.ZonedDateTime {
   }
   get daysInWeek(): Return['daysInWeek'] {
     if (!ES.IsTemporalZonedDateTime(this)) throw new TypeErrorCtor('invalid receiver');
-    return ES.calendarImplForObj(this).isoToDate(date(this), { daysInWeek: true }).daysInWeek;
+    return ES.calendarImplForObj(this).isoToDate(dateTime(this).isoDate, { daysInWeek: true }).daysInWeek;
   }
   get daysInMonth(): Return['daysInMonth'] {
     if (!ES.IsTemporalZonedDateTime(this)) throw new TypeErrorCtor('invalid receiver');
-    return ES.calendarImplForObj(this).isoToDate(date(this), { daysInMonth: true }).daysInMonth;
+    return ES.calendarImplForObj(this).isoToDate(dateTime(this).isoDate, { daysInMonth: true }).daysInMonth;
   }
   get daysInYear(): Return['daysInYear'] {
     if (!ES.IsTemporalZonedDateTime(this)) throw new TypeErrorCtor('invalid receiver');
-    return ES.calendarImplForObj(this).isoToDate(date(this), { daysInYear: true }).daysInYear;
+    return ES.calendarImplForObj(this).isoToDate(dateTime(this).isoDate, { daysInYear: true }).daysInYear;
   }
   get monthsInYear(): Return['monthsInYear'] {
     if (!ES.IsTemporalZonedDateTime(this)) throw new TypeErrorCtor('invalid receiver');
-    return ES.calendarImplForObj(this).isoToDate(date(this), { monthsInYear: true }).monthsInYear;
+    return ES.calendarImplForObj(this).isoToDate(dateTime(this).isoDate, { monthsInYear: true }).monthsInYear;
   }
   get inLeapYear(): Return['inLeapYear'] {
     if (!ES.IsTemporalZonedDateTime(this)) throw new TypeErrorCtor('invalid receiver');
-    return ES.calendarImplForObj(this).isoToDate(date(this), { inLeapYear: true }).inLeapYear;
+    return ES.calendarImplForObj(this).isoToDate(dateTime(this).isoDate, { inLeapYear: true }).inLeapYear;
   }
   get offset(): Return['offset'] {
     if (!ES.IsTemporalZonedDateTime(this)) throw new TypeErrorCtor('invalid receiver');
@@ -186,15 +186,14 @@ export class ZonedDateTime implements Temporal.ZonedDateTime {
     const epochNs = GetSlot(this, EPOCHNANOSECONDS);
     const offsetNs = ES.GetOffsetNanosecondsFor(timeZone, epochNs);
     const isoDateTime = dateTime(this);
-    const isoDate = ES.ISODateTimeToDateRecord(isoDateTime);
     let fields = {
-      ...ES.ISODateToFields(calendar, isoDate),
-      hour: isoDateTime.hour,
-      minute: isoDateTime.minute,
-      second: isoDateTime.second,
-      millisecond: isoDateTime.millisecond,
-      microsecond: isoDateTime.microsecond,
-      nanosecond: isoDateTime.nanosecond,
+      ...ES.ISODateToFields(calendar, isoDateTime.isoDate),
+      hour: isoDateTime.time.hour,
+      minute: isoDateTime.time.minute,
+      second: isoDateTime.time.second,
+      millisecond: isoDateTime.time.millisecond,
+      microsecond: isoDateTime.time.microsecond,
+      nanosecond: isoDateTime.time.nanosecond,
       offset: ES.FormatUTCOffsetNanoseconds(offsetNs)
     };
     const partialZonedDateTime = ES.PrepareCalendarFields(
@@ -211,13 +210,13 @@ export class ZonedDateTime implements Temporal.ZonedDateTime {
     const offset = ES.GetTemporalOffsetOption(resolvedOptions, 'prefer');
     const overflow = ES.GetTemporalOverflowOption(resolvedOptions);
 
-    const { year, month, day, time } = ES.InterpretTemporalDateTimeFields(calendar, fields, overflow);
+    const newDateTime = ES.InterpretTemporalDateTimeFields(calendar, fields, overflow);
     const newOffsetNs = ES.ParseDateTimeUTCOffset(fields.offset);
     const epochNanoseconds = ES.InterpretISODateTimeOffset(
-      year,
-      month,
-      day,
-      time,
+      newDateTime.isoDate.year,
+      newDateTime.isoDate.month,
+      newDateTime.isoDate.day,
+      newDateTime.time,
       'option',
       newOffsetNs,
       timeZone,
@@ -233,7 +232,7 @@ export class ZonedDateTime implements Temporal.ZonedDateTime {
 
     const timeZone = GetSlot(this, TIME_ZONE);
     const calendar = GetSlot(this, CALENDAR);
-    const iso = date(this);
+    const iso = dateTime(this).isoDate;
 
     let epochNs;
     if (temporalTimeParam === undefined) {
@@ -322,7 +321,7 @@ export class ZonedDateTime implements Temporal.ZonedDateTime {
     if (smallestUnit === 'day') {
       // Compute Instants for start-of-day and end-of-day
       // Determine how far the current instant has progressed through this span.
-      const dateStart = ES.ISODateTimeToDateRecord(iso);
+      const dateStart = iso.isoDate;
       const dateEnd = ES.BalanceISODate(dateStart.year, dateStart.month, dateStart.day + 1);
 
       const startNs = ES.GetStartOfDay(timeZone, dateStart);
@@ -343,12 +342,7 @@ export class ZonedDateTime implements Temporal.ZonedDateTime {
     } else {
       // smallestUnit < day
       // Round based on ISO-calendar time units
-      const { year, month, day, hour, minute, second, millisecond, microsecond, nanosecond } = ES.RoundISODateTime(
-        iso,
-        roundingIncrement,
-        smallestUnit,
-        roundingMode
-      );
+      const roundedDateTime = ES.RoundISODateTime(iso, roundingIncrement, smallestUnit, roundingMode);
 
       // Now reset all DateTime fields but leave the TimeZone. The offset will
       // also be retained if the new date/time values are still OK with the old
@@ -357,10 +351,10 @@ export class ZonedDateTime implements Temporal.ZonedDateTime {
       // disambiguation algorithm will be used.
       const offsetNs = ES.GetOffsetNanosecondsFor(timeZone, thisNs);
       epochNanoseconds = ES.InterpretISODateTimeOffset(
-        year,
-        month,
-        day,
-        { hour, minute, second, millisecond, microsecond, nanosecond },
+        roundedDateTime.isoDate.year,
+        roundedDateTime.isoDate.month,
+        roundedDateTime.isoDate.day,
+        roundedDateTime.time,
         'option',
         offsetNs,
         timeZone,
@@ -471,7 +465,7 @@ export class ZonedDateTime implements Temporal.ZonedDateTime {
   startOfDay(): Return['startOfDay'] {
     if (!ES.IsTemporalZonedDateTime(this)) throw new TypeErrorCtor('invalid receiver');
     const timeZone = GetSlot(this, TIME_ZONE);
-    const isoDate = date(this);
+    const isoDate = dateTime(this).isoDate;
     const epochNanoseconds = ES.GetStartOfDay(timeZone, isoDate);
     return ES.CreateTemporalZonedDateTime(epochNanoseconds, timeZone, GetSlot(this, CALENDAR));
   }
@@ -506,12 +500,14 @@ export class ZonedDateTime implements Temporal.ZonedDateTime {
   }
   toPlainDate(): Return['toPlainDate'] {
     if (!ES.IsTemporalZonedDateTime(this)) throw new TypeErrorCtor('invalid receiver');
-    const { year, month, day } = dateTime(this);
+    const {
+      isoDate: { year, month, day }
+    } = dateTime(this);
     return ES.CreateTemporalDate(year, month, day, GetSlot(this, CALENDAR));
   }
   toPlainTime(): Return['toPlainTime'] {
     if (!ES.IsTemporalZonedDateTime(this)) throw new TypeErrorCtor('invalid receiver');
-    const { hour, minute, second, millisecond, microsecond, nanosecond } = dateTime(this);
+    const { hour, minute, second, millisecond, microsecond, nanosecond } = dateTime(this).time;
     const PlainTime = GetIntrinsic('%Temporal.PlainTime%');
     return new PlainTime(hour, minute, second, millisecond, microsecond, nanosecond);
   }
@@ -519,15 +515,15 @@ export class ZonedDateTime implements Temporal.ZonedDateTime {
     if (!ES.IsTemporalZonedDateTime(this)) throw new TypeErrorCtor('invalid receiver');
     const isoDateTime = dateTime(this);
     return ES.CreateTemporalDateTime(
-      isoDateTime.year,
-      isoDateTime.month,
-      isoDateTime.day,
-      isoDateTime.hour,
-      isoDateTime.minute,
-      isoDateTime.second,
-      isoDateTime.millisecond,
-      isoDateTime.microsecond,
-      isoDateTime.nanosecond,
+      isoDateTime.isoDate.year,
+      isoDateTime.isoDate.month,
+      isoDateTime.isoDate.day,
+      isoDateTime.time.hour,
+      isoDateTime.time.minute,
+      isoDateTime.time.second,
+      isoDateTime.time.millisecond,
+      isoDateTime.time.microsecond,
+      isoDateTime.time.nanosecond,
       GetSlot(this, CALENDAR)
     );
   }
@@ -551,8 +547,4 @@ MakeIntrinsicClass(ZonedDateTime, 'Temporal.ZonedDateTime');
 
 function dateTime(zdt: Temporal.ZonedDateTime) {
   return ES.GetISODateTimeFor(GetSlot(zdt, TIME_ZONE), GetSlot(zdt, EPOCHNANOSECONDS));
-}
-
-function date(zdt: Temporal.ZonedDateTime) {
-  return ES.ISODateTimeToDateRecord(dateTime(zdt));
 }

--- a/test/ecmascript.mjs
+++ b/test/ecmascript.mjs
@@ -378,7 +378,7 @@ describe('ECMAScript', () => {
       });
     });
 
-    function test(nanos, zone, expected) {
+    function test(nanos, zone, { year, month, day, hour, minute, second, millisecond, microsecond, nanosecond }) {
       // Internally, we represent BigInt as JSBI instances. JSBI instances are
       // not interchangeable with native BigInt, so we must convert them first.
       // Normally, this would have been done upstream by another part of the
@@ -386,7 +386,10 @@ describe('ECMAScript', () => {
       // we must convert in the test instead.
       const nanosAsBigIntInternal = ES.ToBigInt(nanos);
       it(`${nanos} @ ${zone}`, () =>
-        deepEqual(ES.GetNamedTimeZoneDateTimeParts(zone, nanosAsBigIntInternal), expected));
+        deepEqual(ES.GetNamedTimeZoneDateTimeParts(zone, nanosAsBigIntInternal), {
+          isoDate: { year, month, day },
+          time: { deltaDays: 0, hour, minute, second, millisecond, microsecond, nanosecond }
+        }));
     }
   });
 

--- a/test/validStrings.mjs
+++ b/test/validStrings.mjs
@@ -504,9 +504,7 @@ function fuzzMode(mode) {
     try {
       const parsingMethod = ES[`ParseTemporal${mode}StringRaw`] ?? ES[`ParseTemporal${mode}String`];
       const parsed = parsingMethod(fuzzed);
-      if (parsed.time === 'start-of-day') {
-        parsed.time = { hour: 0, minute: 0, second: 0, millisecond: 0, microsecond: 0, nanosecond: 0 };
-      }
+      if (parsed.time === 'start-of-day') parsed.time = ES.MidnightTimeRecord();
       if (parsed.time) Object.assign(parsed, parsed.time);
       for (let prop of comparisonItems[mode]) {
         let expected = generatedData[prop];


### PR DESCRIPTION
Here is a batch of commits from October 2024 all dealing with refactoring the way ISO Date-Time Records are used in the spec. It made the spec text more concise, so should do the same with this JS code. (Net -1k lines)