### PR TITLE
Minify function names in prod builds

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@js-temporal/polyfill",
-  "version": "0.4.4",
+  "version": "0.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@js-temporal/polyfill",
-      "version": "0.4.4",
+      "version": "0.5.0",
       "license": "ISC",
       "dependencies": {
         "jsbi": "^4.3.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@rollup/plugin-commonjs": "^25.0.0",
         "@rollup/plugin-node-resolve": "^15.1.0",
         "@rollup/plugin-replace": "^5.0.2",
+        "@rollup/plugin-strip": "^3.0.4",
         "@rollup/plugin-terser": "^0.4.3",
         "@rollup/plugin-typescript": "^11.1.1",
         "@typescript-eslint/eslint-plugin": "^5.59.9",
@@ -1903,10 +1904,11 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.4.14",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
-      "dev": true
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
+      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.25",
@@ -2140,6 +2142,39 @@
         "rollup": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@rollup/plugin-strip": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-strip/-/plugin-strip-3.0.4.tgz",
+      "integrity": "sha512-LDRV49ZaavxUo2YoKKMQjCxzCxugu1rCPQa0lDYBOWLj6vtzBMr8DcoJjsmg+s450RbKbe3qI9ZLaSO+O1oNbg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rollup/pluginutils": "^5.0.1",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.30.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/plugin-strip/node_modules/magic-string": {
+      "version": "0.30.17",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
+      "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0"
       }
     },
     "node_modules/@rollup/plugin-terser": {
@@ -6269,9 +6304,9 @@
       }
     },
     "@jridgewell/sourcemap-codec": {
-      "version": "1.4.14",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
+      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
       "dev": true
     },
     "@jridgewell/trace-mapping": {
@@ -6433,6 +6468,28 @@
       "requires": {
         "@rollup/pluginutils": "^5.0.2",
         "magic-string": "^0.27.0"
+      }
+    },
+    "@rollup/plugin-strip": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-strip/-/plugin-strip-3.0.4.tgz",
+      "integrity": "sha512-LDRV49ZaavxUo2YoKKMQjCxzCxugu1rCPQa0lDYBOWLj6vtzBMr8DcoJjsmg+s450RbKbe3qI9ZLaSO+O1oNbg==",
+      "dev": true,
+      "requires": {
+        "@rollup/pluginutils": "^5.0.2",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.30.3"
+      },
+      "dependencies": {
+        "magic-string": {
+          "version": "0.30.17",
+          "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
+          "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
+          "dev": true,
+          "requires": {
+            "@jridgewell/sourcemap-codec": "^1.5.0"
+          }
+        }
       }
     },
     "@rollup/plugin-terser": {

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "@rollup/plugin-commonjs": "^25.0.0",
     "@rollup/plugin-node-resolve": "^15.1.0",
     "@rollup/plugin-replace": "^5.0.2",
+    "@rollup/plugin-strip": "^3.0.4",
     "@rollup/plugin-terser": "^0.4.3",
     "@rollup/plugin-typescript": "^11.1.1",
     "@typescript-eslint/eslint-plugin": "^5.59.9",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -25,7 +25,8 @@ function withPlugins(
     babelConfig: undefined,
     optimize: false,
     debugBuild: true,
-    enableAssertions: true
+    enableAssertions: true,
+    minifyNames: false
   }
 ) {
   const basePlugins = [
@@ -56,16 +57,17 @@ function withPlugins(
     basePlugins.push(
       terser({
         keep_classnames: true,
-        keep_fnames: true,
+        keep_fnames: !options.minifyNames,
         ecma: 2015,
         compress: {
           keep_fargs: true,
           keep_classnames: true,
-          keep_fnames: true
+          keep_fnames: !options.minifyNames,
+          passes: 2
         },
         mangle: {
           keep_classnames: true,
-          keep_fnames: true
+          keep_fnames: !options.minifyNames
         }
       })
     );
@@ -159,7 +161,8 @@ if (isTest262Build) {
     plugins: withPlugins({
       debugBuild: !isProduction,
       enableAssertions: !isProduction,
-      optimize: isProduction
+      optimize: isProduction,
+      minifyNames: isProduction
       // Here is where we could insert the JSBI -> native BigInt plugin if we
       // could find a way to provide a separate bundle for modern browsers
       // that can use native BigInt.

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -2,6 +2,7 @@ import commonjs from '@rollup/plugin-commonjs';
 import nodeResolve from '@rollup/plugin-node-resolve';
 import babel from '@rollup/plugin-babel';
 import replace from '@rollup/plugin-replace';
+import strip from '@rollup/plugin-strip';
 import terser from '@rollup/plugin-terser';
 import sourcemaps from 'rollup-plugin-sourcemaps';
 import { env } from 'process';
@@ -43,6 +44,13 @@ function withPlugins(
       options.babelConfig.inputSourceMap = true;
     }
     basePlugins.push(babel(options.babelConfig));
+  }
+  if (!options.enableAssertions) {
+    basePlugins.push(
+      strip({
+        functions: ['assert', 'assertNotReached', 'assertExists', 'ES.assertExists']
+      })
+    );
   }
   if (options.optimize) {
     basePlugins.push(


### PR DESCRIPTION
Changex rollup's `keep_fnames` option from `true` to `false`.

My understanding is that this option will minify function names, for example the often-long internal exports in `ecmascript.ts`.

This change (and a minor change to run terser's compression 2x to save 85 bytes) reduces minified & gzipped size of `dist/index.cjs` to 36.3K. (a 3.7K reduction). ESM reductions are similar. I didn't apply this optimization to ES5 UMD builds because it caused all ES5 Test262 tests for `Temporal.prototype.*.name` to fail. 