### PR TITLE
April 2026 rebase, part 3

### DIFF
--- a/lib/calendar.ts
+++ b/lib/calendar.ts
@@ -1411,7 +1411,9 @@ class HebrewHelper extends HelperBase {
     // Given that these can be calculated by counting the number of days in
     // those months, I assume that these DO NOT need to be exposed as
     // Hebrew-only prototype fields or methods.
-    return (7 * year + 1) % 19 < 7;
+    let cycleYear = (7 * year + 1) % 19;
+    if (cycleYear < 0) cycleYear += 19;
+    return cycleYear < 7;
   }
   monthsInYear(calendarDate: CalendarYearOnly) {
     return this.inLeapYear(calendarDate) ? 13 : 12;

--- a/lib/calendar.ts
+++ b/lib/calendar.ts
@@ -2190,7 +2190,7 @@ abstract class ChineseBaseHelper extends HelperBase {
     const { month, year } = calendarDate;
     const matchingMonthEntry = this.getMonthList(year, cache)[month];
     if (matchingMonthEntry === undefined) {
-      throw new RangeError(`Invalid month ${month} in Chinese year ${year}`);
+      throw new RangeError(`Invalid month ${month} in ${this.id} year ${year}`);
     }
     return matchingMonthEntry.daysInMonth;
   }
@@ -2339,7 +2339,7 @@ abstract class ChineseBaseHelper extends HelperBase {
       const months = this.getMonthList(year, cache);
       month = months[monthCode];
       if (month === undefined) {
-        throw new RangeError(`Unmatched month ${month}${monthExtra || ''} in Chinese year ${year}`);
+        throw new RangeError(`Unmatched month ${month}${monthExtra || ''} in ${this.id} year ${year}`);
       }
       return { year, month, day: day as number, monthCode };
     } else {
@@ -2359,7 +2359,7 @@ abstract class ChineseBaseHelper extends HelperBase {
           monthCode = adjustedMonthCode;
         }
         if (month === undefined) {
-          throw new RangeError(`Unmatched month ${monthCode} in Chinese year ${year}`);
+          throw new RangeError(`Unmatched month ${monthCode} in ${this.id} year ${year}`);
         }
       } else if (monthCode === undefined) {
         const months = this.getMonthList(year, cache);
@@ -2373,15 +2373,17 @@ abstract class ChineseBaseHelper extends HelperBase {
         }
         monthCode = months[month].monthCode;
         if (monthCode === undefined) {
-          throw new RangeError(`Invalid month ${month} in Chinese year ${year}`);
+          throw new RangeError(`Invalid month ${month} in ${this.id} year ${year}`);
         }
       } else {
         // Both month and monthCode are present. Make sure they don't conflict.
         const months = this.getMonthList(year, cache);
         const monthIndex = months[monthCode];
-        if (!monthIndex) throw new RangeError(`Unmatched monthCode ${monthCode} in Chinese year ${year}`);
+        if (!monthIndex) throw new RangeError(`Unmatched monthCode ${monthCode} in ${this.id} year ${year}`);
         if (month !== monthIndex) {
-          throw new RangeError(`monthCode ${monthCode} doesn't correspond to month ${month} in Chinese year ${year}`);
+          throw new RangeError(
+            `monthCode ${monthCode} doesn't correspond to month ${month} in ${this.id} year ${year}`
+          );
         }
       }
       return { ...calendarDate, year, month, monthCode, day: day as number };

--- a/lib/calendar.ts
+++ b/lib/calendar.ts
@@ -1151,7 +1151,7 @@ abstract class HelperBase {
       years += cycleCount * cycleInfo.years;
       months %= cycleInfo.months;
     }
-    const addedYears = this.adjustCalendarDate({ year: year + years, monthCode, day }, cache);
+    const addedYears = this.adjustCalendarDate({ year: year + years, monthCode, day }, cache, overflow);
     const addedMonths = this.addMonthsCalendar(addedYears, months, overflow, cache);
     const initialDays = days + weeks * 7;
     const addedDays = this.addDaysCalendar(addedMonths, initialDays, cache);

--- a/lib/calendar.ts
+++ b/lib/calendar.ts
@@ -730,7 +730,9 @@ abstract class HelperBase {
         }
       }
       if (type === 'month') {
-        const matches = /^([0-9]*)(.*?)$/.exec(value);
+        // Newer ICU data has some formats with "Mo11" / "Mo9bis" for Chinese
+        // and Dangi months
+        const matches = /^(?:Mo)?([0-9]*)(.*?)$/.exec(value);
         if (!matches || matches.length != 3 || (!matches[1] && !matches[2])) {
           throw new RangeError(`Unexpected month: ${value}`);
         }
@@ -2266,7 +2268,11 @@ abstract class ChineseBaseHelper extends HelperBase {
         if (type === 'day' || type === ('relatedYear' as Intl.DateTimeFormatPartTypes)) {
           calendarFields[type as 'day' | 'relatedYear'] = +value;
         } else if (type === 'month') {
-          calendarFields.monthString = value;
+          if (value.startsWith('Mo')) {
+            calendarFields.monthString = value.slice(2);
+          } else {
+            calendarFields.monthString = value;
+          }
         }
       }
       if (calendarFields.relatedYear === undefined) {

--- a/lib/calendar.ts
+++ b/lib/calendar.ts
@@ -2434,7 +2434,20 @@ class NonIsoCalendar implements CalendarImpl {
     }
     return [];
   }
-  resolveFields(fields: CalendarFieldsRecord /* , type */) {
+  resolveFields<Type extends ISODateToFieldsType>(
+    fields: CalendarFieldsRecord,
+    type: Type
+  ): asserts fields is ResolveFieldsReturn<Type> {
+    if ((type === 'date' || type === 'year-month') && fields.year === undefined) {
+      if (!CalendarSupportsEra(this.helper.id)) {
+        throw new TypeError('year is required');
+      } else if (fields.era === undefined || fields.eraYear === undefined) {
+        throw new TypeError('year (or era and eraYear) are required');
+      }
+    }
+    if ((type === 'date' || type === 'month-day') && fields.day === undefined) {
+      throw new TypeError('day is required');
+    }
     if (this.helper.calendarType !== 'lunisolar') {
       resolveNonLunisolarMonth(fields, this.helper.id);
     }

--- a/lib/calendar.ts
+++ b/lib/calendar.ts
@@ -1720,8 +1720,9 @@ class IndianHelper extends HelperBase {
   // calendar output to fail for all dates before 0001-01-01 ISO.  For example,
   // in Node 12 0000-01-01 is calculated as 6146/12/-583 instead of 10/11/-79 as
   // expected.
-  vulnerableToBceBug =
-    new Date('0000-01-01T00:00Z').toLocaleDateString('en-US-u-ca-indian', { timeZone: 'UTC' }) !== '10/11/-79 Saka';
+  vulnerableToBceBug = !new Date('0000-01-01T00:00Z')
+    .toLocaleDateString('en-US-u-ca-indian', { timeZone: 'UTC' })
+    .startsWith('10/11/-79');
   override checkIcuBugs(isoDate: ISODate) {
     if (this.vulnerableToBceBug && isoDate.year < 1) {
       throw new RangeError(

--- a/lib/calendar.ts
+++ b/lib/calendar.ts
@@ -1598,6 +1598,7 @@ abstract class IslamicBaseHelper extends HelperBase {
     super(eraData);
   }
   abstract override id: BuiltinCalendarId;
+  abstract tabular: boolean;
   calendarType = 'lunar' as const;
   inLeapYear(calendarDate: CalendarYearOnly, cache: OneObjectCache) {
     const startOfYearCalendar = { year: calendarDate.year, month: 1, monthCode: 'M01', day: 1 };
@@ -1614,8 +1615,10 @@ abstract class IslamicBaseHelper extends HelperBase {
   maximumMonthLength(/* calendarDate */) {
     return 30;
   }
-  maxLengthOfMonthCodeInAnyYear(/* monthCode */) {
-    return 30;
+  maxLengthOfMonthCodeInAnyYear(monthCode: string) {
+    if (!this.tabular) return 30; // if observational, any month can have 29 or 30 days
+    const month = ParseMonthCode(monthCode).monthNumber;
+    return [0, 30, 29, 30, 29, 30, 29, 30, 29, 30, 29, 30, 30][month];
   }
   DAYS_PER_ISLAMIC_YEAR = 354 + 11 / 30;
   DAYS_PER_ISO_YEAR = 365.2425;
@@ -1631,24 +1634,28 @@ abstract class IslamicBaseHelper extends HelperBase {
 // is identical.
 class IslamicUmalquraHelper extends IslamicBaseHelper {
   id = 'islamic-umalqura' as const;
+  tabular = false;
   constructor() {
     super(20);
   }
 }
 class IslamicTblaHelper extends IslamicBaseHelper {
   id = 'islamic-tbla' as const;
+  tabular = true;
   constructor() {
     super(19);
   }
 }
 class IslamicCivilHelper extends IslamicBaseHelper {
   id = 'islamic-civil' as const;
+  tabular = true;
   constructor() {
     super(20);
   }
 }
 class IslamicCcHelper extends IslamicBaseHelper {
   id = 'islamicc' as const;
+  tabular = true;
   constructor() {
     super(20);
   }

--- a/lib/calendar.ts
+++ b/lib/calendar.ts
@@ -2044,7 +2044,7 @@ abstract class OrthodoxBaseHelper extends GregorianBaseHelper {
 //   two use negative year numbers before epoch)
 // - Coptic has a different epoch date
 // - Ethiopic has an additional second era that starts at the same date as the
-//   zero era of ethioaa.
+//   zero era of ethioaa, which is the anchor era
 class EthioaaHelper extends OrthodoxBaseHelper {
   constructor() {
     super('ethioaa', [{ code: 'aa', isoEpoch: { year: -5492, month: 7, day: 17 } }]);
@@ -2066,13 +2066,11 @@ class CopticHelper extends OrthodoxBaseHelper {
   }
 }
 
-// Anchor is currently the older era to match ethioaa, but should it be the newer era?
-// See https://github.com/tc39/ecma402/issues/534 for discussion.
 class EthiopicHelper extends OrthodoxBaseHelper {
   constructor() {
     super('ethiopic', [
-      { code: 'aa', isoEpoch: { year: -5492, month: 7, day: 17 } },
-      { code: 'am', isoEpoch: { year: 8, month: 8, day: 27 }, anchorEpoch: { year: 5501 } }
+      { code: 'aa', isoEpoch: { year: -5492, month: 7, day: 17 }, anchorEpoch: { year: -5499 } },
+      { code: 'am', isoEpoch: { year: 8, month: 8, day: 27 } }
     ]);
   }
 }

--- a/lib/calendar.ts
+++ b/lib/calendar.ts
@@ -1,4 +1,4 @@
-import { assert } from './assert';
+import { assert, assertNotReached } from './assert';
 import * as ES from './ecmascript';
 import { DefineIntrinsic } from './intrinsicclass';
 import type { Temporal } from '..';
@@ -1352,14 +1352,24 @@ abstract class HelperBase {
       ({ monthCode, day } = this.isoToCalendarDate(this.calendarToIsoDate(fields, overflow, cache), cache));
     }
 
-    let isoYear, isoMonth, isoDay;
-    let closestCalendar, closestIso;
+    // Shape of property bag is correct, check valid input and apply overflow
+    if (!IsValidMonthCodeForCalendar(this.id, monthCode)) {
+      throw new RangeError(`Invalid monthCode: ${monthCode} does not exist in calendar ${this.id}`);
+    }
+    const maxDayForMonthCode = this.maxLengthOfMonthCodeInAnyYear(monthCode);
+    if (day > maxDayForMonthCode) {
+      if (overflow === 'reject') {
+        throw new RangeError(`No ${this.id} year with monthCode ${monthCode} and day ${day}`);
+      }
+      day = maxDayForMonthCode;
+    }
+
     // Look backwards starting from one of the calendar years spanning ISO year
     // 1972, up to 20 calendar years prior, to find a year that has this month
     // and day. Normal months and days will match immediately, but for leap days
     // and leap months we may have to look for a while. For searches longer than
     // 20 years, override the start date in monthDaySearchStartYear.
-    const startDateIso = {
+    const startDateIso: ISODate = {
       year: this.monthDaySearchStartYear(monthCode, day),
       month: 12,
       day: 31
@@ -1378,34 +1388,11 @@ abstract class HelperBase {
       );
       const isoDate = this.calendarToIsoDate(testCalendarDate, 'constrain', cache);
       const roundTripCalendarDate = this.isoToCalendarDate(isoDate, cache);
-      ({ year: isoYear, month: isoMonth, day: isoDay } = isoDate);
       if (roundTripCalendarDate.monthCode === monthCode && roundTripCalendarDate.day === day) {
-        return { month: isoMonth, day: isoDay, year: isoYear };
-      } else if (overflow === 'constrain') {
-        // If the requested day is never present in any instance of this month
-        // code, and the round trip date is an instance of this month code with
-        // the most possible days, we are as close as we can get.
-        const maxDayForMonthCode = this.maxLengthOfMonthCodeInAnyYear(roundTripCalendarDate.monthCode);
-        if (
-          roundTripCalendarDate.monthCode === monthCode &&
-          roundTripCalendarDate.day === maxDayForMonthCode &&
-          day > maxDayForMonthCode
-        ) {
-          return { month: isoMonth, day: isoDay, year: isoYear };
-        }
-        // non-ISO constrain algorithm tries to find the closest date in a matching month
-        if (
-          closestCalendar === undefined ||
-          (roundTripCalendarDate.monthCode === closestCalendar.monthCode &&
-            roundTripCalendarDate.day > closestCalendar.day)
-        ) {
-          closestCalendar = roundTripCalendarDate;
-          closestIso = isoDate;
-        }
+        return isoDate;
       }
     }
-    if (overflow === 'constrain' && closestIso !== undefined) return closestIso;
-    throw new RangeError(`No recent ${this.id} year with monthCode ${monthCode} and day ${day}`);
+    assertNotReached(`no recent ${this.id} year with ${monthCode}-${day}, adjust monthDaySearchStartYear`);
   }
   getFirstDayOfWeek(): number | undefined {
     return undefined;

--- a/lib/calendar.ts
+++ b/lib/calendar.ts
@@ -1192,21 +1192,40 @@ abstract class HelperBase {
       }
       case 'month':
       case 'year': {
+        // Sign is -1 if calendarTwo < calendarOne, 1 if calendarTwo > calendarOne
         const sign = this.compareCalendarDates(calendarTwo, calendarOne);
+        // If dates are equal, return 0 date duration
         if (!sign) {
           return { years: 0, months: 0, weeks: 0, days: 0 };
         }
+        // Take the difference between the years of the two dates
         const diffYears = calendarTwo.year - calendarOne.year;
+        // Take the difference between the days of the two dates
         const diffDays = calendarTwo.day - calendarOne.day;
+        // Get list of additional months, and possibly cycle info
         const monthInfo = monthCodeInfo[this.id];
         const cycleInfo = monthInfo ? monthInfo.cycleInfo : { years: 1, months: 12 };
+        // Compute years difference if necessary
         if (diffYears && (largestUnit === 'year' || cycleInfo)) {
+          // diffInYearSign is the result of comparing the month-day of calendarOne
+          // and the month-day of calendarTwo, in the forwards direction
           let diffInYearSign = 0;
+          // If calendarTwo's month is greater than calendarOne's month,
+          // then the years difference should be positive (or negative if sign < 0).
           if (calendarTwo.monthCode > calendarOne.monthCode) diffInYearSign = 1;
+          // If calendarTwo's month is less than calendarOne's month,
+          // then the years difference should be negative (or positive if sign < 0).
           if (calendarTwo.monthCode < calendarOne.monthCode) diffInYearSign = -1;
+          // If the two months are equal, the sign of the years difference should be
+          // the sign of the days difference.
           if (!diffInYearSign) diffInYearSign = Math.sign(diffDays);
-          const isOneFurtherInYear = diffInYearSign * sign < 0;
-          years = isOneFurtherInYear ? diffYears - sign : diffYears;
+          // isCalendarOneFurtherInYear is true iff the ordering of the years
+          // doesn't match the ordering of the month/days.
+          const isCalendarOneFurtherInYear = diffInYearSign * sign < 0;
+          // Add either 1 or -1 to years if isCalendarOneFurtherInYear is true.
+          // If monthday-two is later in the year than monthday-one, need
+          // to correct diffYears because it's gone one too far.
+          years = isCalendarOneFurtherInYear ? diffYears - sign : diffYears;
         }
         // Try to skip ahead as many months as possible for this calendar
         // without adding month by month in a loop
@@ -1217,13 +1236,27 @@ abstract class HelperBase {
           }
           years = 0;
         }
+
+        // intermediate should be a date between calendarOne and calendarTwo,
+        // that is within a year of calendarTwo.
         const intermediate =
           years || months ? this.addCalendar(calendarOne, { years, months }, 'constrain', cache) : calendarOne;
+
+        // At this point, intermediate could fail to be in between calendarOne and calendarTwo
+        // due to leap years.
+        // In that case, add or subtract an extra year from years,
+        // so that the months can be totaled up correctly.
+        if (this.compareCalendarDates(intermediate, calendarTwo) * sign > 0) {
+          years -= sign;
+        }
+
         // Now we have less than one cycle remaining. Add one month at a time
         // until we go over the target, then back up one month and calculate
         // remaining days.
-        let current;
-        let next: CalendarYMD = intermediate;
+        let current: CalendarYMD;
+        // Need to re-add years and months because years might have changed
+        let next: CalendarYMD =
+          years || months ? this.addCalendar(calendarOne, { years, months }, 'constrain', cache) : calendarOne;
         do {
           months += sign;
           current = next;
@@ -1237,6 +1270,10 @@ abstract class HelperBase {
         months -= sign; // correct for loop above which overshoots by 1
         const remainingDays = this.calendarDaysUntil(current, calendarTwo, cache);
         days = remainingDays;
+
+        // This may return a duration like <P12M11D> that appears to have unbalanced months.
+        // But that's fine, because subtracting <P12M11D> from a date may have different
+        // results than subtracting <P1Y11D> from the same date, in the presence of leap months.
         break;
       }
     }

--- a/lib/calendar.ts
+++ b/lib/calendar.ts
@@ -1146,7 +1146,7 @@ abstract class HelperBase {
     if (overflow === 'reject' && calendarDate.day !== day) {
       throw new RangeError(`Day ${day} does not exist in resulting calendar month`);
     }
-    return calendarDate;
+    return this.regulateDate(calendarDate, overflow, cache);
   }
   addCalendar(
     calendarDate: CalendarYMD & { monthCode: string },

--- a/lib/calendar.ts
+++ b/lib/calendar.ts
@@ -2455,6 +2455,8 @@ class NonIsoCalendar implements CalendarImpl {
     if (this.helper.calendarType !== 'lunisolar') {
       resolveNonLunisolarMonth(fields, this.helper.id);
     }
+    // Note: Lunisolar calendars go on to resolve month/monthCode in their
+    // adjustCalendarDate implementations
   }
   dateToISO(fields: CalendarDateFields, overflow: Overflow) {
     const cache = new OneObjectCache(this.helper.id);

--- a/lib/calendar.ts
+++ b/lib/calendar.ts
@@ -779,6 +779,17 @@ abstract class HelperBase {
           .toLowerCase();
       }
     }
+    if (hasEra && !result.era) {
+      // Work around ICU bug that neglects to provide an era code for negative
+      // eraYear in the coptic calendar
+      if (this.id !== 'coptic') {
+        // If missing from any other calendar, it's an as-yet-unknown bug
+        throw new RangeError(`Intl.DateTimeFormat.formatToParts lacks era in ${this.id} calendar.`);
+      }
+      // eraYear is also reversed, but using the legacy era code will set it
+      // right
+      result.era = 'era0';
+    }
     if (hasEra && result.eraYear === undefined) {
       // Node 12 has outdated ICU data that lacks the `relatedYear` field in the
       // output of Intl.DateTimeFormat.formatToParts.

--- a/lib/calendar.ts
+++ b/lib/calendar.ts
@@ -1308,11 +1308,8 @@ abstract class HelperBase {
     return 1972;
   }
   monthDayFromFields(fields: MonthDayFromFieldsObject, overflow: Overflow, cache: OneObjectCache): ISODate {
-    let { era, eraYear, year, month, monthCode, day } = fields;
+    let { eraYear, year, monthCode, day } = fields;
     const hasEra = CalendarSupportsEra(this.id);
-    if (month !== undefined && year === undefined && (!hasEra || era === undefined || eraYear === undefined)) {
-      throw new TypeError('when month is present, year (or era and eraYear) are required');
-    }
     if (monthCode === undefined || year !== undefined || (hasEra && eraYear !== undefined)) {
       // Apply overflow behaviour to year/month/day, to get correct monthCode/day
       ({ monthCode, day } = this.isoToCalendarDate(this.calendarToIsoDate(fields, overflow, cache), cache));
@@ -2447,6 +2444,13 @@ class NonIsoCalendar implements CalendarImpl {
     }
     if ((type === 'date' || type === 'month-day') && fields.day === undefined) {
       throw new TypeError('day is required');
+    }
+    if (type === 'month-day' && fields.month !== undefined && fields.year === undefined) {
+      if (!CalendarSupportsEra(this.helper.id)) {
+        throw new TypeError('when month is present, year is required');
+      } else if (fields.era === undefined || fields.eraYear === undefined) {
+        throw new TypeError('when month is present, year (or era and eraYear) are required');
+      }
     }
     if (this.helper.calendarType !== 'lunisolar') {
       resolveNonLunisolarMonth(fields, this.helper.id);

--- a/lib/ecmascript.ts
+++ b/lib/ecmascript.ts
@@ -3601,41 +3601,42 @@ function DifferenceZonedDateTime(
   return CombineDateAndTimeDuration(dateDifference, timeDuration);
 }
 
-// Epoch-nanosecond bounding technique where the start/end of the calendar-unit
-// interval are converted to epoch-nanosecond times and destEpochNs is nudged to
-// either one.
-function NudgeToCalendarUnit(
+interface NudgeWindow {
+  r1: number;
+  r2: number;
+  startEpochNs: JSBI;
+  endEpochNs: JSBI;
+  startDuration: DateDuration;
+  endDuration: DateDuration;
+}
+
+function ComputeNudgeWindow(
   sign: -1 | 1,
-  durationParam: InternalDuration,
+  duration: InternalDuration,
   originEpochNs: JSBI,
-  destEpochNs: JSBI,
   isoDateTime: ISODateTime,
   timeZone: string | null,
   calendar: BuiltinCalendarId,
   increment: number,
   unit: Temporal.DateUnit,
-  roundingMode: Temporal.RoundingMode
-) {
-  // unit must be day, week, month, or year
-  // timeZone may be undefined
-  let duration = durationParam;
-
+  additionalShift: boolean
+): NudgeWindow {
   // Create a duration with smallestUnit trunc'd towards zero
   // Create a separate duration that incorporates roundingIncrement
   let r1, r2, startDuration, endDuration;
   switch (unit) {
     case 'year': {
       const years = RoundNumberToIncrement(duration.date.years, increment, 'trunc');
-      r1 = years;
-      r2 = years + increment * sign;
+      r1 = !additionalShift ? years : years + increment * sign;
+      r2 = r1 + increment * sign;
       startDuration = { years: r1, months: 0, weeks: 0, days: 0 };
       endDuration = { ...startDuration, years: r2 };
       break;
     }
     case 'month': {
       const months = RoundNumberToIncrement(duration.date.months, increment, 'trunc');
-      r1 = months;
-      r2 = months + increment * sign;
+      r1 = !additionalShift ? months : months + increment * sign;
+      r2 = r1 + increment * sign;
       startDuration = AdjustDateDurationRecord(duration.date, 0, 0, r1);
       endDuration = AdjustDateDurationRecord(duration.date, 0, 0, r2);
       break;
@@ -3673,7 +3674,7 @@ function NudgeToCalendarUnit(
     // If the start of the bound is the same as the "origin" (aka relativeTo),
     // use the origin's epoch-nanoseconds as-is instead of relying on isoDateTime,
     // which then gets zoned and converted back to epoch-nanoseconds,
-    // which looses precision and creates a distorted bounding window.
+    // which loses precision and creates a distorted bounding window.
     startEpochNs = originEpochNs;
   } else {
     const start = CalendarDateAdd(calendar, isoDateTime.isoDate, startDuration, 'constrain');
@@ -3690,19 +3691,96 @@ function NudgeToCalendarUnit(
     ? GetEpochNanosecondsFor(timeZone, endDateTime, 'compatible')
     : GetUTCEpochNanoseconds(endDateTime);
 
+  return { r1, r2, startEpochNs, endEpochNs, startDuration, endDuration };
+}
+
+// Epoch-nanosecond bounding technique where the start/end of the calendar-unit
+// interval are converted to epoch-nanosecond times and destEpochNs is nudged to
+// either one.
+function NudgeToCalendarUnit(
+  sign: -1 | 1,
+  durationParam: InternalDuration,
+  originEpochNs: JSBI,
+  destEpochNs: JSBI,
+  isoDateTime: ISODateTime,
+  timeZone: string | null,
+  calendar: BuiltinCalendarId,
+  increment: number,
+  unit: Temporal.DateUnit,
+  roundingMode: Temporal.RoundingMode
+) {
+  let duration = durationParam;
+
+  let didExpandCalendarUnit = false;
+  let nudgeWindow = ComputeNudgeWindow(
+    sign,
+    duration,
+    originEpochNs,
+    isoDateTime,
+    timeZone,
+    calendar,
+    increment,
+    unit,
+    false
+  );
+  let { r1, r2, startEpochNs, endEpochNs, startDuration, endDuration } = nudgeWindow;
+
   // Round the smallestUnit within the epoch-nanosecond span
   if (sign === 1) {
-    assert(
-      JSBI.lessThanOrEqual(startEpochNs, destEpochNs) && JSBI.lessThanOrEqual(destEpochNs, endEpochNs),
-      `${unit} was 0 days long`
-    );
+    if (
+      !(
+        JSBI.lessThanOrEqual(nudgeWindow.startEpochNs, destEpochNs) &&
+        JSBI.lessThanOrEqual(destEpochNs, nudgeWindow.endEpochNs)
+      )
+    ) {
+      // Retry nudge window if it's out of bounds
+      nudgeWindow = ComputeNudgeWindow(
+        sign,
+        duration,
+        originEpochNs,
+        isoDateTime,
+        timeZone,
+        calendar,
+        increment,
+        unit,
+        true
+      );
+      assert(
+        JSBI.lessThanOrEqual(nudgeWindow.startEpochNs, destEpochNs) &&
+          JSBI.lessThanOrEqual(destEpochNs, nudgeWindow.endEpochNs),
+        `${unit} was 0 days long`
+      );
+      didExpandCalendarUnit = true;
+    }
+  } else if (sign == -1) {
+    if (
+      !(
+        JSBI.lessThanOrEqual(nudgeWindow.endEpochNs, destEpochNs) &&
+        JSBI.lessThanOrEqual(destEpochNs, nudgeWindow.startEpochNs)
+      )
+    ) {
+      // Retry nudge window if it's out of bounds
+      nudgeWindow = ComputeNudgeWindow(
+        sign,
+        duration,
+        originEpochNs,
+        isoDateTime,
+        timeZone,
+        calendar,
+        increment,
+        unit,
+        true
+      );
+      assert(
+        JSBI.lessThanOrEqual(nudgeWindow.endEpochNs, destEpochNs) &&
+          JSBI.lessThanOrEqual(destEpochNs, nudgeWindow.startEpochNs),
+        `${unit} was 0 days long`
+      );
+      didExpandCalendarUnit = true;
+    }
   }
-  if (sign === -1) {
-    assert(
-      JSBI.lessThanOrEqual(endEpochNs, destEpochNs) && JSBI.lessThanOrEqual(destEpochNs, startEpochNs),
-      `${unit} was 0 days long`
-    );
-  }
+  ({ r1, r2, startEpochNs, endEpochNs, startDuration, endDuration } = nudgeWindow);
+
   assert(!JSBI.equal(endEpochNs, startEpochNs), 'startEpochNs must ≠ endEpochNs');
   const numerator = TimeDuration.fromEpochNsDiff(destEpochNs, startEpochNs);
   const denominator = TimeDuration.fromEpochNsDiff(endEpochNs, startEpochNs);
@@ -3727,8 +3805,8 @@ function NudgeToCalendarUnit(
   assert(Math.abs(r1) <= Math.abs(total) && Math.abs(total) <= Math.abs(r2), 'r1 ≤ total ≤ r2');
 
   // Determine whether expanded or contracted
-  const didExpandCalendarUnit = roundedUnit === Math.abs(r2);
-  duration = { date: didExpandCalendarUnit ? endDuration : startDuration, time: TimeDuration.ZERO };
+  didExpandCalendarUnit ||= roundedUnit === Math.abs(r2);
+  duration = { date: roundedUnit == Math.abs(r2) ? endDuration : startDuration, time: TimeDuration.ZERO };
 
   const nudgeResult = {
     duration,

--- a/lib/ecmascript.ts
+++ b/lib/ecmascript.ts
@@ -3217,7 +3217,7 @@ export function RejectDateTime(
 export function RejectDateTimeRange(isoDateTime: ISODateTime) {
   const ns = GetUTCEpochNanoseconds(isoDateTime);
   if (JSBI.lessThan(ns, DATETIME_NS_MIN) || JSBI.greaterThan(ns, DATETIME_NS_MAX)) {
-    const dateTimeString = ISODateTimeToString(isoDateTime, 'iso8601', undefined, 'never');
+    const dateTimeString = ISODateTimeToString(isoDateTime, 'iso8601', 'auto', 'never');
     throw new RangeError(`${dateTimeString} is outside of supported range`);
   }
 }
@@ -3227,7 +3227,7 @@ function AssertISODateTimeWithinLimits(isoDateTime: ISODateTime) {
   const ns = GetUTCEpochNanoseconds(isoDateTime);
   assert(
     JSBI.greaterThanOrEqual(ns, DATETIME_NS_MIN) && JSBI.lessThanOrEqual(ns, DATETIME_NS_MAX),
-    `${ISODateTimeToString(isoDateTime, 'iso8601', undefined, 'never')} is outside the representable range`
+    `${ISODateTimeToString(isoDateTime, 'iso8601', 'auto', 'never')} is outside the representable range`
   );
 }
 

--- a/lib/intl.ts
+++ b/lib/intl.ts
@@ -387,6 +387,7 @@ type MaybeFalseOptions = {
 function amend(optionsParam: Intl.DateTimeFormatOptions = {}, amended: MaybeFalseOptions = {}) {
   const options = Object.assign({}, optionsParam);
   const props = [
+    'era',
     'year',
     'month',
     'day',
@@ -413,6 +414,7 @@ type OptionsType<T extends TypesWithToLocaleString> = NonNullable<Parameters<T['
 
 function timeAmend(originalOptions: OptionsType<Temporal.PlainTime>) {
   const options = amend(originalOptions, {
+    era: false,
     year: false,
     month: false,
     day: false,
@@ -462,7 +464,7 @@ function yearMonthAmend(originalOptions: OptionsType<Temporal.PlainYearMonth>) {
     delete options.dateStyle;
     Object.assign(options, dateStyleHacks[style]);
   }
-  if (!('year' in options || 'month' in options || 'era' in options)) {
+  if (!('year' in options || 'month' in options)) {
     if (hasAnyDateTimeOptions(originalOptions)) {
       throw new TypeError(`cannot format PlainYearMonth with options [${Object.keys(originalOptions)}]`);
     }
@@ -577,14 +579,7 @@ function instantAmend(optionsParam: OptionsType<Temporal.Instant>) {
 }
 
 function hasDateOptions(options: OptionsType<TypesWithToLocaleString>) {
-  return (
-    'year' in options ||
-    'month' in options ||
-    'day' in options ||
-    'weekday' in options ||
-    'dateStyle' in options ||
-    'era' in options
-  );
+  return 'year' in options || 'month' in options || 'day' in options || 'weekday' in options || 'dateStyle' in options;
 }
 
 function hasTimeOptions(options: OptionsType<TypesWithToLocaleString>) {

--- a/test/expected-failures-cldr48.txt
+++ b/test/expected-failures-cldr48.txt
@@ -10,6 +10,3 @@ staging/Intl402/Temporal/old/indian-calendar.js
 staging/Intl402/Temporal/old/non-iso-calendars-coptic.js
 staging/Intl402/Temporal/old/non-iso-calendars-ethioaa.js
 staging/Intl402/Temporal/old/non-iso-calendars-indian.js
-
-# Needs further investigation if a later rebase doesn't fix:
-staging/sm/Temporal/PlainDate/non-positive-era-year.js

--- a/test/expected-failures-cldr48.txt
+++ b/test/expected-failures-cldr48.txt
@@ -4,9 +4,9 @@
 # CLDR 48 provides new era code, which the polyfill won't handle until a later
 # rebase.
 staging/Intl402/Temporal/old/non-iso-calendars-ethiopic.js
-staging/sm/Temporal/PlainDate/withCalendar.js
 
 # Tests incorrect, expecting old era codes
+staging/Intl402/Temporal/old/indian-calendar.js
 staging/Intl402/Temporal/old/non-iso-calendars-coptic.js
 staging/Intl402/Temporal/old/non-iso-calendars-ethioaa.js
 staging/Intl402/Temporal/old/non-iso-calendars-indian.js

--- a/test/expected-failures-cldr48.txt
+++ b/test/expected-failures-cldr48.txt
@@ -1,22 +1,6 @@
 # Tests in this file are expected to fail for Node 20 LTS, Node 22 LTS, and
 # Node 24 LTS.
 
-# CLDR 48 introduced "Mo1" through "Mo12" English month names in the Chinese
-# calendar, which the polyfill won't handle until a later rebase.
-intl402/Temporal/PlainDate/from/calendar-not-supporting-eras.js
-intl402/Temporal/PlainDate/prototype/until/until-across-lunisolar-leap-months.js
-intl402/Temporal/PlainDateTime/from/calendar-not-supporting-eras.js
-intl402/Temporal/PlainMonthDay/from/calendar-not-supporting-eras.js
-intl402/Temporal/PlainMonthDay/from/constrain-to-leap-day.js
-intl402/Temporal/PlainYearMonth/from/calendar-not-supporting-eras.js
-intl402/Temporal/PlainYearMonth/from/reference-day-chinese.js
-intl402/Temporal/ZonedDateTime/from/calendar-not-supporting-eras.js
-staging/Intl402/Temporal/old/addition-across-lunisolar-leap-months-chinese.js
-staging/Intl402/Temporal/old/non-iso-calendars-chinese.js
-staging/Intl402/Temporal/old/non-iso-calendars-dangi.js
-staging/sm/Temporal/PlainMonthDay/from-chinese-leap-month-common.js
-staging/sm/Temporal/PlainMonthDay/from-chinese.js
-
 # CLDR 48 provides new era code, which the polyfill won't handle until a later
 # rebase.
 staging/Intl402/Temporal/old/non-iso-calendars-ethiopic.js

--- a/test/expected-failures-cldr48.txt
+++ b/test/expected-failures-cldr48.txt
@@ -1,12 +1,8 @@
 # Tests in this file are expected to fail for Node 20 LTS, Node 22 LTS, and
 # Node 24 LTS.
 
-# CLDR 48 provides new era code, which the polyfill won't handle until a later
-# rebase.
-staging/Intl402/Temporal/old/non-iso-calendars-ethiopic.js
-
 # Tests incorrect, expecting old era codes
-staging/Intl402/Temporal/old/indian-calendar.js
 staging/Intl402/Temporal/old/non-iso-calendars-coptic.js
 staging/Intl402/Temporal/old/non-iso-calendars-ethioaa.js
+staging/Intl402/Temporal/old/non-iso-calendars-ethiopic.js
 staging/Intl402/Temporal/old/non-iso-calendars-indian.js

--- a/test/expected-failures-cldr48.txt
+++ b/test/expected-failures-cldr48.txt
@@ -19,6 +19,7 @@ staging/sm/Temporal/PlainMonthDay/from-chinese.js
 
 # CLDR 48 provides new era code, which the polyfill won't handle until a later
 # rebase.
+staging/Intl402/Temporal/old/non-iso-calendars-ethiopic.js
 staging/sm/Temporal/PlainDate/withCalendar.js
 
 # Tests incorrect, expecting old era codes

--- a/test/expected-failures.txt
+++ b/test/expected-failures.txt
@@ -18,6 +18,11 @@ staging/sm/Temporal/PlainDate/from-constrain-hebrew.js
 staging/sm/Temporal/PlainDate/from-islamic-umalqura.js
 
 # Faulty leap month calculations in Chinese calendar in ICU4C
+intl402/Temporal/PlainDate/prototype/monthCode/chinese-calendar-dates.js
+intl402/Temporal/PlainDateTime/prototype/monthCode/chinese-calendar-dates.js
+intl402/Temporal/PlainMonthDay/prototype/monthCode/chinese-calendar-dates.js
+intl402/Temporal/PlainYearMonth/prototype/monthCode/chinese-calendar-dates.js
+intl402/Temporal/ZonedDateTime/prototype/monthCode/chinese-calendar-dates.js
 # https://unicode-org.atlassian.net/browse/ICU-22230
 staging/sm/Temporal/PlainMonthDay/from-chinese-leap-month-uncommon.js
 

--- a/test/expected-failures.txt
+++ b/test/expected-failures.txt
@@ -21,9 +21,6 @@ staging/sm/Temporal/PlainDate/from-islamic-umalqura.js
 # https://unicode-org.atlassian.net/browse/ICU-22230
 staging/sm/Temporal/PlainMonthDay/from-chinese-leap-month-uncommon.js
 
-# https://github.com/tc39/ecma402/issues/534
-staging/Intl402/Temporal/old/non-iso-calendars-ethiopic.js
-
 # https://github.com/tc39/test262/commit/95d90bf9f2f519cad3305e3948cbb1663b0b667a
 # Fails on V8, no upstream bug open yet
 intl402/DateTimeFormat/prototype/resolvedOptions/resolved-calendar-unicode-extensions-and-options.js


### PR DESCRIPTION
This batch of commits mainly deals with working around weirdnesses in newer ICU versions, and bugfixes to pass the test262 tests dealing with calendar calculations.

There is one normative change, from the November 2025 TC39 plenary. It deals with rounding durations in edge cases and is unlikely to break any working code.

Closes: #360