### PR TITLE
Update description to reflect Stage 4 proposal

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@js-temporal/polyfill",
   "version": "0.5.1",
-  "description": "Polyfill for Temporal (https://github.com/tc39/proposal-temporal), an ECMA TC39 Stage 3 proposal",
+  "description": "Polyfill for Temporal (https://github.com/tc39/proposal-temporal), an ECMA TC39 Stage 4 proposal",
   "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.esm.js",


### PR DESCRIPTION
This pull request updates the project description in `package.json` to reflect that the Temporal proposal is now at ECMA TC39 Stage 4, instead of Stage 3.

- Updated the `description` field in `package.json` to state that Temporal is now a Stage 4 proposal.