### PR TITLE
Fix type of DurationFormatOptions.localeMatcher

### DIFF
--- a/lib/durationformat.d.ts
+++ b/lib/durationformat.d.ts
@@ -10,7 +10,7 @@ declare namespace Intl {
   type DurationDisplay = 'auto' | 'always';
 
   interface DurationFormatOptions {
-    localeMatcher?: 'best fit' | 'basic' | undefined;
+    localeMatcher?: 'best fit' | 'lookup' | undefined;
     numberingSystem?: string | undefined;
     style?: 'long' | 'short' | 'narrow' | 'digital' | undefined;
     years?: DurationCalendarUnitStyle | undefined;


### PR DESCRIPTION
I misread the spec text when I wrote this type definition, it should be `lookup` and not `basic`.