### PR TITLE
Update test262

### DIFF
--- a/test/expected-failures-before-node16.txt
+++ b/test/expected-failures-before-node16.txt
@@ -7,26 +7,6 @@ intl402/Temporal/PlainTime/prototype/toLocaleString/options-conflict.js
 intl402/Temporal/PlainYearMonth/prototype/toLocaleString/options-conflict.js
 intl402/Temporal/ZonedDateTime/prototype/toLocaleString/options-conflict.js
 
-# Tests using Object.hasOwn which is not available in Node 14
-intl402/Temporal/PlainDate/from/calendar-not-supporting-eras.js
-intl402/Temporal/PlainDate/from/canonicalize-era-codes.js
-intl402/Temporal/PlainDate/from/remapping-era.js
-intl402/Temporal/PlainDate/prototype/with/gregorian-mutually-exclusive-fields.js
-intl402/Temporal/PlainDate/prototype/with/japanese-mutually-exclusive-fields.js
-intl402/Temporal/PlainDateTime/from/calendar-not-supporting-eras.js
-intl402/Temporal/PlainDateTime/from/canonicalize-era-codes.js
-intl402/Temporal/PlainYearMonth/from/argument-object.js
-intl402/Temporal/PlainYearMonth/from/calendar-not-supporting-eras.js
-intl402/Temporal/PlainYearMonth/from/canonicalize-era-codes.js
-intl402/Temporal/PlainYearMonth/from/reference-day-chinese.js
-intl402/Temporal/PlainYearMonth/from/reference-day-gregory.js
-intl402/Temporal/PlainYearMonth/from/reference-day-hebrew.js
-intl402/Temporal/PlainYearMonth/from/remapping-era.js
-intl402/Temporal/PlainYearMonth/prototype/with/minimum-valid-year-month.js
-intl402/Temporal/ZonedDateTime/construct-non-utc-non-iso.js
-intl402/Temporal/ZonedDateTime/supported-values-of.js
-staging/Intl402/Temporal/old/japanese-era.js
-
 # Bug where -u-ca- in locale identifier is not honored
 built-ins/Temporal/PlainMonthDay/prototype/toLocaleString/return-string.js
 built-ins/Temporal/PlainYearMonth/prototype/toLocaleString/return-string.js


### PR DESCRIPTION
I removed usage of Object.hasOwn from the era helper, which means these tests should pass now on old Node runtimes that don't have it.