### PR TITLE
Support Node 22 & 23

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -90,6 +90,15 @@ overrides:
     rules:
       no-param-reassign: off
   - files:
+      - '*.json'
+    rules:
+      quotes:
+        - error
+        - double
+      quote-props: off
+      max-len: off
+      semi: off
+  - files:
       - '**/*.ts'
     plugins:
       - '@typescript-eslint'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [20.x, 18.x, 16.x, 14.x]
+        version: [23.x, 22.x, 20.x, 18.x, 16.x, 14.x]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [20.x, 18.x, 16.x, 14.x]
+        version: [23.x, 22.x, 20.x, 18.x, 16.x, 14.x]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -41,7 +41,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [20.x, 18.x, 16.x, 14.x]
+        version: [23.x, 22.x, 20.x, 18.x, 16.x, 14.x]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -59,7 +59,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [20.x, 18.x, 16.x, 14.x]
+        version: [23.x, 22.x, 20.x, 18.x, 16.x, 14.x]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -78,10 +78,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: use node.js v20.x
+      - name: use node.js v22.x
         uses: actions/setup-node@v3
         with:
-          node-version: 20.x
+          node-version: 22.x
       - run: npm ci
       - run: |
           npm ci

--- a/lib/intl.ts
+++ b/lib/intl.ts
@@ -162,13 +162,13 @@ function createDateTimeFormat(
     SetSlot(dtf, TZ_ORIGINAL, ro.timeZone);
   } else {
     const id = ES.ToString(timeZoneOption);
-    if (ES.IsOffsetTimeZoneIdentifier(id)) {
-      // Note: https://github.com/tc39/ecma402/issues/683 will remove this
-      throw new RangeError('Intl.DateTimeFormat does not currently support offset time zones');
+    if (id.startsWith('−')) {
+      // The initial (Node 23) implementation of offset time zones allowed use
+      // of the Unicode minus sign, which was disallowed by a later spec change.
+      throw new RangeError('Unicode minus (U+2212) is not supported in time zone offsets');
     }
-    const record = ES.GetAvailableNamedTimeZoneIdentifier(id);
-    if (!record) throw new RangeError(`Intl.DateTimeFormat formats built-in time zones, not ${id}`);
-    SetSlot(dtf, TZ_ORIGINAL, record.identifier);
+    // store a normalized identifier
+    SetSlot(dtf, TZ_ORIGINAL, ES.ToTemporalTimeZoneIdentifier(id));
   }
   return undefined; // TODO: I couldn't satisfy TS without adding this. Is there another way?
 }

--- a/lib/intl.ts
+++ b/lib/intl.ts
@@ -734,6 +734,9 @@ function temporalDurationToCompatibilityRecord(duration: Temporal.Duration) {
   return record;
 }
 
+const { format: IntlDurationFormatPrototypeFormat, formatToParts: IntlDurationFormatPrototypeFormatToParts } =
+  Intl.DurationFormat?.prototype ?? Object.create(null);
+
 export function ModifiedIntlDurationFormatPrototypeFormat(
   this: Intl.DurationFormat,
   durationLike: Temporal.DurationLike
@@ -741,7 +744,7 @@ export function ModifiedIntlDurationFormatPrototypeFormat(
   Intl.DurationFormat.prototype.resolvedOptions.call(this); // brand check
   const duration = ES.ToTemporalDuration(durationLike);
   const record = temporalDurationToCompatibilityRecord(duration);
-  return this.format(record);
+  return IntlDurationFormatPrototypeFormat.call(this, record);
 }
 
 if (Intl.DurationFormat?.prototype) {
@@ -750,6 +753,6 @@ if (Intl.DurationFormat?.prototype) {
     Intl.DurationFormat.prototype.resolvedOptions.call(this); // brand check
     const duration = ES.ToTemporalDuration(durationLike);
     const record = temporalDurationToCompatibilityRecord(duration);
-    return this.formatToParts(record);
+    return IntlDurationFormatPrototypeFormatToParts.call(this, record);
   };
 }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "types": "./index.d.ts",
   "scripts": {
     "test": "npm run build && node --no-warnings --experimental-modules --experimental-specifier-resolution=node --icu-data-dir node_modules/full-icu --loader ./test/resolve.source.mjs ./test/all.mjs",
-    "test262": "TEST262=1 npm run build && TIMEOUT=60000 node runtest262.mjs \"$@\"",
+    "test262": "TEST262=1 npm run build && node runtest262.mjs \"$@\"",
     "testValidStrings": "npm run build && node --experimental-modules --experimental-specifier-resolution=node --no-warnings --icu-data-dir ./node_modules/full-icu/ --loader ./test/resolve.source.mjs test/validStrings.mjs",
     "build": "rm -rf dist/* tsc-out/* && tsc && rollup -c rollup.config.js --bundleConfigAsCjs",
     "prepare": "npm run build",

--- a/runtest262.mjs
+++ b/runtest262.mjs
@@ -31,9 +31,10 @@ yargs(hideBin(process.argv))
       if (nodeVersion < 18) expectedFailureFiles.push('test/expected-failures-before-node18.txt');
       if (nodeVersion < 16) expectedFailureFiles.push('test/expected-failures-before-node16.txt');
       if (nodeVersion < 20) expectedFailureFiles.push('test/expected-failures-before-node20.txt');
+      if (nodeVersion < 22) expectedFailureFiles.push('test/expected-failures-before-node22.txt');
+      if (nodeVersion < 23) expectedFailureFiles.push('test/expected-failures-before-node23.txt');
       // Eventually this should be fixed and this condition should be updated.
       if (nodeVersion >= 18) expectedFailureFiles.push('test/expected-failures-cldr42.txt');
-      if (nodeVersion >= 20) expectedFailureFiles.push('test/expected-failures-cldr46.txt');
 
       // As we migrate commits from proposal-temporal, remove expected failures from here.
       expectedFailureFiles.push('test/expected-failures-todo-migrated-code.txt');

--- a/runtest262.mjs
+++ b/runtest262.mjs
@@ -5,7 +5,7 @@ import { hideBin } from 'yargs/helpers';
 
 const isProduction = process.env.NODE_ENV === 'production';
 const isTranspiledBuild = !!process.env.TRANSPILE;
-const timeoutMsecs = process.env.TIMEOUT || 30000;
+const timeoutMsecs = process.env.TIMEOUT || 60000;
 
 yargs(hideBin(process.argv))
   .command(

--- a/test/expected-failures-before-node22.txt
+++ b/test/expected-failures-before-node22.txt
@@ -1,0 +1,8 @@
+# Fails until CLDR 46 (released 2024-10-24) makes its way into a Node.js release
+staging/Intl402/Temporal/old/non-iso-calendars.js
+
+# These rely on Intl.DateTimeFormat supporting offset time zones.
+intl402/DateTimeFormat/prototype/format/offset-timezone-gmt-same.js
+intl402/DateTimeFormat/prototype/formatToParts/offset-timezone-correct.js
+intl402/DateTimeFormat/prototype/resolvedOptions/offset-timezone-basic.js
+intl402/DateTimeFormat/prototype/resolvedOptions/offset-timezone-change.js

--- a/test/expected-failures-before-node23.txt
+++ b/test/expected-failures-before-node23.txt
@@ -1,0 +1,12 @@
+# Fails until Intl.DurationFormat available in Node.js release
+intl402/DurationFormat/prototype/format/taint-temporal-duration-prototype.js
+intl402/DurationFormat/prototype/format/temporal-duration-object-arg.js
+intl402/DurationFormat/prototype/format/temporal-duration-string-arg.js
+intl402/DurationFormat/prototype/formatToParts/taint-temporal-duration-prototype.js
+intl402/DurationFormat/prototype/formatToParts/temporal-duration-object-arg.js
+intl402/DurationFormat/prototype/formatToParts/temporal-duration-string-arg.js
+intl402/Temporal/Duration/prototype/toLocaleString/returns-same-results-as-DurationFormat.js
+
+# A regression in V8 (https://issues.chromium.org/issues/40893567) caused
+# these tests to fail before Node 23.
+intl402/DateTimeFormat/prototype/format/timedatestyle-en.js

--- a/test/expected-failures-cldr42.txt
+++ b/test/expected-failures-cldr42.txt
@@ -10,4 +10,3 @@ staging/Intl402/Temporal/old/datetime-toLocaleString.js
 staging/Intl402/Temporal/old/instant-toLocaleString.js
 staging/Intl402/Temporal/old/time-toLocaleString.js
 intl402/DateTimeFormat/prototype/format/temporal-objects-resolved-time-zone.js
-intl402/DateTimeFormat/prototype/format/timedatestyle-en.js

--- a/test/expected-failures-cldr46.txt
+++ b/test/expected-failures-cldr46.txt
@@ -1,6 +1,0 @@
-# Failures in this file are expected to fail for all Test262 tests. To record
-# expected test failures for the transpiled or optimized builds of the polyfill,
-# see expected-failures-es5.txt and expected-failures-opt.txt respectively.
-
-# CLDR 46 / ICU 76.1 was backported to Node 20.19 LTS
-staging/Intl402/Temporal/old/non-iso-calendars.js

--- a/test/expected-failures.txt
+++ b/test/expected-failures.txt
@@ -6,21 +6,12 @@
 # canonicalizing the timezone name.
 staging/Intl402/Temporal/old/date-time-format.js
 
-# temporal-test262-runner doesn't support the $262 global object
-intl402/DateTimeFormat/proto-from-ctor-realm.js
-
 # These are caught by the default test glob, but are unrelated to Temporal.
 # They rely on Intl.DateTimeFormat supporting offset time zones.
 intl402/DateTimeFormat/prototype/format/offset-timezone-gmt-same.js
 intl402/DateTimeFormat/prototype/formatToParts/offset-timezone-correct.js
 intl402/DateTimeFormat/prototype/resolvedOptions/offset-timezone-basic.js
 intl402/DateTimeFormat/prototype/resolvedOptions/offset-timezone-change.js
-
-# https://github.com/tc39/ecma402/issues/402
-intl402/DateTimeFormat/prototype/resolvedOptions/hourCycle-default.js
-
-# Fails until CLDR 46 (released 2024-10-24) makes its way into a Node.js release
-staging/Intl402/Temporal/old/non-iso-calendars.js
 
 # https://github.com/tc39/test262/pull/4336
 intl402/DateTimeFormat/canonicalize-utc-timezone.js
@@ -36,12 +27,3 @@ staging/sm/Temporal/PlainDate/from-islamic-umalqura.js
 # Faulty leap month calculations in Chinese calendar in ICU4C
 # https://unicode-org.atlassian.net/browse/ICU-22230
 staging/sm/Temporal/PlainMonthDay/from-chinese-leap-month-uncommon.js
-
-# Fails until Intl.DurationFormat available in Node.js release
-intl402/DurationFormat/prototype/format/taint-temporal-duration-prototype.js
-intl402/DurationFormat/prototype/format/temporal-duration-object-arg.js
-intl402/DurationFormat/prototype/format/temporal-duration-string-arg.js
-intl402/DurationFormat/prototype/formatToParts/taint-temporal-duration-prototype.js
-intl402/DurationFormat/prototype/formatToParts/temporal-duration-object-arg.js
-intl402/DurationFormat/prototype/formatToParts/temporal-duration-string-arg.js
-intl402/Temporal/Duration/prototype/toLocaleString/returns-same-results-as-DurationFormat.js

--- a/test/expected-failures.txt
+++ b/test/expected-failures.txt
@@ -6,13 +6,6 @@
 # canonicalizing the timezone name.
 staging/Intl402/Temporal/old/date-time-format.js
 
-# These are caught by the default test glob, but are unrelated to Temporal.
-# They rely on Intl.DateTimeFormat supporting offset time zones.
-intl402/DateTimeFormat/prototype/format/offset-timezone-gmt-same.js
-intl402/DateTimeFormat/prototype/formatToParts/offset-timezone-correct.js
-intl402/DateTimeFormat/prototype/resolvedOptions/offset-timezone-basic.js
-intl402/DateTimeFormat/prototype/resolvedOptions/offset-timezone-change.js
-
 # https://github.com/tc39/test262/pull/4336
 intl402/DateTimeFormat/canonicalize-utc-timezone.js
 


### PR DESCRIPTION
Support Node 22 & 23. In addition to changing expected failures files for bugs that Node fixed, there were two Node changes that required polyfill code changes:
* Now that Node 22 supports offset time zones in Intl.DTF, we needed to stop throwing when these IDs were supplied, and we needed to guard against U+2212 (unicode minus) in offset time zone IDs because Node doesn't catch these (yet).
* Node 23 adds `Intl.DurationFormat`, and this PR fixes an infinite recursive loop (accidentally introduced in 19b00b2) that occurred if a native `Intl.DurationFormat` was present.

Fixes #323.