### PR TITLE
fix: add updated era codes to EthiopicHelper

### DIFF
--- a/lib/calendar.ts
+++ b/lib/calendar.ts
@@ -1934,8 +1934,13 @@ class CopticHelper extends OrthodoxBaseHelper {
 class EthiopicHelper extends OrthodoxBaseHelper {
   constructor() {
     super('ethiopic', [
-      { code: 'ethioaa', names: ['ethiopic-amete-alem', 'mundi'], isoEpoch: { year: -5492, month: 7, day: 17 } },
-      { code: 'ethiopic', names: ['incar'], isoEpoch: { year: 8, month: 8, day: 27 }, anchorEpoch: { year: 5501 } }
+      { code: 'ethioaa', names: ['ethiopic-amete-alem', 'mundi', 'aa'], isoEpoch: { year: -5492, month: 7, day: 17 } },
+      {
+        code: 'ethiopic',
+        names: ['incar', 'am'],
+        isoEpoch: { year: 8, month: 8, day: 27 },
+        anchorEpoch: { year: 5501 }
+      }
     ]);
   }
 }


### PR DESCRIPTION
This adds the updated era codes for Ethiopic calendar to reflect the updates in CLDR48 https://cldr.unicode.org/downloads/cldr-48#identifiers

Dealing with Ethiopian calendars started failing in the polyfill in versions of node after 20.19 (and after recent browser updates in Firefox) as ICU updated the era codes: https://unicode-org.atlassian.net/browse/ICU-23167. In the polyfill code, the `ecamscript` module seems to delegate to call the `calendar` module passing the updated era code, but the `calendar` module then can't match the era code failing with `RangeError: Era am (ISO year 2016) was not matched by any era`. 

We observed the failure on CI first as node updated the ICU, but then it started failing on Firefox after an update. It currently works on Chrome stable, but fails with the same error on Canary: https://developers.dhis2.org/demo/?path=/story/calendarinput--ethiopic-with-amharic
